### PR TITLE
replace breaks with leaves

### DIFF
--- a/examples/ERC20/ERC20.sol
+++ b/examples/ERC20/ERC20.sol
@@ -32,6 +32,12 @@ contract WARP {
             allowance[src][sender] -= wad;
         }
 
+        for (uint i = 20; i > 10; i--) {
+            if (i == 3) {
+                break;
+            }
+        }
+
         balanceOf[src] -= wad;
         balanceOf[dst] += wad;
 

--- a/warp/ERC20.cairo
+++ b/warp/ERC20.cairo
@@ -1,1196 +1,444 @@
-__warp_block_0()
-func abi_decode(dataEnd : Uint256) -> ():
-    alloc_locals
-    local _1_1 : Uint256 = Uint256(low=0, high=0)
-    let (local _2_2 : Uint256) = not(Uint256(low=3, high=0))
-    let (local _3_3 : Uint256) = add(dataEnd, _2_2)
-    let (local _4_4 : Uint256) = slt(_3_3, _1_1)
-    if _4_4.low + _4_4.high != 0:
-        __warp_block_1(_1_1)
-    end
+%lang starknet
+%builtins pedersen range_check
+
+from evm.memory import mstore
+from evm.sha3 import sha
+from evm.uint256 import is_eq, is_gt, is_lt, is_zero, slt, u256_add
+from evm.utils import update_msize
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.default_dict import default_dict_new
+from starkware.cairo.common.dict_access import DictAccess
+from starkware.cairo.common.math_cmp import is_le
+from starkware.cairo.common.registers import get_fp_and_pc
+from starkware.cairo.common.uint256 import (
+    Uint256, uint256_and, uint256_eq, uint256_not, uint256_shl, uint256_sub)
+from starkware.starknet.common.storage import Storage
+
+@storage_var
+func evm_storage(low : felt, high : felt, part : felt) -> (res : felt):
+end
+
+func s_load{storage_ptr : Storage*, range_check_ptr, pedersen_ptr : HashBuiltin*}(
+        key : Uint256) -> (res : Uint256):
+    let (low_r) = evm_storage.read(key.low, key.high, 1)
+    let (high_r) = evm_storage.read(key.low, key.high, 2)
+    return (Uint256(low_r, high_r))
+end
+
+func s_store{storage_ptr : Storage*, range_check_ptr, pedersen_ptr : HashBuiltin*}(
+        key : Uint256, value : Uint256):
+    evm_storage.write(low=key.low, high=key.high, part=1, value=value.low)
+    evm_storage.write(low=key.low, high=key.high, part=2, value=value.high)
     return ()
 end
 
-func abi_decode_address(dataEnd_7 : Uint256) -> (value0 : Uint256):
-    alloc_locals
-    local _1_8 : Uint256 = Uint256(low=32, high=0)
-    let (local _2_9 : Uint256) = not(Uint256(low=3, high=0))
-    let (local _3_10 : Uint256) = add(dataEnd_7, _2_9)
-    let (local _4_11 : Uint256) = slt(_3_10, _1_8)
-    if _4_11.low + _4_11.high != 0:
-        __warp_block_2()
-    end
-    local _7_14 : Uint256 = Uint256(low=4, high=0)
-    let (local value_15 : Uint256) = calldataload(_7_14)
-    let (local _8_16 : Uint256) = sub(
-        shl(Uint256(low=160, high=0), Uint256(low=1, high=0)), Uint256(low=1, high=0))
-    let (local _9_17 : Uint256) = and(value_15, _8_16)
-    let (local _10_18 : Uint256) = eq(value_15, _9_17)
-    let (local _11_19 : Uint256) = iszero(_10_18)
-    if _11_19.low + _11_19.high != 0:
-        __warp_block_3()
-    end
-    local value0 = value_15
-    return (value0)
+@view
+func get_storage_low{storage_ptr : Storage*, range_check_ptr, pedersen_ptr : HashBuiltin*}(
+        low : felt, high : felt) -> (res : felt):
+    let (storage_val_low) = evm_storage.read(low=low, high=high, part=1)
+    return (res=storage_val_low)
 end
 
-func abi_decode_addresst_address(dataEnd_22 : Uint256) -> (value0_23 : Uint256, value1 : Uint256):
-    alloc_locals
-    local _1_24 : Uint256 = Uint256(low=64, high=0)
-    let (local _2_25 : Uint256) = not(Uint256(low=3, high=0))
-    let (local _3_26 : Uint256) = add(dataEnd_22, _2_25)
-    let (local _4_27 : Uint256) = slt(_3_26, _1_24)
-    if _4_27.low + _4_27.high != 0:
-        __warp_block_4()
-    end
-    local _7_30 : Uint256 = Uint256(low=4, high=0)
-    let (local value_31 : Uint256) = calldataload(_7_30)
-    let (local _8_32 : Uint256) = sub(
-        shl(Uint256(low=160, high=0), Uint256(low=1, high=0)), Uint256(low=1, high=0))
-    let (local _9_33 : Uint256) = and(value_31, _8_32)
-    let (local _10_34 : Uint256) = eq(value_31, _9_33)
-    let (local _11_35 : Uint256) = iszero(_10_34)
-    if _11_35.low + _11_35.high != 0:
-        __warp_block_5()
-    end
-    local value0_23 = value_31
-    local _14_38 : Uint256 = Uint256(low=36, high=0)
-    let (local value_1 : Uint256) = calldataload(_14_38)
-    let (local _15_39 : Uint256) = and(value_1, _8_32)
-    let (local _16_40 : Uint256) = eq(value_1, _15_39)
-    let (local _17_41 : Uint256) = iszero(_16_40)
-    if _17_41.low + _17_41.high != 0:
-        __warp_block_6()
-    end
-    local value1 = value_1
-    return (value0_23, value1)
+@view
+func get_storage_high{storage_ptr : Storage*, range_check_ptr, pedersen_ptr : HashBuiltin*}(
+        low : felt, high : felt) -> (res : felt):
+    let (storage_val_high) = evm_storage.read(low=low, high=high, part=2)
+    return (res=storage_val_high)
 end
 
-func abi_decode_addresst_addresst_uint256t_address(dataEnd_44 : Uint256) -> (
-        value0_45 : Uint256, value1_46 : Uint256, value2 : Uint256, value3 : Uint256):
+func cleanup_from_storage_uint256{
+        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
+        memory_dict : DictAccess*, msize}(value_60 : Uint256) -> (cleaned : Uint256):
     alloc_locals
-    local _1_47 : Uint256 = Uint256(low=128, high=0)
-    let (local _2_48 : Uint256) = not(Uint256(low=3, high=0))
-    let (local _3_49 : Uint256) = add(dataEnd_44, _2_48)
-    let (local _4_50 : Uint256) = slt(_3_49, _1_47)
-    if _4_50.low + _4_50.high != 0:
-        __warp_block_7()
-    end
-    local _7_53 : Uint256 = Uint256(low=4, high=0)
-    let (local value_54 : Uint256) = calldataload(_7_53)
-    let (local _8_55 : Uint256) = sub(
-        shl(Uint256(low=160, high=0), Uint256(low=1, high=0)), Uint256(low=1, high=0))
-    let (local _9_56 : Uint256) = and(value_54, _8_55)
-    let (local _10_57 : Uint256) = eq(value_54, _9_56)
-    let (local _11_58 : Uint256) = iszero(_10_57)
-    if _11_58.low + _11_58.high != 0:
-        __warp_block_8()
-    end
-    local value0_45 = value_54
-    local _14_61 : Uint256 = Uint256(low=36, high=0)
-    let (local value_1_62 : Uint256) = calldataload(_14_61)
-    let (local _15_63 : Uint256) = and(value_1_62, _8_55)
-    let (local _16_64 : Uint256) = eq(value_1_62, _15_63)
-    let (local _17_65 : Uint256) = iszero(_16_64)
-    if _17_65.low + _17_65.high != 0:
-        __warp_block_9()
-    end
-    local value1_46 = value_1_62
-    local _20_68 : Uint256 = Uint256(low=68, high=0)
-    let (local value2) = calldataload(_20_68)
-    local _21_69 : Uint256 = Uint256(low=100, high=0)
-    let (local value_2 : Uint256) = calldataload(_21_69)
-    let (local _22_70 : Uint256) = and(value_2, _8_55)
-    let (local _23_71 : Uint256) = eq(value_2, _22_70)
-    let (local _24_72 : Uint256) = iszero(_23_71)
-    if _24_72.low + _24_72.high != 0:
-        __warp_block_10()
-    end
-    local value3 = value_2
-    return (value0_45, value1_46, value2, value3)
+    local cleaned : Uint256 = value_60
+    return (cleaned)
 end
-
-func abi_decode_addresst_uint256(dataEnd_75 : Uint256) -> (
-        value0_76 : Uint256, value1_77 : Uint256):
+func extract_from_storage_value_dynamict_uint8{
+        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
+        memory_dict : DictAccess*, msize}(slot_value : Uint256) -> (value_61 : Uint256):
     alloc_locals
-    local _1_78 : Uint256 = Uint256(low=64, high=0)
-    let (local _2_79 : Uint256) = not(Uint256(low=3, high=0))
-    let (local _3_80 : Uint256) = add(dataEnd_75, _2_79)
-    let (local _4_81 : Uint256) = slt(_3_80, _1_78)
-    if _4_81.low + _4_81.high != 0:
-        __warp_block_11()
-    end
-    local _7_84 : Uint256 = Uint256(low=4, high=0)
-    let (local value_85 : Uint256) = calldataload(_7_84)
-    let (local _8_86 : Uint256) = sub(
-        shl(Uint256(low=160, high=0), Uint256(low=1, high=0)), Uint256(low=1, high=0))
-    let (local _9_87 : Uint256) = and(value_85, _8_86)
-    let (local _10_88 : Uint256) = eq(value_85, _9_87)
-    let (local _11_89 : Uint256) = iszero(_10_88)
-    if _11_89.low + _11_89.high != 0:
-        __warp_block_12()
-    end
-    local value0_76 = value_85
-    local _14_92 : Uint256 = Uint256(low=36, high=0)
-    let (local value1_77) = calldataload(_14_92)
-    return (value0_76, value1_77)
+    local _1_62 : Uint256 = Uint256(low=255, high=0)
+
+    let (local value_61 : Uint256) = uint256_and(slot_value, _1_62)
+
+    return (value_61)
 end
-
-func abi_decode_addresst_uint256t_address(dataEnd_93 : Uint256) -> (
-        value0_94 : Uint256, value1_95 : Uint256, value2_96 : Uint256):
+func fun_approve{
+        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
+        memory_dict : DictAccess*, msize}(
+        var_guy : Uint256, var_wad : Uint256, var_sender : Uint256) -> (var_ : Uint256):
     alloc_locals
-    local _1_97 : Uint256 = Uint256(low=96, high=0)
-    let (local _2_98 : Uint256) = not(Uint256(low=3, high=0))
-    let (local _3_99 : Uint256) = add(dataEnd_93, _2_98)
-    let (local _4_100 : Uint256) = slt(_3_99, _1_97)
-    if _4_100.low + _4_100.high != 0:
-        __warp_block_13()
-    end
-    local _7_103 : Uint256 = Uint256(low=4, high=0)
-    let (local value_104 : Uint256) = calldataload(_7_103)
-    let (local _8_105 : Uint256) = sub(
-        shl(Uint256(low=160, high=0), Uint256(low=1, high=0)), Uint256(low=1, high=0))
-    let (local _9_106 : Uint256) = and(value_104, _8_105)
-    let (local _10_107 : Uint256) = eq(value_104, _9_106)
-    let (local _11_108 : Uint256) = iszero(_10_107)
-    if _11_108.low + _11_108.high != 0:
-        __warp_block_14()
-    end
-    local value0_94 = value_104
-    local _14_111 : Uint256 = Uint256(low=36, high=0)
-    let (local value1_95) = calldataload(_14_111)
-    local _15_112 : Uint256 = Uint256(low=68, high=0)
-    let (local value_1_113 : Uint256) = calldataload(_15_112)
-    let (local _16_114 : Uint256) = and(value_1_113, _8_105)
-    let (local _17_115 : Uint256) = eq(value_1_113, _16_114)
-    let (local _18_116 : Uint256) = iszero(_17_115)
-    if _18_116.low + _18_116.high != 0:
-        __warp_block_15()
-    end
-    local value2_96 = value_1_113
-    return (value0_94, value1_95, value2_96)
-end
-
-func abi_decode_uint256t_address(dataEnd_119 : Uint256) -> (
-        value0_120 : Uint256, value1_121 : Uint256):
-    alloc_locals
-    local _1_122 : Uint256 = Uint256(low=64, high=0)
-    let (local _2_123 : Uint256) = not(Uint256(low=3, high=0))
-    let (local _3_124 : Uint256) = add(dataEnd_119, _2_123)
-    let (local _4_125 : Uint256) = slt(_3_124, _1_122)
-    if _4_125.low + _4_125.high != 0:
-        __warp_block_16()
-    end
-    local _7_128 : Uint256 = Uint256(low=4, high=0)
-    let (local value0_120) = calldataload(_7_128)
-    local _8_129 : Uint256 = Uint256(low=36, high=0)
-    let (local value_130 : Uint256) = calldataload(_8_129)
-    let (local _9_131 : Uint256) = sub(
-        shl(Uint256(low=160, high=0), Uint256(low=1, high=0)), Uint256(low=1, high=0))
-    let (local _10_132 : Uint256) = and(value_130, _9_131)
-    let (local _11_133 : Uint256) = eq(value_130, _10_132)
-    let (local _12_134 : Uint256) = iszero(_11_133)
-    if _12_134.low + _12_134.high != 0:
-        __warp_block_17()
-    end
-    local value1_121 = value_130
-    return (value0_120, value1_121)
-end
-
-func abi_encode_bool(headStart : Uint256, value0_137 : Uint256) -> (tail : Uint256):
-    alloc_locals
-    local _1_138 : Uint256 = Uint256(low=32, high=0)
-    let (local tail) = add(headStart, _1_138)
-    let (local _2_139 : Uint256) = iszero(value0_137)
-    let (local _3_140 : Uint256) = iszero(_2_139)
-    mstore(headStart, _3_140)
-    return (tail)
-end
-
-func abi_encode_string(headStart_141 : Uint256, value0_142 : Uint256) -> (tail_143 : Uint256):
-    alloc_locals
-    local _1_144 : Uint256 = Uint256(low=32, high=0)
-    local _2_145 : Uint256 = _1_144
-    mstore(headStart_141, _1_144)
-    let (local length : Uint256) = mload(value0_142)
-    local _3_146 : Uint256 = _1_144
-    let (local _4_147 : Uint256) = add(headStart_141, _1_144)
-    mstore(_4_147, length)
-    local i : Uint256 = Uint256(low=0, high=0)
-    let (local i) = __warp_block_19(_1_144, headStart_141, i, value0_142)
-    let (local _11_154 : Uint256) = gt(i, length)
-    if _11_154.low + _11_154.high != 0:
-        __warp_block_20(headStart_141, length)
-    end
-    local _16_159 : Uint256 = Uint256(low=64, high=0)
-    let (local _17_160 : Uint256) = not(Uint256(low=31, high=0))
-    local _18_161 : Uint256 = Uint256(low=31, high=0)
-    let (local _19_162 : Uint256) = add(length, _18_161)
-    let (local _20_163 : Uint256) = and(_19_162, _17_160)
-    let (local _21_164 : Uint256) = add(headStart_141, _20_163)
-    let (local tail_143) = add(_21_164, _16_159)
-    return (tail_143)
-end
-
-func abi_encode_uint256(headStart_165 : Uint256, value0_166 : Uint256) -> (tail_167 : Uint256):
-    alloc_locals
-    local _1_168 : Uint256 = Uint256(low=32, high=0)
-    let (local tail_167) = add(headStart_165, _1_168)
-    mstore(headStart_165, value0_166)
-    return (tail_167)
-end
-
-func abi_encode_uint8(headStart_169 : Uint256, value0_170 : Uint256) -> (tail_171 : Uint256):
-    alloc_locals
-    local _1_172 : Uint256 = Uint256(low=32, high=0)
-    let (local tail_171) = add(headStart_169, _1_172)
-    local _2_173 : Uint256 = Uint256(low=255, high=0)
-    let (local _3_174 : Uint256) = and(value0_170, _2_173)
-    mstore(headStart_169, _3_174)
-    return (tail_171)
-end
-
-func array_dataslot_string_storage() -> (data : Uint256):
-    alloc_locals
-    local _1_175 : Uint256 = Uint256(low=0, high=0)
-    local _2_176 : Uint256 = _1_175
-    mstore(_1_175, _1_175)
-    local data = Uint256(low=100557845882747507273875182862946526563, high=54570651553685478358117286254199992264)
-    return (data)
-end
-
-func array_dataslot_string_storage_3075() -> (data_177 : Uint256):
-    alloc_locals
-    local _1_178 : Uint256 = Uint256(low=1, high=0)
-    local _2_179 : Uint256 = Uint256(low=0, high=0)
-    mstore(_2_179, _1_178)
-    local data_177 = Uint256(low=17219183504112405672555532996650339574, high=235346966651632113557018504892503714354)
-    return (data_177)
-end
-
-func array_storeLengthForEncoding_string(pos : Uint256, length_180 : Uint256) -> (
-        updated_pos : Uint256):
-    alloc_locals
-    mstore(pos, length_180)
-    local _1_181 : Uint256 = Uint256(low=32, high=0)
-    let (local updated_pos) = add(pos, _1_181)
-    return (updated_pos)
-end
-
-func checked_add_uint256(x : Uint256, y : Uint256) -> (sum : Uint256):
-    alloc_locals
-    let (local _1_182 : Uint256) = not(y)
-    let (local _2_183 : Uint256) = gt(x, _1_182)
-    if _2_183.low + _2_183.high != 0:
-        panic_error_0x11()
-    end
-    let (local sum) = add(x, y)
-    return (sum)
-end
-
-func finalize_allocation(memPtr : Uint256, size : Uint256) -> ():
-    alloc_locals
-    let (local _1_184 : Uint256) = not(Uint256(low=31, high=0))
-    local _2_185 : Uint256 = Uint256(low=31, high=0)
-    let (local _3_186 : Uint256) = add(size, _2_185)
-    let (local _4_187 : Uint256) = and(_3_186, _1_184)
-    let (local newFreePtr : Uint256) = add(memPtr, _4_187)
-    let (local _5_188 : Uint256) = lt(newFreePtr, memPtr)
-    local _6_189 : Uint256 = Uint256(low=18446744073709551615, high=0)
-    let (local _7_190 : Uint256) = gt(newFreePtr, _6_189)
-    let (local _8_191 : Uint256) = or(_7_190, _5_188)
-    if _8_191.low + _8_191.high != 0:
-        __warp_block_21()
-    end
-    local _15_198 : Uint256 = Uint256(low=64, high=0)
-    mstore(_15_198, newFreePtr)
-    return ()
-end
-
-func fun_approve(var_guy : Uint256, var_wad : Uint256, var_sender : Uint256) -> (var_ : Uint256):
-    alloc_locals
-    let (local _1_199 : Uint256) = sub(
-        shl(Uint256(low=160, high=0), Uint256(low=1, high=0)), Uint256(low=1, high=0))
-    let (local _2_200 : Uint256) = and(var_sender, _1_199)
-    local _3_201 : Uint256 = Uint256(low=0, high=0)
-    mstore(_3_201, _2_200)
-    local _4_202 : Uint256 = Uint256(low=5, high=0)
-    local _5_203 : Uint256 = Uint256(low=32, high=0)
-    mstore(_5_203, _4_202)
-    local _6_204 : Uint256 = Uint256(low=64, high=0)
-    local _7_205 : Uint256 = _3_201
-    let (local _8_206 : Uint256) = keccak256(_3_201, _6_204)
     let (
-        local _9_207 : Uint256) = mapping_index_access_mapping_address_mapping_address_uint256_of_address(
-        _8_206, var_guy)
-    sstore(_9_207, var_wad)
-    local var_ = Uint256(low=1, high=0)
+        local _1_63 : Uint256) = mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256_543(
+        var_sender)
+    let (
+        local _2_64 : Uint256) = mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256(
+        _1_63, var_guy)
+    update_storage_value_offsett_uint256_to_uint256(_2_64, var_wad)
+    local var_ : Uint256 = Uint256(low=1, high=0)
     return (var_)
 end
-
-func fun_deposit(var_sender_208 : Uint256, var_value : Uint256) -> ():
+func fun_deposit{
+        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
+        memory_dict : DictAccess*, msize}(var_sender_65 : Uint256, var_value : Uint256) -> ():
     alloc_locals
-    let (local _1_209 : Uint256) = sub(
-        shl(Uint256(low=160, high=0), Uint256(low=1, high=0)), Uint256(low=1, high=0))
-    let (local _2_210 : Uint256) = and(var_sender_208, _1_209)
-    local _3_211 : Uint256 = Uint256(low=0, high=0)
-    mstore(_3_211, _2_210)
-    local _4_212 : Uint256 = Uint256(low=4, high=0)
-    local _5_213 : Uint256 = Uint256(low=32, high=0)
-    mstore(_5_213, _4_212)
-    local _6_214 : Uint256 = Uint256(low=64, high=0)
-    local _7_215 : Uint256 = _3_211
-    let (local dataSlot : Uint256) = keccak256(_3_211, _6_214)
-    let (local _8_216 : Uint256) = sload(dataSlot)
-    let (local _9_217 : Uint256) = checked_add_uint256(_8_216, var_value)
-    sstore(dataSlot, _9_217)
+    let (
+        local _1_66 : Uint256) = mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256_544(
+        var_sender_65)
+
+    let (local _2_67 : Uint256) = s_load(_1_66)
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local storage_ptr : Storage* = storage_ptr
+    let (local _3_68 : Uint256) = cleanup_from_storage_uint256(_2_67)
+    let (local _4_69 : Uint256) = u256_add(_3_68, var_value)
+    update_storage_value_offsett_uint256_to_uint256(_1_66, _4_69)
     return ()
 end
-
-func fun_transferFrom(
-        var_src : Uint256, var_dst : Uint256, var_wad_218 : Uint256, var_sender_219 : Uint256) -> (
+func fun_transferFrom{
+        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
+        memory_dict : DictAccess*, msize}(
+        var_src : Uint256, var_dst : Uint256, var_wad_70 : Uint256, var_sender_71 : Uint256) -> (
         var : Uint256):
     alloc_locals
-    let (local _1_220 : Uint256) = sub(
-        shl(Uint256(low=160, high=0), Uint256(low=1, high=0)), Uint256(low=1, high=0))
-    let (local _2_221 : Uint256) = and(var_src, _1_220)
-    let (local _3_222 : Uint256) = and(var_sender_219, _1_220)
-    let (local _4_223 : Uint256) = eq(_2_221, _3_222)
-    let (local _5_224 : Uint256) = iszero(_4_223)
-    if _5_224.low + _5_224.high != 0:
-        __warp_block_22(_2_221, var_sender_219, var_src, var_wad_218)
+
+    let (local _1_72 : Uint256) = is_eq(var_src, var_sender_71)
+
+    let (local _2_73 : Uint256) = is_zero(_1_72)
+
+    if _2_73.low + _2_73.high != 0:
+        __warp_block_0(var_sender_71, var_src, var_wad_70)
     end
     let (
-        local _25_244 : Uint256) = mapping_index_access_mapping_address_mapping_address_uint256_of_address_1560(
+        local _18 : Uint256) = mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256_544(
         var_src)
-    let (local _26_245 : Uint256) = sload(_25_244)
-    let (local _27_246 : Uint256) = lt(_26_245, var_wad_218)
-    if _27_246.low + _27_246.high != 0:
-        panic_error_0x11()
-    end
-    let (local _28_247 : Uint256) = sub(_26_245, var_wad_218)
-    sstore(_25_244, _28_247)
+
+    let (local _19 : Uint256) = s_load(_18)
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local storage_ptr : Storage* = storage_ptr
+    let (local _20 : Uint256) = cleanup_from_storage_uint256(_19)
+    let (local _21 : Uint256) = uint256_sub(_20, var_wad_70)
+    update_storage_value_offsett_uint256_to_uint256(_18, _21)
     let (
-        local _29_248 : Uint256) = mapping_index_access_mapping_address_mapping_address_uint256_of_address_1560(
+        local _22 : Uint256) = mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256_544(
         var_dst)
-    let (local _30_249 : Uint256) = sload(_29_248)
-    let (local _31_250 : Uint256) = checked_add_uint256(_30_249, var_wad_218)
-    sstore(_29_248, _31_250)
-    local var = Uint256(low=1, high=0)
+
+    let (local _23 : Uint256) = s_load(_22)
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local storage_ptr : Storage* = storage_ptr
+    let (local _24 : Uint256) = cleanup_from_storage_uint256(_23)
+    let (local _25 : Uint256) = u256_add(_24, var_wad_70)
+    update_storage_value_offsett_uint256_to_uint256(_22, _25)
+    local var : Uint256 = Uint256(low=1, high=0)
     return (var)
 end
-
-func fun_withdraw(var_wad_251 : Uint256, var_sender_252 : Uint256) -> ():
+func fun_withdraw{
+        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
+        memory_dict : DictAccess*, msize}(var_wad_80 : Uint256, var_sender_81 : Uint256) -> ():
     alloc_locals
-    let (local _1_253 : Uint256) = sub(
-        shl(Uint256(low=160, high=0), Uint256(low=1, high=0)), Uint256(low=1, high=0))
-    let (local cleaned : Uint256) = and(var_sender_252, _1_253)
-    local _2_254 : Uint256 = Uint256(low=0, high=0)
-    mstore(_2_254, cleaned)
-    local _3_255 : Uint256 = Uint256(low=4, high=0)
-    local _4_256 : Uint256 = Uint256(low=32, high=0)
-    mstore(_4_256, _3_255)
-    local _5_257 : Uint256 = Uint256(low=64, high=0)
-    let (local _6_258 : Uint256) = keccak256(_2_254, _5_257)
-    let (local _7_259 : Uint256) = sload(_6_258)
-    let (local _8_260 : Uint256) = lt(_7_259, var_wad_251)
-    if _8_260.low + _8_260.high != 0:
-        revert(_2_254, _2_254)
-    end
-    mstore(_2_254, cleaned)
-    local _9_261 : Uint256 = _3_255
-    local _10_262 : Uint256 = _4_256
-    mstore(_4_256, _3_255)
-    local _11_263 : Uint256 = _5_257
-    let (local dataSlot_264 : Uint256) = keccak256(_2_254, _5_257)
-    let (local _12_265 : Uint256) = sload(dataSlot_264)
-    let (local _13_266 : Uint256) = lt(_12_265, var_wad_251)
-    if _13_266.low + _13_266.high != 0:
-        panic_error_0x11()
-    end
-    let (local _14_267 : Uint256) = sub(_12_265, var_wad_251)
-    sstore(dataSlot_264, _14_267)
-    return ()
-end
-
-func getter_fun_balanceOf(key : Uint256) -> (ret_268 : Uint256):
-    alloc_locals
-    let (local _1_269 : Uint256) = sub(
-        shl(Uint256(low=160, high=0), Uint256(low=1, high=0)), Uint256(low=1, high=0))
-    let (local _2_270 : Uint256) = and(key, _1_269)
-    local _3_271 : Uint256 = Uint256(low=0, high=0)
-    mstore(_3_271, _2_270)
-    local _4_272 : Uint256 = Uint256(low=4, high=0)
-    local _5_273 : Uint256 = Uint256(low=32, high=0)
-    mstore(_5_273, _4_272)
-    local _6_274 : Uint256 = Uint256(low=64, high=0)
-    local _7_275 : Uint256 = _3_271
-    let (local _8_276 : Uint256) = keccak256(_3_271, _6_274)
-    let (local ret_268) = sload(_8_276)
-    return (ret_268)
-end
-
-func mapping_index_access_mapping_address_mapping_address_uint256_of_address_1558(
-        key_277 : Uint256) -> (dataSlot_278 : Uint256):
-    alloc_locals
-    let (local _1_279 : Uint256) = sub(
-        shl(Uint256(low=160, high=0), Uint256(low=1, high=0)), Uint256(low=1, high=0))
-    let (local _2_280 : Uint256) = and(key_277, _1_279)
-    local _3_281 : Uint256 = Uint256(low=0, high=0)
-    mstore(_3_281, _2_280)
-    local _4_282 : Uint256 = Uint256(low=5, high=0)
-    local _5_283 : Uint256 = Uint256(low=32, high=0)
-    mstore(_5_283, _4_282)
-    local _6_284 : Uint256 = Uint256(low=64, high=0)
-    local _7_285 : Uint256 = _3_281
-    let (local dataSlot_278) = keccak256(_3_281, _6_284)
-    return (dataSlot_278)
-end
-
-func mapping_index_access_mapping_address_mapping_address_uint256_of_address_1560(
-        key_286 : Uint256) -> (dataSlot_287 : Uint256):
-    alloc_locals
-    let (local _1_288 : Uint256) = sub(
-        shl(Uint256(low=160, high=0), Uint256(low=1, high=0)), Uint256(low=1, high=0))
-    let (local _2_289 : Uint256) = and(key_286, _1_288)
-    local _3_290 : Uint256 = Uint256(low=0, high=0)
-    mstore(_3_290, _2_289)
-    local _4_291 : Uint256 = Uint256(low=4, high=0)
-    local _5_292 : Uint256 = Uint256(low=32, high=0)
-    mstore(_5_292, _4_291)
-    local _6_293 : Uint256 = Uint256(low=64, high=0)
-    local _7_294 : Uint256 = _3_290
-    let (local dataSlot_287) = keccak256(_3_290, _6_293)
-    return (dataSlot_287)
-end
-
-func mapping_index_access_mapping_address_mapping_address_uint256_of_address(
-        slot : Uint256, key_295 : Uint256) -> (dataSlot_296 : Uint256):
-    alloc_locals
-    let (local _1_297 : Uint256) = sub(
-        shl(Uint256(low=160, high=0), Uint256(low=1, high=0)), Uint256(low=1, high=0))
-    let (local _2_298 : Uint256) = and(key_295, _1_297)
-    local _3_299 : Uint256 = Uint256(low=0, high=0)
-    mstore(_3_299, _2_298)
-    local _4_300 : Uint256 = Uint256(low=32, high=0)
-    mstore(_4_300, slot)
-    local _5_301 : Uint256 = Uint256(low=64, high=0)
-    local _6_302 : Uint256 = _3_299
-    let (local dataSlot_296) = keccak256(_3_299, _5_301)
-    return (dataSlot_296)
-end
-
-func panic_error_0x11() -> ():
-    alloc_locals
-    let (local _1_303 : Uint256) = shl(Uint256(low=224, high=0), Uint256(low=1313373041, high=0))
-    local _2_304 : Uint256 = Uint256(low=0, high=0)
-    mstore(_2_304, _1_303)
-    local _3_305 : Uint256 = Uint256(low=17, high=0)
-    local _4_306 : Uint256 = Uint256(low=4, high=0)
-    mstore(_4_306, _3_305)
-    local _5_307 : Uint256 = Uint256(low=36, high=0)
-    local _6_308 : Uint256 = _2_304
-    revert(_2_304, _5_307)
-    return ()
-end
-
-func read_from_storage_dynamic_split_string() -> (value_309 : Uint256):
-    alloc_locals
-    local _1_310 : Uint256 = Uint256(low=64, high=0)
-    let (local memPtr_311 : Uint256) = mload(_1_310)
-    local ret_312 : Uint256 = Uint256(low=0, high=0)
-    let (local slotValue : Uint256) = sload(ret_312)
-    local length_313 : Uint256 = ret_312
-    local _2_314 : Uint256 = Uint256(low=1, high=0)
-    local _3_315 : Uint256 = _2_314
-    let (local length_313) = shr(_2_314, slotValue)
-    local _4_316 : Uint256 = _2_314
-    let (local outOfPlaceEncoding : Uint256) = and(slotValue, _2_314)
-    let (local _5_317 : Uint256) = iszero(outOfPlaceEncoding)
-    if _5_317.low + _5_317.high != 0:
-        let (local length_313) = __warp_block_23(length_313)
-    end
-    local _7_319 : Uint256 = Uint256(low=32, high=0)
-    local _8_320 : Uint256 = _7_319
-    let (local _9_321 : Uint256) = lt(length_313, _7_319)
-    let (local _10_322 : Uint256) = eq(outOfPlaceEncoding, _9_321)
-    if _10_322.low + _10_322.high != 0:
-        __warp_block_24(ret_312)
-    end
-    let (local pos_327 : Uint256) = array_storeLengthForEncoding_string(memPtr_311, length_313)
-    let (local ret_312) = __warp_block_25(
-        _2_314, _7_319, length_313, outOfPlaceEncoding, pos_327, ret_312, slotValue)
-    let (local _20_334 : Uint256) = sub(ret_312, memPtr_311)
-    finalize_allocation(memPtr_311, _20_334)
-    local value_309 = memPtr_311
-    return (value_309)
-end
-
-func read_from_storage_dynamic_split_string_1556() -> (value_335 : Uint256):
-    alloc_locals
-    local _1_336 : Uint256 = Uint256(low=64, high=0)
-    let (local memPtr_337 : Uint256) = mload(_1_336)
-    local ret_338 : Uint256 = Uint256(low=0, high=0)
-    local _2_339 : Uint256 = Uint256(low=1, high=0)
-    local _3_340 : Uint256 = _2_339
-    let (local slotValue_341 : Uint256) = sload(_2_339)
-    local length_342 : Uint256 = ret_338
-    local _4_343 : Uint256 = _2_339
-    let (local length_342) = shr(_2_339, slotValue_341)
-    local _5_344 : Uint256 = _2_339
-    let (local outOfPlaceEncoding_345 : Uint256) = and(slotValue_341, _2_339)
-    let (local _6_346 : Uint256) = iszero(outOfPlaceEncoding_345)
-    if _6_346.low + _6_346.high != 0:
-        let (local length_342) = __warp_block_26(length_342)
-    end
-    local _8_348 : Uint256 = Uint256(low=32, high=0)
-    local _9_349 : Uint256 = _8_348
-    let (local _10_350 : Uint256) = lt(length_342, _8_348)
-    let (local _11_351 : Uint256) = eq(outOfPlaceEncoding_345, _10_350)
-    if _11_351.low + _11_351.high != 0:
-        __warp_block_27(ret_338)
-    end
-    let (local pos_356 : Uint256) = array_storeLengthForEncoding_string(memPtr_337, length_342)
-    let (local ret_338) = __warp_block_28(
-        _2_339, _8_348, length_342, outOfPlaceEncoding_345, pos_356, ret_338, slotValue_341)
-    let (local _21_364 : Uint256) = sub(ret_338, memPtr_337)
-    finalize_allocation(memPtr_337, _21_364)
-    local value_335 = memPtr_337
-    return (value_335)
-end
-
-func __warp_block_0() -> ():
-    alloc_locals
-    local _1 : Uint256 = Uint256(low=64, high=0)
-    local _2 : Uint256 = Uint256(low=128, high=0)
-    mstore(_1, _2)
-    local _3 : Uint256 = Uint256(low=4, high=0)
-    let (local _4 : Uint256) = calldatasize()
-    let (local _5 : Uint256) = lt(_4, _3)
-    let (local _6 : Uint256) = iszero(_5)
-    if _6.low + _6.high != 0:
-        __warp_block_29(_1, _4)
-    end
-    local _52 : Uint256 = Uint256(low=0, high=0)
-    local _53 : Uint256 = _52
-    revert(_52, _52)
-    return ()
-end
-
-func __warp_block_1(_1_1 : Uint256) -> ():
-    alloc_locals
-    local _5_5 : Uint256 = _1_1
-    local _6_6 : Uint256 = _1_1
-    revert(_1_1, _1_1)
-    return ()
-end
-
-func __warp_block_2() -> ():
-    alloc_locals
-    local _5_12 : Uint256 = Uint256(low=0, high=0)
-    local _6_13 : Uint256 = _5_12
-    revert(_5_12, _5_12)
-    return ()
-end
-
-func __warp_block_3() -> ():
-    alloc_locals
-    local _12_20 : Uint256 = Uint256(low=0, high=0)
-    local _13_21 : Uint256 = _12_20
-    revert(_12_20, _12_20)
-    return ()
-end
-
-func __warp_block_4() -> ():
-    alloc_locals
-    local _5_28 : Uint256 = Uint256(low=0, high=0)
-    local _6_29 : Uint256 = _5_28
-    revert(_5_28, _5_28)
-    return ()
-end
-
-func __warp_block_5() -> ():
-    alloc_locals
-    local _12_36 : Uint256 = Uint256(low=0, high=0)
-    local _13_37 : Uint256 = _12_36
-    revert(_12_36, _12_36)
-    return ()
-end
-
-func __warp_block_6() -> ():
-    alloc_locals
-    local _18_42 : Uint256 = Uint256(low=0, high=0)
-    local _19_43 : Uint256 = _18_42
-    revert(_18_42, _18_42)
-    return ()
-end
-
-func __warp_block_7() -> ():
-    alloc_locals
-    local _5_51 : Uint256 = Uint256(low=0, high=0)
-    local _6_52 : Uint256 = _5_51
-    revert(_5_51, _5_51)
-    return ()
-end
-
-func __warp_block_8() -> ():
-    alloc_locals
-    local _12_59 : Uint256 = Uint256(low=0, high=0)
-    local _13_60 : Uint256 = _12_59
-    revert(_12_59, _12_59)
-    return ()
-end
-
-func __warp_block_9() -> ():
-    alloc_locals
-    local _18_66 : Uint256 = Uint256(low=0, high=0)
-    local _19_67 : Uint256 = _18_66
-    revert(_18_66, _18_66)
-    return ()
-end
-
-func __warp_block_10() -> ():
-    alloc_locals
-    local _25_73 : Uint256 = Uint256(low=0, high=0)
-    local _26_74 : Uint256 = _25_73
-    revert(_25_73, _25_73)
-    return ()
-end
-
-func __warp_block_11() -> ():
-    alloc_locals
-    local _5_82 : Uint256 = Uint256(low=0, high=0)
-    local _6_83 : Uint256 = _5_82
-    revert(_5_82, _5_82)
-    return ()
-end
-
-func __warp_block_12() -> ():
-    alloc_locals
-    local _12_90 : Uint256 = Uint256(low=0, high=0)
-    local _13_91 : Uint256 = _12_90
-    revert(_12_90, _12_90)
-    return ()
-end
-
-func __warp_block_13() -> ():
-    alloc_locals
-    local _5_101 : Uint256 = Uint256(low=0, high=0)
-    local _6_102 : Uint256 = _5_101
-    revert(_5_101, _5_101)
-    return ()
-end
-
-func __warp_block_14() -> ():
-    alloc_locals
-    local _12_109 : Uint256 = Uint256(low=0, high=0)
-    local _13_110 : Uint256 = _12_109
-    revert(_12_109, _12_109)
-    return ()
-end
-
-func __warp_block_15() -> ():
-    alloc_locals
-    local _19_117 : Uint256 = Uint256(low=0, high=0)
-    local _20_118 : Uint256 = _19_117
-    revert(_19_117, _19_117)
-    return ()
-end
-
-func __warp_block_16() -> ():
-    alloc_locals
-    local _5_126 : Uint256 = Uint256(low=0, high=0)
-    local _6_127 : Uint256 = _5_126
-    revert(_5_126, _5_126)
-    return ()
-end
-
-func __warp_block_17() -> ():
-    alloc_locals
-    local _13_135 : Uint256 = Uint256(low=0, high=0)
-    local _14_136 : Uint256 = _13_135
-    revert(_13_135, _13_135)
-    return ()
-end
-
-func __warp_block_18(
-        _1_144 : Uint256, headStart_141 : Uint256, i : Uint256, value0_142 : Uint256) -> (
-        i : Uint256):
-    alloc_locals
-    let (local _5_148 : Uint256) = add(value0_142, i)
-    let (local _6_149 : Uint256) = add(_5_148, _1_144)
-    let (local _7_150 : Uint256) = mload(_6_149)
-    local _8_151 : Uint256 = Uint256(low=64, high=0)
-    let (local _9_152 : Uint256) = add(headStart_141, i)
-    let (local _10_153 : Uint256) = add(_9_152, _8_151)
-    mstore(_10_153, _7_150)
-    let (local i) = add(i, _1_144)
-    return (i)
-end
-
-func __warp_block_19(
-        _1_144 : Uint256, headStart_141 : Uint256, i : Uint256, value0_142 : Uint256) -> (
-        _1_144 : Uint256, headStart_141 : Uint256, i : Uint256, value0_142 : Uint256):
-    alloc_locals
-    if lt(i, length).low + lt(i, length).high != 0:
-        let (local i) = __warp_block_18(_1_144, headStart_141, i, value0_142)
-        let (local i) = __warp_block_19(_1_144, headStart_141, i, value0_142)
-    end
-    return (_1_144, headStart_141, i, value0_142)
-end
-
-func __warp_block_20(headStart_141 : Uint256, length : Uint256) -> ():
-    alloc_locals
-    local _12_155 : Uint256 = Uint256(low=0, high=0)
-    local _13_156 : Uint256 = Uint256(low=64, high=0)
-    let (local _14_157 : Uint256) = add(headStart_141, length)
-    let (local _15_158 : Uint256) = add(_14_157, _13_156)
-    mstore(_15_158, _12_155)
-    return ()
-end
-
-func __warp_block_21() -> ():
-    alloc_locals
-    let (local _9_192 : Uint256) = shl(Uint256(low=224, high=0), Uint256(low=1313373041, high=0))
-    local _10_193 : Uint256 = Uint256(low=0, high=0)
-    mstore(_10_193, _9_192)
-    local _11_194 : Uint256 = Uint256(low=65, high=0)
-    local _12_195 : Uint256 = Uint256(low=4, high=0)
-    mstore(_12_195, _11_194)
-    local _13_196 : Uint256 = Uint256(low=36, high=0)
-    local _14_197 : Uint256 = _10_193
-    revert(_10_193, _13_196)
-    return ()
-end
-
-func __warp_block_22(
-        _2_221 : Uint256, var_sender_219 : Uint256, var_src : Uint256, var_wad_218 : Uint256) -> ():
-    alloc_locals
-    local _6_225 : Uint256 = Uint256(low=0, high=0)
-    mstore(_6_225, _2_221)
-    local _7_226 : Uint256 = Uint256(low=5, high=0)
-    local _8_227 : Uint256 = Uint256(low=32, high=0)
-    mstore(_8_227, _7_226)
-    local _9_228 : Uint256 = Uint256(low=64, high=0)
-    let (local _10_229 : Uint256) = keccak256(_6_225, _9_228)
     let (
-        local _11_230 : Uint256) = mapping_index_access_mapping_address_mapping_address_uint256_of_address(
-        _10_229, var_sender_219)
-    let (local _12_231 : Uint256) = sload(_11_230)
-    let (local _13_232 : Uint256) = lt(_12_231, var_wad_218)
-    if _13_232.low + _13_232.high != 0:
-        revert(_6_225, _6_225)
-    end
+        local _1_82 : Uint256) = mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256_544(
+        var_sender_81)
+    let (local _2_83 : Uint256) = read_from_storage_split_dynamic_uint256(_1_82)
+
+    let (local _3_84 : Uint256) = is_lt(_2_83, var_wad_80)
+
+    local memory_dict : DictAccess* = memory_dict
+
+    let (local _4_85 : Uint256) = is_zero(_3_84)
+
+    require_helper(_4_85)
     let (
-        local _14_233 : Uint256) = mapping_index_access_mapping_address_mapping_address_uint256_of_address_1560(
+        local _5_86 : Uint256) = mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256_544(
+        var_sender_81)
+
+    let (local _6_87 : Uint256) = s_load(_5_86)
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local storage_ptr : Storage* = storage_ptr
+    let (local _7_88 : Uint256) = cleanup_from_storage_uint256(_6_87)
+    let (local _8_89 : Uint256) = uint256_sub(_7_88, var_wad_80)
+    update_storage_value_offsett_uint256_to_uint256(_5_86, _8_89)
+    return ()
+end
+func getter_fun_balanceOf{
+        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
+        memory_dict : DictAccess*, msize}(key : Uint256) -> (ret__warp_mangled : Uint256):
+    alloc_locals
+    let (
+        local _1_90 : Uint256) = mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256_552(
+        key)
+    let (local ret__warp_mangled : Uint256) = read_from_storage_split_dynamic_uint256(_1_90)
+    return (ret__warp_mangled)
+end
+func mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256_540{
+        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
+        memory_dict : DictAccess*, msize}(key_91 : Uint256) -> (dataSlot : Uint256):
+    alloc_locals
+    local _1_92 : Uint256 = Uint256(low=0, high=0)
+    let (local msize) = update_msize{range_check_ptr=range_check_ptr}(msize, _1_92.low, 32)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+
+    mstore(offset=_1_92.low, value=key_91)
+    local memory_dict : DictAccess* = memory_dict
+    local _2_93 : Uint256 = Uint256(low=3, high=0)
+    local _3_94 : Uint256 = Uint256(low=32, high=0)
+    let (local msize) = update_msize{range_check_ptr=range_check_ptr}(msize, _3_94.low, 32)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+
+    mstore(offset=_3_94.low, value=_2_93)
+    local memory_dict : DictAccess* = memory_dict
+    local _4_95 : Uint256 = Uint256(low=64, high=0)
+    local _5_96 : Uint256 = _1_92
+
+    let (local dataSlot : Uint256) = sha(_1_92.low, _4_95.low)
+    local msize = msize
+    local memory_dict : DictAccess* = memory_dict
+    return (dataSlot)
+end
+func mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256_543{
+        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
+        memory_dict : DictAccess*, msize}(key_97 : Uint256) -> (dataSlot_98 : Uint256):
+    alloc_locals
+    local _1_99 : Uint256 = Uint256(low=0, high=0)
+    let (local msize) = update_msize{range_check_ptr=range_check_ptr}(msize, _1_99.low, 32)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+
+    mstore(offset=_1_99.low, value=key_97)
+    local memory_dict : DictAccess* = memory_dict
+    local _2_100 : Uint256 = Uint256(low=3, high=0)
+    local _3_101 : Uint256 = Uint256(low=32, high=0)
+    let (local msize) = update_msize{range_check_ptr=range_check_ptr}(msize, _3_101.low, 32)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+
+    mstore(offset=_3_101.low, value=_2_100)
+    local memory_dict : DictAccess* = memory_dict
+    local _4_102 : Uint256 = Uint256(low=64, high=0)
+    local _5_103 : Uint256 = _1_99
+
+    let (local dataSlot_98 : Uint256) = sha(_1_99.low, _4_102.low)
+    local msize = msize
+    local memory_dict : DictAccess* = memory_dict
+    return (dataSlot_98)
+end
+func mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256_544{
+        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
+        memory_dict : DictAccess*, msize}(key_104 : Uint256) -> (dataSlot_105 : Uint256):
+    alloc_locals
+    local _1_106 : Uint256 = Uint256(low=0, high=0)
+    let (local msize) = update_msize{range_check_ptr=range_check_ptr}(msize, _1_106.low, 32)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+
+    mstore(offset=_1_106.low, value=key_104)
+    local memory_dict : DictAccess* = memory_dict
+    local _2_107 : Uint256 = Uint256(low=2, high=0)
+    local _3_108 : Uint256 = Uint256(low=32, high=0)
+    let (local msize) = update_msize{range_check_ptr=range_check_ptr}(msize, _3_108.low, 32)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+
+    mstore(offset=_3_108.low, value=_2_107)
+    local memory_dict : DictAccess* = memory_dict
+    local _4_109 : Uint256 = Uint256(low=64, high=0)
+    local _5_110 : Uint256 = _1_106
+
+    let (local dataSlot_105 : Uint256) = sha(_1_106.low, _4_109.low)
+    local msize = msize
+    local memory_dict : DictAccess* = memory_dict
+    return (dataSlot_105)
+end
+func mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256_552{
+        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
+        memory_dict : DictAccess*, msize}(key_111 : Uint256) -> (dataSlot_112 : Uint256):
+    alloc_locals
+    local _1_113 : Uint256 = Uint256(low=0, high=0)
+    let (local msize) = update_msize{range_check_ptr=range_check_ptr}(msize, _1_113.low, 32)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+
+    mstore(offset=_1_113.low, value=key_111)
+    local memory_dict : DictAccess* = memory_dict
+    local _2_114 : Uint256 = Uint256(low=2, high=0)
+    local _3_115 : Uint256 = Uint256(low=32, high=0)
+    let (local msize) = update_msize{range_check_ptr=range_check_ptr}(msize, _3_115.low, 32)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+
+    mstore(offset=_3_115.low, value=_2_114)
+    local memory_dict : DictAccess* = memory_dict
+    local _4_116 : Uint256 = Uint256(low=64, high=0)
+    local _5_117 : Uint256 = _1_113
+
+    let (local dataSlot_112 : Uint256) = sha(_1_113.low, _4_116.low)
+    local msize = msize
+    local memory_dict : DictAccess* = memory_dict
+    return (dataSlot_112)
+end
+func mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256{
+        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
+        memory_dict : DictAccess*, msize}(slot : Uint256, key_118 : Uint256) -> (
+        dataSlot_119 : Uint256):
+    alloc_locals
+    local _1_120 : Uint256 = Uint256(low=0, high=0)
+    let (local msize) = update_msize{range_check_ptr=range_check_ptr}(msize, _1_120.low, 32)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+
+    mstore(offset=_1_120.low, value=key_118)
+    local memory_dict : DictAccess* = memory_dict
+    local _2_121 : Uint256 = Uint256(low=32, high=0)
+    let (local msize) = update_msize{range_check_ptr=range_check_ptr}(msize, _2_121.low, 32)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+
+    mstore(offset=_2_121.low, value=slot)
+    local memory_dict : DictAccess* = memory_dict
+    local _3_122 : Uint256 = Uint256(low=64, high=0)
+    local _4_123 : Uint256 = _1_120
+
+    let (local dataSlot_119 : Uint256) = sha(_1_120.low, _3_122.low)
+    local msize = msize
+    local memory_dict : DictAccess* = memory_dict
+    return (dataSlot_119)
+end
+func panic_error_0x11{
+        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
+        memory_dict : DictAccess*, msize}() -> ():
+    alloc_locals
+
+    let (local _1_124 : Uint256) = uint256_shl(
+        Uint256(low=224, high=0), Uint256(low=1313373041, high=0))
+
+    local _2_125 : Uint256 = Uint256(low=0, high=0)
+    let (local msize) = update_msize{range_check_ptr=range_check_ptr}(msize, _2_125.low, 32)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+
+    mstore(offset=_2_125.low, value=_1_124)
+    local memory_dict : DictAccess* = memory_dict
+    local _3_126 : Uint256 = Uint256(low=17, high=0)
+    local _4_127 : Uint256 = Uint256(low=4, high=0)
+    let (local msize) = update_msize{range_check_ptr=range_check_ptr}(msize, _4_127.low, 32)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+
+    mstore(offset=_4_127.low, value=_3_126)
+    local memory_dict : DictAccess* = memory_dict
+    local _5_128 : Uint256 = Uint256(low=36, high=0)
+    local _6_129 : Uint256 = _2_125
+    assert 0 = 1
+    return ()
+end
+func read_from_storage_split_dynamic_uint256{
+        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
+        memory_dict : DictAccess*, msize}(slot_130 : Uint256) -> (value_131 : Uint256):
+    alloc_locals
+
+    let (local _1_132 : Uint256) = s_load(slot_130)
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local storage_ptr : Storage* = storage_ptr
+    let (local value_131 : Uint256) = cleanup_from_storage_uint256(_1_132)
+    return (value_131)
+end
+func require_helper{
+        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
+        memory_dict : DictAccess*, msize}(condition : Uint256) -> ():
+    alloc_locals
+
+    let (local _1_133 : Uint256) = is_zero(condition)
+
+    if _1_133.low + _1_133.high != 0:
+        __warp_block_1()
+    end
+    return ()
+end
+func revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74{
+        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
+        memory_dict : DictAccess*, msize}() -> ():
+    alloc_locals
+    local _1_136 : Uint256 = Uint256(low=0, high=0)
+    local _2_137 : Uint256 = _1_136
+    assert 0 = 1
+    return ()
+end
+func update_byte_slice_shift{
+        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
+        memory_dict : DictAccess*, msize}(value_138 : Uint256, toInsert : Uint256) -> (
+        result : Uint256):
+    alloc_locals
+    local result : Uint256 = toInsert
+    return (result)
+end
+func update_storage_value_offsett_uint256_to_uint256{
+        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
+        memory_dict : DictAccess*, msize}(slot_139 : Uint256, value_140 : Uint256) -> ():
+    alloc_locals
+
+    let (local _1_141 : Uint256) = s_load(slot_139)
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local storage_ptr : Storage* = storage_ptr
+    let (local _2_142 : Uint256) = update_byte_slice_shift(_1_141, value_140)
+    s_store(key=slot_139, value=_2_142)
+    return ()
+end
+func __warp_block_0{
+        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
+        memory_dict : DictAccess*, msize}(
+        var_sender_71 : Uint256, var_src : Uint256, var_wad_70 : Uint256) -> ():
+    alloc_locals
+    let (
+        local _3_74 : Uint256) = mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256_543(
         var_src)
-    let (local _15_234 : Uint256) = sload(_14_233)
-    let (local _16_235 : Uint256) = lt(_15_234, var_wad_218)
-    if _16_235.low + _16_235.high != 0:
-        revert(_6_225, _6_225)
-    end
-    mstore(_6_225, _2_221)
-    local _17_236 : Uint256 = _7_226
-    local _18_237 : Uint256 = _8_227
-    mstore(_8_227, _7_226)
-    local _19_238 : Uint256 = _9_228
-    let (local _20_239 : Uint256) = keccak256(_6_225, _9_228)
     let (
-        local _21_240 : Uint256) = mapping_index_access_mapping_address_mapping_address_uint256_of_address(
-        _20_239, var_sender_219)
-    let (local _22_241 : Uint256) = sload(_21_240)
-    let (local _23_242 : Uint256) = lt(_22_241, var_wad_218)
-    if _23_242.low + _23_242.high != 0:
-        panic_error_0x11()
-    end
-    let (local _24_243 : Uint256) = sub(_22_241, var_wad_218)
-    sstore(_21_240, _24_243)
-    return ()
-end
+        local _4_75 : Uint256) = mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256(
+        _3_74, var_sender_71)
+    let (local _5_76 : Uint256) = read_from_storage_split_dynamic_uint256(_4_75)
 
-func __warp_block_23(length_313 : Uint256) -> (length_313 : Uint256):
-    alloc_locals
-    local _6_318 : Uint256 = Uint256(low=127, high=0)
-    let (local length_313) = and(length_313, _6_318)
-    return (length_313)
-end
+    let (local _6_77 : Uint256) = is_lt(_5_76, var_wad_70)
 
-func __warp_block_24(ret_312 : Uint256) -> ():
-    alloc_locals
-    let (local _11_323 : Uint256) = shl(Uint256(low=224, high=0), Uint256(low=1313373041, high=0))
-    mstore(ret_312, _11_323)
-    local _12_324 : Uint256 = Uint256(low=34, high=0)
-    local _13_325 : Uint256 = Uint256(low=4, high=0)
-    mstore(_13_325, _12_324)
-    local _14_326 : Uint256 = Uint256(low=36, high=0)
-    revert(ret_312, _14_326)
-    return ()
-end
+    local memory_dict : DictAccess* = memory_dict
 
-func __warp_block_25(
-        _2_314 : Uint256, _7_319 : Uint256, length_313 : Uint256, outOfPlaceEncoding : Uint256,
-        pos_327 : Uint256, ret_312 : Uint256, slotValue : Uint256) -> (ret_312 : Uint256):
-    alloc_locals
-    local match_var : Uint256 = outOfPlaceEncoding
-    if eq(match_var, Uint256(low=0, high=0)).low + eq(match_var, Uint256(low=0, high=0)).high != 0:
-        let (local ret_312) = __warp_block_30(_7_319, pos_327, ret_312, slotValue)
-        if
-            eq(match_var, Uint256(low=1, high=0)).low + eq(match_var, Uint256(low=1, high=0)).high !=
-            0:
-            let (local ret_312) = __warp_block_31(_2_314, _7_319, length_313, pos_327, ret_312)
-        end
-    end
-    return (ret_312)
-end
+    let (local _7_78 : Uint256) = is_zero(_6_77)
 
-func __warp_block_26(length_342 : Uint256) -> (length_342 : Uint256):
-    alloc_locals
-    local _7_347 : Uint256 = Uint256(low=127, high=0)
-    let (local length_342) = and(length_342, _7_347)
-    return (length_342)
-end
-
-func __warp_block_27(ret_338 : Uint256) -> ():
-    alloc_locals
-    let (local _12_352 : Uint256) = shl(Uint256(low=224, high=0), Uint256(low=1313373041, high=0))
-    mstore(ret_338, _12_352)
-    local _13_353 : Uint256 = Uint256(low=34, high=0)
-    local _14_354 : Uint256 = Uint256(low=4, high=0)
-    mstore(_14_354, _13_353)
-    local _15_355 : Uint256 = Uint256(low=36, high=0)
-    revert(ret_338, _15_355)
-    return ()
-end
-
-func __warp_block_28(
-        _2_339 : Uint256, _8_348 : Uint256, length_342 : Uint256, outOfPlaceEncoding_345 : Uint256,
-        pos_356 : Uint256, ret_338 : Uint256, slotValue_341 : Uint256) -> (ret_338 : Uint256):
-    alloc_locals
-    local match_var : Uint256 = outOfPlaceEncoding_345
-    if eq(match_var, Uint256(low=0, high=0)).low + eq(match_var, Uint256(low=0, high=0)).high != 0:
-        let (local ret_338) = __warp_block_32(_8_348, pos_356, ret_338, slotValue_341)
-        if
-            eq(match_var, Uint256(low=1, high=0)).low + eq(match_var, Uint256(low=1, high=0)).high !=
-            0:
-            let (local ret_338) = __warp_block_33(_2_339, _8_348, length_342, pos_356, ret_338)
-        end
-    end
-    return (ret_338)
-end
-
-func __warp_block_29(_1 : Uint256, _4 : Uint256) -> ():
-    alloc_locals
-    local _7 : Uint256 = Uint256(low=0, high=0)
-    let (local _8 : Uint256) = calldataload(_7)
-    local _9 : Uint256 = Uint256(low=224, high=0)
-    let (local _10 : Uint256) = shr(_9, _8)
-    __warp_block_34(_1, _10, _4, _7)
-    return ()
-end
-
-func __warp_block_30(
-        _7_319 : Uint256, pos_327 : Uint256, ret_312 : Uint256, slotValue : Uint256) -> (
-        ret_312 : Uint256):
-    alloc_locals
-    let (local _15_328 : Uint256) = not(Uint256(low=255, high=0))
-    let (local _16_329 : Uint256) = and(slotValue, _15_328)
-    mstore(pos_327, _16_329)
-    local _17_330 : Uint256 = _7_319
-    let (local ret_312) = add(pos_327, _7_319)
-    return (ret_312)
-end
-
-func __warp_block_31(
-        _2_314 : Uint256, _7_319 : Uint256, length_313 : Uint256, pos_327 : Uint256,
-        ret_312 : Uint256) -> (ret_312 : Uint256):
-    alloc_locals
-    let (local dataPos : Uint256) = array_dataslot_string_storage()
-    local i_331 : Uint256 = Uint256(low=0, high=0)
-    let (local dataPos, local i_331) = __warp_block_36(_2_314, _7_319, dataPos, i_331, pos_327)
-    let (local ret_312) = add(pos_327, i_331)
-    return (ret_312)
-end
-
-func __warp_block_32(
-        _8_348 : Uint256, pos_356 : Uint256, ret_338 : Uint256, slotValue_341 : Uint256) -> (
-        ret_338 : Uint256):
-    alloc_locals
-    let (local _16_357 : Uint256) = not(Uint256(low=255, high=0))
-    let (local _17_358 : Uint256) = and(slotValue_341, _16_357)
-    mstore(pos_356, _17_358)
-    local _18_359 : Uint256 = _8_348
-    let (local ret_338) = add(pos_356, _8_348)
-    return (ret_338)
-end
-
-func __warp_block_33(
-        _2_339 : Uint256, _8_348 : Uint256, length_342 : Uint256, pos_356 : Uint256,
-        ret_338 : Uint256) -> (ret_338 : Uint256):
-    alloc_locals
-    let (local dataPos_360 : Uint256) = array_dataslot_string_storage_3075()
-    local i_361 : Uint256 = Uint256(low=0, high=0)
-    let (local dataPos_360, local i_361) = __warp_block_38(
-        _2_339, _8_348, dataPos_360, i_361, pos_356)
-    let (local ret_338) = add(pos_356, i_361)
-    return (ret_338)
-end
-
-func __warp_block_34(_1 : Uint256, _10 : Uint256, _4 : Uint256, _7 : Uint256) -> ():
-    alloc_locals
-    local match_var : Uint256 = _10
-    if
-        eq(match_var, Uint256(low=16192718, high=0)).low + eq(match_var, Uint256(low=16192718, high=0)).high !=
-        0:
-        __warp_block_39(_1, _4, _7)
-        if
-            eq(match_var, Uint256(low=117300739, high=0)).low + eq(match_var, Uint256(low=117300739, high=0)).high !=
-            0:
-            __warp_block_40(_1, _4, _7)
-            if
-                eq(match_var, Uint256(low=309457050, high=0)).low + eq(match_var, Uint256(low=309457050, high=0)).high !=
-                0:
-                __warp_block_41(_1, _4)
-                if
-                    eq(match_var, Uint256(low=404098525, high=0)).low + eq(match_var, Uint256(low=404098525, high=0)).high !=
-                    0:
-                    __warp_block_42(_1, _4, _7)
-                    if
-                        eq(match_var, Uint256(low=826074471, high=0)).low + eq(match_var, Uint256(low=826074471, high=0)).high !=
-                        0:
-                        __warp_block_43(_1, _4, _7)
-                        if
-                            eq(match_var, Uint256(low=1206382372, high=0)).low + eq(match_var, Uint256(low=1206382372, high=0)).high !=
-                            0:
-                            __warp_block_44(_1, _4, _7)
-                            if
-                                eq(match_var, Uint256(low=1607020700, high=0)).low + eq(match_var, Uint256(low=1607020700, high=0)).high !=
-                                0:
-                                __warp_block_45(_1, _4)
-                                if
-                                    eq(match_var, Uint256(low=1889567281, high=0)).low + eq(match_var, Uint256(low=1889567281, high=0)).high !=
-                                    0:
-                                    __warp_block_46(_1, _4, _7)
-                                    if
-                                        eq(match_var, Uint256(low=2514000705, high=0)).low + eq(match_var, Uint256(low=2514000705, high=0)).high !=
-                                        0:
-                                        __warp_block_47(_1, _4, _7)
-                                        if
-                                            eq(match_var, Uint256(low=3714247998, high=0)).low + eq(match_var, Uint256(low=3714247998, high=0)).high !=
-                                            0:
-                                            __warp_block_48(_1, _4, _7)
-                                        end
-                                    end
-                                end
-                            end
-                        end
-                    end
-                end
-            end
-        end
-    end
-    return ()
-end
-
-func __warp_block_35(
-        _2_314 : Uint256, _7_319 : Uint256, dataPos : Uint256, i_331 : Uint256,
-        pos_327 : Uint256) -> (dataPos : Uint256, i_331 : Uint256):
-    alloc_locals
-    let (local _18_332 : Uint256) = sload(dataPos)
-    let (local _19_333 : Uint256) = add(pos_327, i_331)
-    mstore(_19_333, _18_332)
-    let (local dataPos) = add(dataPos, _2_314)
-    let (local i_331) = add(i_331, _7_319)
-    return (dataPos, i_331)
-end
-
-func __warp_block_36(
-        _2_314 : Uint256, _7_319 : Uint256, dataPos : Uint256, i_331 : Uint256,
-        pos_327 : Uint256) -> (
-        _2_314 : Uint256, _7_319 : Uint256, dataPos : Uint256, i_331 : Uint256, pos_327 : Uint256):
-    alloc_locals
-    if lt(i_331, length_313).low + lt(i_331, length_313).high != 0:
-        let (local dataPos, local i_331) = __warp_block_35(_2_314, _7_319, dataPos, i_331, pos_327)
-        let (local dataPos, local i_331) = __warp_block_36(_2_314, _7_319, dataPos, i_331, pos_327)
-    end
-    return (_2_314, _7_319, dataPos, i_331, pos_327)
-end
-
-func __warp_block_37(
-        _2_339 : Uint256, _8_348 : Uint256, dataPos_360 : Uint256, i_361 : Uint256,
-        pos_356 : Uint256) -> (dataPos_360 : Uint256, i_361 : Uint256):
-    alloc_locals
-    let (local _19_362 : Uint256) = sload(dataPos_360)
-    let (local _20_363 : Uint256) = add(pos_356, i_361)
-    mstore(_20_363, _19_362)
-    let (local dataPos_360) = add(dataPos_360, _2_339)
-    let (local i_361) = add(i_361, _8_348)
-    return (dataPos_360, i_361)
-end
-
-func __warp_block_38(
-        _2_339 : Uint256, _8_348 : Uint256, dataPos_360 : Uint256, i_361 : Uint256,
-        pos_356 : Uint256) -> (
-        _2_339 : Uint256, _8_348 : Uint256, dataPos_360 : Uint256, i_361 : Uint256,
-        pos_356 : Uint256):
-    alloc_locals
-    if lt(i_361, length_342).low + lt(i_361, length_342).high != 0:
-        let (local dataPos_360, local i_361) = __warp_block_37(
-            _2_339, _8_348, dataPos_360, i_361, pos_356)
-        let (local dataPos_360, local i_361) = __warp_block_38(
-            _2_339, _8_348, dataPos_360, i_361, pos_356)
-    end
-    return (_2_339, _8_348, dataPos_360, i_361, pos_356)
-end
-
-func __warp_block_39(_1 : Uint256, _4 : Uint256, _7 : Uint256) -> ():
-    alloc_locals
-    local _11 : Uint256 = _4
-    let (local param : Uint256, local param_1 : Uint256) = abi_decode_uint256t_address(_4)
-    fun_withdraw(param, param_1)
-    let (local _12 : Uint256) = mload(_1)
-    return (_12, _7)
-    return ()
-end
-
-func __warp_block_40(_1 : Uint256, _4 : Uint256, _7 : Uint256) -> ():
-    alloc_locals
-    let (local _13 : Uint256) = callvalue()
-    if _13.low + _13.high != 0:
-        revert(_7, _7)
-    end
-    local _14 : Uint256 = _4
-    abi_decode(_4)
-    let (local ret__warp_mangled : Uint256) = read_from_storage_dynamic_split_string()
-    let (local memPos : Uint256) = mload(_1)
-    let (local _15 : Uint256) = abi_encode_string(memPos, ret__warp_mangled)
-    let (local _16 : Uint256) = sub(_15, memPos)
-    return (memPos, _16)
-    return ()
-end
-
-func __warp_block_41(_1 : Uint256, _4 : Uint256) -> ():
-    alloc_locals
-    local _17 : Uint256 = _4
-    let (local param_2 : Uint256, local param_3 : Uint256,
-        local param_4 : Uint256) = abi_decode_addresst_uint256t_address(_4)
-    let (local ret_1 : Uint256) = fun_approve(param_2, param_3, param_4)
-    let (local memPos_1 : Uint256) = mload(_1)
-    let (local _18 : Uint256) = abi_encode_bool(memPos_1, ret_1)
-    let (local _19 : Uint256) = sub(_18, memPos_1)
-    return (memPos_1, _19)
-    return ()
-end
-
-func __warp_block_42(_1 : Uint256, _4 : Uint256, _7 : Uint256) -> ():
-    alloc_locals
-    let (local _20 : Uint256) = callvalue()
-    if _20.low + _20.high != 0:
-        revert(_7, _7)
-    end
-    local _21 : Uint256 = _4
-    abi_decode(_4)
-    local _22 : Uint256 = Uint256(low=3, high=0)
-    let (local ret_2 : Uint256) = sload(_22)
-    let (local memPos_2 : Uint256) = mload(_1)
-    let (local _23 : Uint256) = abi_encode_uint256(memPos_2, ret_2)
-    let (local _24 : Uint256) = sub(_23, memPos_2)
-    return (memPos_2, _24)
-    return ()
-end
-
-func __warp_block_43(_1 : Uint256, _4 : Uint256, _7 : Uint256) -> ():
-    alloc_locals
-    let (local _25 : Uint256) = callvalue()
-    if _25.low + _25.high != 0:
-        revert(_7, _7)
-    end
-    local _26 : Uint256 = _4
-    abi_decode(_4)
-    local _27 : Uint256 = Uint256(low=255, high=0)
-    local _28 : Uint256 = Uint256(low=2, high=0)
-    let (local _29 : Uint256) = sload(_28)
-    let (local ret_3 : Uint256) = and(_29, _27)
-    let (local memPos_3 : Uint256) = mload(_1)
-    let (local _30 : Uint256) = abi_encode_uint8(memPos_3, ret_3)
-    let (local _31 : Uint256) = sub(_30, memPos_3)
-    return (memPos_3, _31)
-    return ()
-end
-
-func __warp_block_44(_1 : Uint256, _4 : Uint256, _7 : Uint256) -> ():
-    alloc_locals
-    local _32 : Uint256 = _4
-    let (local param_5 : Uint256, local param_6 : Uint256) = abi_decode_addresst_uint256(_4)
-    fun_deposit(param_5, param_6)
-    let (local _33 : Uint256) = mload(_1)
-    return (_33, _7)
-    return ()
-end
-
-func __warp_block_45(_1 : Uint256, _4 : Uint256) -> ():
-    alloc_locals
-    local _34 : Uint256 = _4
-    let (local param_7 : Uint256, local param_8 : Uint256, local param_9 : Uint256,
-        local param_10 : Uint256) = abi_decode_addresst_addresst_uint256t_address(_4)
-    let (local ret_4 : Uint256) = fun_transferFrom(param_7, param_8, param_9, param_10)
-    let (local memPos_4 : Uint256) = mload(_1)
-    let (local _35 : Uint256) = abi_encode_bool(memPos_4, ret_4)
-    let (local _36 : Uint256) = sub(_35, memPos_4)
-    return (memPos_4, _36)
-    return ()
-end
-
-func __warp_block_46(_1 : Uint256, _4 : Uint256, _7 : Uint256) -> ():
-    alloc_locals
-    let (local _37 : Uint256) = callvalue()
-    if _37.low + _37.high != 0:
-        revert(_7, _7)
-    end
-    local _38 : Uint256 = _4
-    let (local _39 : Uint256) = abi_decode_address(_4)
-    let (local ret_5 : Uint256) = getter_fun_balanceOf(_39)
-    let (local memPos_5 : Uint256) = mload(_1)
-    let (local _40 : Uint256) = abi_encode_uint256(memPos_5, ret_5)
-    let (local _41 : Uint256) = sub(_40, memPos_5)
-    return (memPos_5, _41)
-    return ()
-end
-
-func __warp_block_47(_1 : Uint256, _4 : Uint256, _7 : Uint256) -> ():
-    alloc_locals
-    let (local _42 : Uint256) = callvalue()
-    if _42.low + _42.high != 0:
-        revert(_7, _7)
-    end
-    local _43 : Uint256 = _4
-    abi_decode(_4)
-    let (local ret_6 : Uint256) = read_from_storage_dynamic_split_string_1556()
-    let (local memPos_6 : Uint256) = mload(_1)
-    let (local _44 : Uint256) = abi_encode_string(memPos_6, ret_6)
-    let (local _45 : Uint256) = sub(_44, memPos_6)
-    return (memPos_6, _45)
-    return ()
-end
-
-func __warp_block_48(_1 : Uint256, _4 : Uint256, _7 : Uint256) -> ():
-    alloc_locals
-    let (local _46 : Uint256) = callvalue()
-    if _46.low + _46.high != 0:
-        revert(_7, _7)
-    end
-    local _47 : Uint256 = _4
-    let (local param_11 : Uint256, local param_12 : Uint256) = abi_decode_addresst_address(_4)
+    require_helper(_7_78)
     let (
-        local _48 : Uint256) = mapping_index_access_mapping_address_mapping_address_uint256_of_address_1558(
-        param_11)
+        local _8_79 : Uint256) = mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256_544(
+        var_src)
+    let (local _9 : Uint256) = read_from_storage_split_dynamic_uint256(_8_79)
+    let (local _10 : Uint256) = cleanup_from_storage_uint256(_9)
+
+    let (local _11 : Uint256) = is_lt(_10, var_wad_70)
+
+    local memory_dict : DictAccess* = memory_dict
+
+    let (local _12 : Uint256) = is_zero(_11)
+
+    require_helper(_12)
     let (
-        local _49 : Uint256) = mapping_index_access_mapping_address_mapping_address_uint256_of_address(
-        _48, param_12)
-    let (local value : Uint256) = sload(_49)
-    let (local memPos_7 : Uint256) = mload(_1)
-    let (local _50 : Uint256) = abi_encode_uint256(memPos_7, value)
-    let (local _51 : Uint256) = sub(_50, memPos_7)
-    return (memPos_7, _51)
+        local _13 : Uint256) = mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256_543(
+        var_src)
+    let (
+        local _14 : Uint256) = mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256(
+        _13, var_sender_71)
+
+    let (local _15 : Uint256) = s_load(_14)
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local storage_ptr : Storage* = storage_ptr
+    let (local _16 : Uint256) = cleanup_from_storage_uint256(_15)
+    let (local _17 : Uint256) = uint256_sub(_16, var_wad_70)
+    update_storage_value_offsett_uint256_to_uint256(_14, _17)
+    return ()
+end
+func __warp_block_1{
+        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
+        memory_dict : DictAccess*, msize}() -> ():
+    alloc_locals
+    local _2_134 : Uint256 = Uint256(low=0, high=0)
+    local _3_135 : Uint256 = _2_134
+    assert 0 = 1
     return ()
 end
 

--- a/warp/ERC20.cairo
+++ b/warp/ERC20.cairo
@@ -53,6 +53,7 @@ func cleanup_from_storage_uint256{
     local cleaned : Uint256 = value_60
     return (cleaned)
 end
+
 func extract_from_storage_value_dynamict_uint8{
         range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
         memory_dict : DictAccess*, msize}(slot_value : Uint256) -> (value_61 : Uint256):
@@ -63,6 +64,7 @@ func extract_from_storage_value_dynamict_uint8{
 
     return (value_61)
 end
+
 func fun_approve{
         range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
         memory_dict : DictAccess*, msize}(
@@ -78,6 +80,7 @@ func fun_approve{
     local var_ : Uint256 = Uint256(low=1, high=0)
     return (var_)
 end
+
 func fun_deposit{
         range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
         memory_dict : DictAccess*, msize}(var_sender_65 : Uint256, var_value : Uint256) -> ():
@@ -94,6 +97,7 @@ func fun_deposit{
     update_storage_value_offsett_uint256_to_uint256(_1_66, _4_69)
     return ()
 end
+
 func fun_transferFrom{
         range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
         memory_dict : DictAccess*, msize}(
@@ -131,6 +135,7 @@ func fun_transferFrom{
     local var : Uint256 = Uint256(low=1, high=0)
     return (var)
 end
+
 func fun_withdraw{
         range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
         memory_dict : DictAccess*, msize}(var_wad_80 : Uint256, var_sender_81 : Uint256) -> ():
@@ -159,6 +164,7 @@ func fun_withdraw{
     update_storage_value_offsett_uint256_to_uint256(_5_86, _8_89)
     return ()
 end
+
 func getter_fun_balanceOf{
         range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
         memory_dict : DictAccess*, msize}(key : Uint256) -> (ret__warp_mangled : Uint256):
@@ -169,6 +175,7 @@ func getter_fun_balanceOf{
     let (local ret__warp_mangled : Uint256) = read_from_storage_split_dynamic_uint256(_1_90)
     return (ret__warp_mangled)
 end
+
 func mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256_540{
         range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
         memory_dict : DictAccess*, msize}(key_91 : Uint256) -> (dataSlot : Uint256):
@@ -196,6 +203,7 @@ func mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256_540
     local memory_dict : DictAccess* = memory_dict
     return (dataSlot)
 end
+
 func mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256_543{
         range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
         memory_dict : DictAccess*, msize}(key_97 : Uint256) -> (dataSlot_98 : Uint256):
@@ -223,6 +231,7 @@ func mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256_543
     local memory_dict : DictAccess* = memory_dict
     return (dataSlot_98)
 end
+
 func mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256_544{
         range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
         memory_dict : DictAccess*, msize}(key_104 : Uint256) -> (dataSlot_105 : Uint256):
@@ -250,6 +259,7 @@ func mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256_544
     local memory_dict : DictAccess* = memory_dict
     return (dataSlot_105)
 end
+
 func mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256_552{
         range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
         memory_dict : DictAccess*, msize}(key_111 : Uint256) -> (dataSlot_112 : Uint256):
@@ -277,6 +287,7 @@ func mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256_552
     local memory_dict : DictAccess* = memory_dict
     return (dataSlot_112)
 end
+
 func mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256{
         range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
         memory_dict : DictAccess*, msize}(slot : Uint256, key_118 : Uint256) -> (
@@ -304,6 +315,7 @@ func mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256{
     local memory_dict : DictAccess* = memory_dict
     return (dataSlot_119)
 end
+
 func panic_error_0x11{
         range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
         memory_dict : DictAccess*, msize}() -> ():
@@ -332,6 +344,7 @@ func panic_error_0x11{
     assert 0 = 1
     return ()
 end
+
 func read_from_storage_split_dynamic_uint256{
         range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
         memory_dict : DictAccess*, msize}(slot_130 : Uint256) -> (value_131 : Uint256):
@@ -343,6 +356,7 @@ func read_from_storage_split_dynamic_uint256{
     let (local value_131 : Uint256) = cleanup_from_storage_uint256(_1_132)
     return (value_131)
 end
+
 func require_helper{
         range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
         memory_dict : DictAccess*, msize}(condition : Uint256) -> ():
@@ -355,6 +369,7 @@ func require_helper{
     end
     return ()
 end
+
 func revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74{
         range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
         memory_dict : DictAccess*, msize}() -> ():
@@ -364,6 +379,7 @@ func revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f
     assert 0 = 1
     return ()
 end
+
 func update_byte_slice_shift{
         range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
         memory_dict : DictAccess*, msize}(value_138 : Uint256, toInsert : Uint256) -> (
@@ -372,6 +388,7 @@ func update_byte_slice_shift{
     local result : Uint256 = toInsert
     return (result)
 end
+
 func update_storage_value_offsett_uint256_to_uint256{
         range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
         memory_dict : DictAccess*, msize}(slot_139 : Uint256, value_140 : Uint256) -> ():
@@ -384,6 +401,7 @@ func update_storage_value_offsett_uint256_to_uint256{
     s_store(key=slot_139, value=_2_142)
     return ()
 end
+
 func __warp_block_0{
         range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
         memory_dict : DictAccess*, msize}(
@@ -432,6 +450,7 @@ func __warp_block_0{
     update_storage_value_offsett_uint256_to_uint256(_14, _17)
     return ()
 end
+
 func __warp_block_1{
         range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
         memory_dict : DictAccess*, msize}() -> ():

--- a/warp/for-loop-with-break.cairo
+++ b/warp/for-loop-with-break.cairo
@@ -1,0 +1,143 @@
+%lang starknet
+%builtins pedersen range_check
+from evm.memory import mstore
+from evm.uint256 import is_gt, is_lt, is_zero, slt, u256_add
+from evm.utils import update_msize
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.default_dict import default_dict_new
+from starkware.cairo.common.dict_access import DictAccess
+from starkware.cairo.common.math_cmp import is_le
+from starkware.cairo.common.registers import get_fp_and_pc
+from starkware.cairo.common.uint256 import (
+    Uint256, uint256_eq, uint256_not, uint256_shl, uint256_sub)
+from starkware.starknet.common.storage import Storage
+
+@storage_var
+func evm_storage(low : felt, high : felt, part : felt) -> (res : felt):
+end
+
+func s_load{storage_ptr : Storage*, range_check_ptr, pedersen_ptr : HashBuiltin*}(
+        key : Uint256) -> (res : Uint256):
+    let (low_r) = evm_storage.read(key.low, key.high, 1)
+    let (high_r) = evm_storage.read(key.low, key.high, 2)
+    return (Uint256(low_r, high_r))
+end
+
+func s_store{storage_ptr : Storage*, range_check_ptr, pedersen_ptr : HashBuiltin*}(
+        key : Uint256, value : Uint256):
+    evm_storage.write(low=key.low, high=key.high, part=1, value=value.low)
+    evm_storage.write(low=key.low, high=key.high, part=2, value=value.high)
+    return ()
+end
+
+@view
+func get_storage_low{storage_ptr : Storage*, range_check_ptr, pedersen_ptr : HashBuiltin*}(
+        low : felt, high : felt) -> (res : felt):
+    let (storage_val_low) = evm_storage.read(low=low, high=high, part=1)
+    return (res=storage_val_low)
+end
+
+@view
+func get_storage_high{storage_ptr : Storage*, range_check_ptr, pedersen_ptr : HashBuiltin*}(
+        low : felt, high : felt) -> (res : felt):
+    let (storage_val_high) = evm_storage.read(low=low, high=high, part=2)
+    return (res=storage_val_high)
+end
+
+func fun_transferFrom{
+        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
+        memory_dict : DictAccess*, msize}(var_i : Uint256, var_j : Uint256) -> (var : Uint256):
+    alloc_locals
+    local var_k : Uint256 = Uint256(low=0, high=0)
+    let (local var_k : Uint256) = __warp_loop_0(var_j, var_k)
+
+    local var : Uint256 = Uint256(low=1, high=0)
+    return (var)
+end
+
+func panic_error_0x11{
+        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
+        memory_dict : DictAccess*, msize}() -> ():
+    alloc_locals
+
+    let (local _1_12 : Uint256) = uint256_shl(
+        Uint256(low=224, high=0), Uint256(low=1313373041, high=0))
+
+    local _2_13 : Uint256 = Uint256(low=0, high=0)
+    let (local msize) = update_msize{range_check_ptr=range_check_ptr}(msize, _2_13.low, 32)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+
+    mstore(offset=_2_13.low, value=_1_12)
+    local memory_dict : DictAccess* = memory_dict
+    local _3_14 : Uint256 = Uint256(low=17, high=0)
+    local _4_15 : Uint256 = Uint256(low=4, high=0)
+    let (local msize) = update_msize{range_check_ptr=range_check_ptr}(msize, _4_15.low, 32)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+
+    mstore(offset=_4_15.low, value=_3_14)
+    local memory_dict : DictAccess* = memory_dict
+    local _5_16 : Uint256 = Uint256(low=36, high=0)
+    local _6_17 : Uint256 = _2_13
+    assert 0 = 1
+    return ()
+end
+
+func revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74{
+        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
+        memory_dict : DictAccess*, msize}() -> ():
+    alloc_locals
+    local _1_18 : Uint256 = Uint256(low=0, high=0)
+    local _2_19 : Uint256 = _1_18
+    assert 0 = 1
+    return ()
+end
+
+func __warp_loop_body_0{
+        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
+        memory_dict : DictAccess*, msize}(
+        __warp_break_0 : Uint256, var_j : Uint256, var_k : Uint256) -> (
+        __warp_break_0 : Uint256, var_k : Uint256):
+    alloc_locals
+
+    let (local _1_11 : Uint256) = is_gt(var_k, var_j)
+
+    if _1_11.low + _1_11.high != 0:
+        local __warp_break_0 : Uint256 = Uint256(low=1, high=0)
+        return (__warp_break_0, var_k)
+    end
+    let (local var_k : Uint256) = uint256_sub(var_k)
+    let (local var_k : Uint256) = u256_add(var_k, var_j)
+    return (__warp_break_0, var_k)
+end
+
+func __warp_loop_0{
+        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
+        memory_dict : DictAccess*, msize}(var_j : Uint256, var_k : Uint256) -> (var_k : Uint256):
+    alloc_locals
+
+    let (local __warp_subexpr_0 : Uint256) = is_lt(var_k, var_i)
+
+    local memory_dict : DictAccess* = memory_dict
+    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
+        let (local var_k : Uint256) = __warp_block_0(var_j, var_k)
+    end
+    return (var_k)
+end
+
+func __warp_block_0{
+        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
+        memory_dict : DictAccess*, msize}(var_j : Uint256, var_k : Uint256) -> (var_k : Uint256):
+    alloc_locals
+    local __warp_break_0 : Uint256 = Uint256(low=0, high=0)
+    let (local __warp_break_0 : Uint256, local var_k : Uint256) = __warp_loop_body_0(
+        __warp_break_0, var_j, var_k)
+    if __warp_break_0.low + __warp_break_0.high != 0:
+        return (var_k)
+    else:
+        let (local var_k : Uint256) = __warp_loop_0(var_j, var_k)
+    end
+    return (var_k)
+end
+

--- a/warp/for-loop-with-break.sol
+++ b/warp/for-loop-with-break.sol
@@ -1,0 +1,13 @@
+pragma solidity >=0.8.6;
+
+contract WARP {
+    function transferFrom(uint i, uint j) public payable returns (bool) {
+        for (uint k = 0; k < i; k += j) {
+            if (k > j) {
+                break;
+            }
+            k -= 1;
+        }
+        return true;
+    }
+}

--- a/warp/for-loop-with-continue.cairo
+++ b/warp/for-loop-with-continue.cairo
@@ -1,0 +1,126 @@
+%lang starknet
+%builtins pedersen range_check
+from evm.memory import mstore
+from evm.uint256 import is_gt, is_lt, is_zero, slt, u256_add
+from evm.utils import update_msize
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.default_dict import default_dict_new
+from starkware.cairo.common.dict_access import DictAccess
+from starkware.cairo.common.math_cmp import is_le
+from starkware.cairo.common.registers import get_fp_and_pc
+from starkware.cairo.common.uint256 import (
+    Uint256, uint256_eq, uint256_not, uint256_shl, uint256_sub)
+from starkware.starknet.common.storage import Storage
+
+@storage_var
+func evm_storage(low : felt, high : felt, part : felt) -> (res : felt):
+end
+
+func s_load{storage_ptr : Storage*, range_check_ptr, pedersen_ptr : HashBuiltin*}(
+        key : Uint256) -> (res : Uint256):
+    let (low_r) = evm_storage.read(key.low, key.high, 1)
+    let (high_r) = evm_storage.read(key.low, key.high, 2)
+    return (Uint256(low_r, high_r))
+end
+
+func s_store{storage_ptr : Storage*, range_check_ptr, pedersen_ptr : HashBuiltin*}(
+        key : Uint256, value : Uint256):
+    evm_storage.write(low=key.low, high=key.high, part=1, value=value.low)
+    evm_storage.write(low=key.low, high=key.high, part=2, value=value.high)
+    return ()
+end
+
+@view
+func get_storage_low{storage_ptr : Storage*, range_check_ptr, pedersen_ptr : HashBuiltin*}(
+        low : felt, high : felt) -> (res : felt):
+    let (storage_val_low) = evm_storage.read(low=low, high=high, part=1)
+    return (res=storage_val_low)
+end
+
+@view
+func get_storage_high{storage_ptr : Storage*, range_check_ptr, pedersen_ptr : HashBuiltin*}(
+        low : felt, high : felt) -> (res : felt):
+    let (storage_val_high) = evm_storage.read(low=low, high=high, part=2)
+    return (res=storage_val_high)
+end
+
+func fun_transferFrom{
+        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
+        memory_dict : DictAccess*, msize}(var_i : Uint256, var_j : Uint256) -> (var : Uint256):
+    alloc_locals
+    local var_k : Uint256 = Uint256(low=0, high=0)
+    let (local var_k : Uint256) = __warp_loop_0(var_j, var_k)
+
+    local var : Uint256 = Uint256(low=1, high=0)
+    return (var)
+end
+
+func panic_error_0x11{
+        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
+        memory_dict : DictAccess*, msize}() -> ():
+    alloc_locals
+
+    let (local _1_12 : Uint256) = uint256_shl(
+        Uint256(low=224, high=0), Uint256(low=1313373041, high=0))
+
+    local _2_13 : Uint256 = Uint256(low=0, high=0)
+    let (local msize) = update_msize{range_check_ptr=range_check_ptr}(msize, _2_13.low, 32)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+
+    mstore(offset=_2_13.low, value=_1_12)
+    local memory_dict : DictAccess* = memory_dict
+    local _3_14 : Uint256 = Uint256(low=17, high=0)
+    local _4_15 : Uint256 = Uint256(low=4, high=0)
+    let (local msize) = update_msize{range_check_ptr=range_check_ptr}(msize, _4_15.low, 32)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+
+    mstore(offset=_4_15.low, value=_3_14)
+    local memory_dict : DictAccess* = memory_dict
+    local _5_16 : Uint256 = Uint256(low=36, high=0)
+    local _6_17 : Uint256 = _2_13
+    assert 0 = 1
+    return ()
+end
+
+func revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74{
+        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
+        memory_dict : DictAccess*, msize}() -> ():
+    alloc_locals
+    local _1_18 : Uint256 = Uint256(low=0, high=0)
+    local _2_19 : Uint256 = _1_18
+    assert 0 = 1
+    return ()
+end
+
+func __warp_loop_body_0{
+        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
+        memory_dict : DictAccess*, msize}(var_j : Uint256, var_k : Uint256) -> (var_k : Uint256):
+    alloc_locals
+
+    let (local _1_11 : Uint256) = is_gt(var_k, var_j)
+
+    if _1_11.low + _1_11.high != 0:
+        return (var_k)
+    end
+    let (local var_k : Uint256) = uint256_sub(var_k)
+    let (local var_k : Uint256) = u256_add(var_k, var_j)
+    return (var_k)
+end
+
+func __warp_loop_0{
+        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
+        memory_dict : DictAccess*, msize}(var_j : Uint256, var_k : Uint256) -> (var_k : Uint256):
+    alloc_locals
+
+    let (local __warp_subexpr_0 : Uint256) = is_lt(var_k, var_i)
+
+    local memory_dict : DictAccess* = memory_dict
+    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
+        let (local var_k : Uint256) = __warp_loop_body_0(var_j, var_k)
+        let (local var_k : Uint256) = __warp_loop_0(var_j, var_k)
+    end
+    return (var_k)
+end
+

--- a/warp/for-loop-with-continue.sol
+++ b/warp/for-loop-with-continue.sol
@@ -1,0 +1,13 @@
+pragma solidity >=0.8.6;
+
+contract WARP {
+    function transferFrom(uint i, uint j) public payable returns (bool) {
+        for (uint k = 0; k < i; k += j) {
+            if (k > j) {
+                continue;
+            }
+            k -= 1;
+        }
+        return true;
+    }
+}

--- a/warp/yul/BuiltinHandler.py
+++ b/warp/yul/BuiltinHandler.py
@@ -351,7 +351,7 @@ mstore8(offset={self.address}, byte=byte)
         return {
             "evm.memory": {"mstore8"},
             "evm.uint256": {"extract_lowest_byte"},
-            "evm.utils": {"update_msize"}
+            "evm.utils": {"update_msize"},
         }
 
 
@@ -379,9 +379,10 @@ class MSize(BuiltinHandler):
             module="evm.utils",
             function_name="round_up_to_multiple",
             function_args=function_args,
-            preamble="let (local immediate) = round_up_to_multiple(msize, 32)"
+            preamble="let (local immediate) = round_up_to_multiple(msize, 32)",
         )
         self.function_call = "Uint256(immediate, 0)"
+
 
 # ============ Storage ============
 class SStore(BuiltinHandler):

--- a/warp/yul/ExpressionSplitter.py
+++ b/warp/yul/ExpressionSplitter.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Optional
+
+import yul.yul_ast as ast
+from yul.AstMapper import AstMapper
+
+
+@dataclass
+class BlockEnv:
+    split_stmt: Optional[ast.VariableDeclaration] = None
+    split_stmt_count: int = 0
+
+    def process_subexpr(self, call: ast.FunctionCall) -> str:
+        name = f"__warp_subexpr_{self.split_stmt_count}"
+        self.split_stmt = ast.VariableDeclaration(
+            variables=[ast.TypedName(name)], value=call
+        )
+        return name
+
+
+class ExpressionSplitter(AstMapper):
+    def __init__(self):
+        super().__init__()
+        self.block_env_stack: list[BlockEnv] = []
+
+    def visit_function_call(self, node: ast.FunctionCall):
+        if len(self.path) == 1:  # no parent
+            return ast.FunctionCall(node.function_name, self.visit_list(node.arguments))
+        parent = self.path[-2]
+        if isinstance(
+            parent, (ast.Assignment, ast.VariableDeclaration, ast.ExpressionStatement)
+        ):
+            return ast.FunctionCall(node.function_name, self.visit_list(node.arguments))
+        var_name = self.block_env_stack[-1].process_subexpr(node)
+        return ast.Identifier(var_name)
+
+    def visit_block(self, node: ast.Block):
+        with self._new_block_env() as env:
+            new_stmts = []
+            for stmt in node.statements:
+                new_stmt = self.visit(stmt)
+                split_stmts = [new_stmt]  # in the reverse order of declaration
+                while env.split_stmt:
+                    split_stmt = env.split_stmt
+                    env.split_stmt = None
+                    split_stmts.append(self.visit(split_stmt))
+                split_stmts.reverse()
+                new_stmts.extend(split_stmts)
+            return ast.Block(tuple(new_stmts))
+
+    @contextmanager
+    def _new_block_env(self) -> BlockEnv:
+        env = BlockEnv()
+        self.block_env_stack.append(env)
+        try:
+            yield env
+        finally:
+            self.block_env_stack.pop()

--- a/warp/yul/ForLoopEliminator.py
+++ b/warp/yul/ForLoopEliminator.py
@@ -80,7 +80,7 @@ class ForLoopEliminator(AstMapper):
                     body_call,
                     ast.If(
                         condition=break_id,
-                        body=ast.Block((ast.Leave(),)),
+                        body=ast.Block((ast.LEAVE,)),
                         else_body=ast.Block((loop_call,)),
                     ),
                 )
@@ -110,12 +110,12 @@ class ForLoopEliminator(AstMapper):
                     variable_names=[ast.Identifier(self.break_name)],
                     value=ast.Literal(True),
                 ),
-                ast.Leave(),
+                ast.LEAVE,
             )
         )
 
     def visit_continue(self, node: ast.Continue):
-        return ast.Leave()
+        return ast.LEAVE
 
     @contextmanager
     def _new_for_loop(self):

--- a/warp/yul/ForLoopEliminator.py
+++ b/warp/yul/ForLoopEliminator.py
@@ -1,0 +1,130 @@
+from contextlib import contextmanager
+from typing import Optional
+
+import yul.yul_ast as ast
+from yul.AstMapper import AstMapper
+
+
+class ForLoopEliminator(AstMapper):
+    """This class removes for-loops from Yul AST. Loops are replaced by
+    recursive functions.
+
+    Furthermore, it replaces breaks and continues with leaves.
+    "breaking" from a loop requires an additional condition variable.
+
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.n_loops = 0
+        self.body_name: Optional[str] = None
+        self.loop_name: Optional[str] = None
+        self.break_name: Optional[str] = None
+        self.aux_functions: [ast.FunctionDefinition] = []
+
+    def map(self, node: ast.Node, **kwargs):
+        if not isinstance(node, ast.Block):
+            return self.visit(node)
+
+        block = self.visit(node)
+        return ast.Block(block.statements + tuple(self.aux_functions))
+
+    def visit_for_loop(self, node: ast.ForLoop):
+        assert not node.pre.statements, "Loop not simplified"
+        assert not node.post.statements, "Loop not simplified"
+
+        with self._new_for_loop():
+            body = self.visit(node.body)
+            break_id = ast.Identifier(self.break_name)
+
+            free_vars = sorted(body.scope.free_variables)
+            mod_vars = sorted(body.scope.modified_variables)
+            # ↓ default Uint256 type for everything
+            typed_free_vars = [ast.TypedName(x.name) for x in free_vars]
+            typed_mod_vars = [ast.TypedName(x.name) for x in mod_vars]
+
+            body_call = ast.Assignment(
+                variable_names=mod_vars,
+                value=ast.FunctionCall(
+                    function_name=ast.Identifier(self.body_name), arguments=free_vars
+                ),
+            )
+            body_fun = ast.FunctionDefinition(
+                name=self.body_name,
+                parameters=typed_free_vars,
+                return_variables=typed_mod_vars,
+                body=body,
+            )
+
+            has_break = break_id in body.scope.free_variables
+            if has_break:
+                free_vars = sorted(body.scope.free_variables - {break_id})
+                mod_vars = sorted(body.scope.modified_variables - {break_id})
+                typed_free_vars = [ast.TypedName(x.name) for x in free_vars]
+                typed_mod_vars = [ast.TypedName(x.name) for x in mod_vars]
+
+            loop_call = ast.Assignment(
+                variable_names=mod_vars,
+                value=ast.FunctionCall(
+                    function_name=ast.Identifier(self.loop_name),
+                    arguments=free_vars,
+                ),
+            )
+
+            if has_break:
+                loop_statements = (
+                    ast.VariableDeclaration(
+                        variables=[ast.TypedName(self.break_name)],
+                        value=ast.Literal(False),
+                    ),
+                    body_call,
+                    ast.If(
+                        condition=break_id,
+                        body=ast.Block((ast.Leave(),)),
+                        else_body=ast.Block((loop_call,)),
+                    ),
+                )
+            else:
+                loop_statements = (body_call, loop_call)
+
+            loop_fun = ast.FunctionDefinition(
+                name=self.loop_name,
+                parameters=typed_free_vars,
+                return_variables=typed_mod_vars,
+                body=ast.Block(
+                    (
+                        ast.If(
+                            condition=node.condition,
+                            body=ast.Block(loop_statements),
+                        ),
+                    )
+                ),
+            )
+            self.aux_functions.extend((body_fun, loop_fun))
+            return ast.Block((loop_call,))
+
+    def visit_break(self, node: ast.Break):
+        return ast.Block(
+            (
+                ast.Assignment(
+                    variable_names=[ast.Identifier(self.break_name)],
+                    value=ast.Literal(True),
+                ),
+                ast.Leave(),
+            )
+        )
+
+    def visit_continue(self, node: ast.Continue):
+        return ast.Leave()
+
+    @contextmanager
+    def _new_for_loop(self):
+        old_names = (self.body_name, self.loop_name, self.break_name)
+        self.body_name = f"__warp_loop_body_{self.n_loops}"
+        self.loop_name = f"__warp_loop_{self.n_loops}"
+        self.break_name = f"__warp_break_{self.n_loops}"
+        self.n_loops += 1
+        try:
+            yield None
+        finally:
+            self.body_name, self.loop_name, self.break_name = old_names

--- a/warp/yul/LeaveNormalizer.py
+++ b/warp/yul/LeaveNormalizer.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import yul.yul_ast as ast
+from yul.AstMapper import AstMapper
+
+
+class LeaveNormalizer(AstMapper):
+    """This class puts a 'leave' statement at the end of each function. If
+    the function consists of a single 'if', it puts 'leave' at the end of
+    each branch.
+
+    After this transformation, the only thing required to correctly
+    place cairo 'return's during the transpilation process is to just
+    replace yul 'leave's.
+
+    """
+
+    def visit_function_definition(self, node: ast.FunctionDefinition):
+        return ast.FunctionDefinition(
+            name=node.name,
+            parameters=node.parameters,
+            return_variables=node.return_variables,
+            body=normalize_block(node.body),
+        )
+
+
+def normalize_block(block: ast.Block) -> ast.Block:
+    return ast.Block(normalize_statements(block.statements))
+
+
+def normalize_statements(statements: tuple[ast.Statement]) -> tuple[ast.Statement]:
+    statements = strip_trailing_leaves(statements)
+    if len(statements) == 1 and isinstance(statements[0], ast.If):
+        return (normalize_if(statements[0]),)
+    else:
+        return (*statements, ast.LEAVE)
+
+
+def normalize_if(if_node: ast.If) -> ast.If:
+    return ast.If(
+        condition=if_node.condition,
+        body=normalize_block(if_node.body),
+        else_body=normalize_block(if_node.else_body)
+        if if_node.else_body
+        else ast.Block((ast.LEAVE,)),
+    )
+
+
+def strip_trailing_leaves(statements: tuple[ast.Statement]) -> tuple[ast.Statement]:
+    leave_no = len(statements)
+    while leave_no > 0 and isinstance(statements[leave_no - 1], ast.Leave):
+        leave_no -= 1
+    return statements[:leave_no]

--- a/warp/yul/ScopeFlattener.py
+++ b/warp/yul/ScopeFlattener.py
@@ -22,9 +22,7 @@ class ScopeFlattener(AstMapper):
         return ast.Block(tuple(all_statements))
 
     def visit_block(self, node: ast.Block, inline: Optional[bool] = None):
-        if inline:
-            return super().visit_block(node)
-        if not node.scope.bound_variables and inline is not False:
+        if inline or not node.scope.bound_variables:
             return super().visit_block(node)
 
         free_vars = sorted(node.scope.free_variables)  # to ensure order
@@ -46,39 +44,7 @@ class ScopeFlattener(AstMapper):
                 arguments=free_vars,
             ),
         )
-        return self.visit(block_call)
-
-    def visit_for_loop(self, node: ast.ForLoop):
-        assert not node.pre.statements, "Loop not simplified"
-        assert not node.post.statements, "Loop not simplified"
-        fun_call = self.visit(node.body, inline=False)
-        typed_free_vars = self.block_functions[-1].parameters
-        typed_mod_vars = self.block_functions[-1].return_variables
-        free_vars = [ast.Identifier(x.name) for x in typed_free_vars]
-        mod_vars = [ast.Identifier(x.name) for x in typed_mod_vars]
-        fun_name = self._request_fresh_name()
-        loop_call = ast.Assignment(
-            variable_names=mod_vars,
-            value=ast.FunctionCall(
-                function_name=ast.Identifier(fun_name),
-                arguments=free_vars,
-            ),
-        )
-        loop_fun = ast.FunctionDefinition(
-            name=fun_name,
-            parameters=typed_free_vars,
-            return_variables=typed_free_vars,
-            body=ast.Block(
-                (
-                    ast.If(
-                        condition=node.condition,
-                        body=ast.Block((fun_call, loop_call)),
-                    ),
-                )
-            ),
-        )
-        self.block_functions.append(loop_fun)
-        return self.visit(loop_call)
+        return ast.Block((self.visit(block_call),))
 
     def visit_function_definition(self, node: ast.FunctionDefinition):
         return ast.FunctionDefinition(

--- a/warp/yul/ScopeFlattener.py
+++ b/warp/yul/ScopeFlattener.py
@@ -6,6 +6,7 @@ from yul.AstMapper import AstMapper
 
 class ScopeFlattener(AstMapper):
     def __init__(self):
+        super().__init__()
         self.n_names: int = 0
         self.block_functions: list[ast.FunctionDefinition] = []
 

--- a/warp/yul/ToCairoVisitor.py
+++ b/warp/yul/ToCairoVisitor.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
 from collections import defaultdict
 from typing import Optional
 
+from starkware.cairo.lang.compiler.parser import parse_file
+import solcx
 import yul.yul_ast as ast
 from transpiler.Imports import merge_imports, UINT256_MODULE, format_imports
 from yul.BuiltinHandler import YUL_BUILTINS_MAP
@@ -26,15 +29,70 @@ MAIN_PREAMBLE = """%lang starknet
 %builtins pedersen range_check
 """
 
+# This means that a warp_block_x
+# just reverts, so we can discard its definition and 
+# replace its callsites with assert 0 = 1
+DISCARD = """    assert 0 = 1
+    return ()"""
+
+IF_REF_COPY = """
+tempvar range_check_ptr = range_check_ptr
+tempvar pedersen_ptr : HashBuiltin* = pedersen_ptr
+tempvar storage_ptr : Storage* = storage_ptr
+tempvar msize = msize
+tempvar memory_dict : DictAccess* = memory_dict
+"""
+
 
 class ToCairoVisitor(AstVisitor):
-    def __init__(self):
+    def __init__(self, sol_source):
         super().__init__()
         self.preamble: bool = False
         self.n_names: int = 0
+        self.sol_source: str = sol_source
+        self.solc_version: float = self.get_source_version(sol_source)
+        self.validate_solc_ver()
+        self.public_functions = self.get_public_functions(self.sol_source)
         self.imports = defaultdict(set)
+        self.discarded_warp_blocks: list[str] = []
+        self.external_cairo_funcs: dict[str, dict[str, str]] = {}
+        self.current_function_ret_vars_len: int = 0
         merge_imports(self.imports, COMMON_IMPORTS)
         self.last_function: Optional[ast.FunctionDefinition] = None
+
+    def get_source_version(self, sol_source: str) -> float:
+        code_split = sol_source.split("\n")
+        for line in code_split:
+            if "pragma" in line:
+                ver: float = float(line[line.index("0.") + 2 :].replace(";", ""))
+                if ver < 8.0:
+                    raise Exception(
+                        "Please use a version of solidity that is at least 0.8.0"
+                    )
+                return ver
+        raise Exception("No Solidity version specified in contract")
+
+    def check_installed_solc(self, source_version: float) -> str:
+        solc_vers = solcx.get_installed_solc_versions()
+        vers_clean = []
+        src_ver = "0." + str(source_version)
+        for ver in solc_vers:
+            vers_clean.append(".".join(str(x) for x in list(ver.precedence_key)[:3]))
+        if src_ver not in vers_clean:
+            solcx.install_solc(src_ver)
+        return src_ver
+
+    def validate_solc_ver(self):
+        src_ver: str = self.check_installed_solc(self.solc_version)
+        solcx.set_solc_version(src_ver)
+
+    def get_public_functions(self, sol_source: str) -> list[str]:
+        public_functions = set()
+        abi = solcx.compile_source(sol_source, output_values=["hashes"])
+        for value in abi.values():
+            for v in value["hashes"]:
+                public_functions.add(f"fun_{v[:v.find('(')]}")
+        return list(public_functions)
 
     def translate(self, node: ast.Node) -> str:
         main_part = self.print(node)
@@ -53,6 +111,16 @@ class ToCairoVisitor(AstVisitor):
     def common_visit(self, node: ast.Node, *args, **kwargs):
         raise AssertionError(
             f"Each node type should have a custom visit, but {type(node)} doesn't"
+        )
+
+    def should_ignore(self, function_name: str) -> bool:
+        return (
+            "abi_" in function_name
+            or "checked_" in function_name
+            or "panic_error" in function_name
+            or "increment_uint" in function_name
+            or "decrement_uint" in function_name
+            or "getter_" in function_name
         )
 
     def visit_typed_name(self, node: ast.TypedName) -> str:
@@ -75,6 +143,20 @@ class ToCairoVisitor(AstVisitor):
             variables.append(var_repr)
         return ", ".join("local " + x for x in variables)
 
+    def remove_generated_call(self, args_repr: str, function_name: str) -> str:
+        if "checked_add" in function_name:
+            return f"u256_add({args_repr})"
+        elif "checked_sub" in function_name:
+            return f"uint256_sub({args_repr})"
+        elif "revert" in function_name:
+            return f"assert 0 = 1"
+        elif "increment_uint256" in function_name:
+            return f"u256_add({args_repr}, 1)"
+        elif "decrement_uint256" in function_name:
+            return f"uint256_sub({args_repr}, 1)"
+        else:
+            return f"{function_name}({args_repr})"
+
     def visit_assignment(self, node: ast.Assignment) -> str:
         self.preamble = False
         value_repr: str = self.print(node.value)
@@ -93,10 +175,16 @@ class ToCairoVisitor(AstVisitor):
 let ({ids_repr}) = {builtin_to_cairo.function_call}
 {builtin_to_cairo.ref_copy}"""
             else:
+                call = self.remove_generated_call(function_args, function_name)
                 if not node.variable_names:
                     return value_repr
+                elif function_name in self.external_cairo_funcs:
+                    ids_repr_felt = self.to_high_low_felt(ids_repr)
+                    return f"let ({ids_repr_felt}) = {call}\n" + self.init_u256(
+                        ids_repr
+                    )
                 else:
-                    return f"let ({ids_repr}) = {value_repr}"
+                    return f"let ({ids_repr}) = {call}"
         else:
             ids_repr: str = self.generate_ids_typed(node.variable_names)
             self.preamble = True
@@ -105,15 +193,19 @@ let ({ids_repr}) = {builtin_to_cairo.function_call}
     def visit_function_call(self, node: ast.FunctionCall) -> str:
         fun_repr = self.print(node.function_name)
         args_repr = ", ".join(self.print(x) for x in node.arguments)
+        if fun_repr in self.external_cairo_funcs:
+            args_repr = self.to_high_low_felt(args_repr)
         if fun_repr == "revert":
             return "assert 0 = 1"
-        if fun_repr.startswith("checked_add"):
+        elif fun_repr.startswith("checked_add"):
             merge_imports(self.imports, {"evm.uint256": {"u256_add"}})
             return f"u256_add({args_repr})"
-        if fun_repr.startswith("checked_sub"):
+        elif fun_repr.startswith("checked_sub"):
             merge_imports(self.imports, {UINT256_MODULE: {"uint256_sub"}})
             return f"uint256_sub({args_repr})"
-        if fun_repr in YUL_BUILTINS_MAP.keys():
+        elif fun_repr in self.discarded_warp_blocks or "panic_error" in fun_repr:
+            return "assert 0 = 1"
+        elif fun_repr in YUL_BUILTINS_MAP.keys():
             builtin_to_cairo = YUL_BUILTINS_MAP[fun_repr](args_repr)
             merge_imports(self.imports, builtin_to_cairo.required_imports())
             if self.preamble:
@@ -159,6 +251,17 @@ let ({vars_repr}) = {builtin_to_cairo.function_call}
                 if not node.variables:
                     return value_repr
                 else:
+                    if function_name in self.external_cairo_funcs:
+                        vars_repr_felt = self.to_high_low_felt(vars_repr)
+                        return (
+                            f"let ({vars_repr_felt}) = {function_name}({self.to_high_low_felt(function_args)})\n"
+                            + self.init_u256(vars_repr)
+                        )
+                    elif "mapping_index" in function_name:
+                        return f"""let ({vars_repr}) = {function_name}({function_args})
+local range_check_ptr = range_check_ptr
+local memory_dict : DictAccess* = memory_dict
+local msize = msize"""
                     return f"let ({vars_repr}) = {value_repr}"
         else:
             vars_repr = self.generate_ids_typed(node.variables)
@@ -168,22 +271,120 @@ let ({vars_repr}) = {builtin_to_cairo.function_call}
     def visit_block(self, node: ast.Block) -> str:
         return "\n".join(self.print(x) for x in node.statements)
 
+    def to_high_low_felt(self, vars: str) -> str:
+        if vars != "":
+            vars = vars.replace(" : Uint256", "")
+            vars = vars.split(",")
+            params_repr = ", ".join(f"{p.strip()}_low, {p.strip()}_high" for p in vars)
+            return params_repr
+        else:
+            return vars
+
+    def init_u256(self, params_repr: str) -> str:
+        params = params_repr.replace(" : Uint256", "")
+        params = params.split(",")
+        declr_str = ""
+        for p in params:
+            if "local" in p:
+                p_no_local = p.replace("local", "").strip()
+                declr_str += (
+                    f"{p}: Uint256 = Uint256({p_no_local}_low, {p_no_local}_high)\n"
+                )
+            else:
+                declr_str += f"local {p}: Uint256 = Uint256({p}_low, {p}_high)\n"
+        return declr_str
+
+    def gen_external_return_names(self, names: str) -> str:
+        if names != "":
+            vars = names.replace(" : Uint256", "")
+            vars = vars.split(",")
+            params_repr = ", ".join(f"{p.strip()}.low, {p.strip()}.high" for p in vars)
+            return params_repr
+        else:
+            return names
+
+    def gen_external_function_def(
+        self,
+        fun_name: str,
+        params_repr: str,
+        return_repr: str,
+        return_names_repr: str,
+        body: str,
+    ) -> str:
+        body = self.init_u256(params_repr) + "\n" + body
+        params = self.to_high_low_felt(params_repr)
+        return_signature = self.to_high_low_felt(return_repr)
+        return_names = self.gen_external_return_names(return_names_repr)
+        self.external_cairo_funcs[fun_name] = {"return_names": return_names}
+        if self.current_function_ret_vars_len == 0:
+            assignment = f"""{fun_name}{{range_check_ptr=range_check_ptr,
+            pedersen_ptr=pedersen_ptr,
+            storage_ptr=storage_ptr,
+            memory_dict=memory_dict,
+            msize=msize}}({params})"""
+        else:
+            assignment = f"""let ({return_signature}) = {fun_name}{{range_check_ptr=range_check_ptr,
+            pedersen_ptr=pedersen_ptr,
+            storage_ptr=storage_ptr,
+            memory_dict=memory_dict,
+            msize=msize}}({params})"""
+        return f"""
+func {fun_name}{{range_check_ptr, pedersen_ptr: HashBuiltin*, storage_ptr: Storage*, memory_dict : DictAccess*, msize}}({params}) -> ({return_signature}):
+alloc_locals
+{body}
+return ({return_names})
+end
+
+@external
+func {fun_name}_external{{range_check_ptr, pedersen_ptr: HashBuiltin*, storage_ptr: Storage*}}({params}) -> ({return_signature}):
+alloc_locals
+let (local memory_dict : DictAccess*) = default_dict_new(0)
+tempvar msize = 0
+{assignment}
+return ({return_signature})
+end
+"""
+
     def visit_function_definition(self, node: ast.FunctionDefinition):
         self.last_function = node
         params_repr = ", ".join(self.print(x) for x in node.parameters)
         returns_repr = ", ".join(self.print(x) for x in node.return_variables)
+        return_names = ", ".join(x.name for x in node.return_variables)
+        if node.name in self.public_functions:
+            # must split into high/low bits
+            self.current_function_ret_vars_len = len(node.return_variables) * 2
+            self.curr_fun_ret_felt = True
+        else:
+            self.current_function_ret_vars_len = len(node.return_variables)
+            self.curr_fun_ret_felt = False
         body_repr = self.print(node.body)
-        if "abi_" in node.name or "checked_" in node.name:
+        if self.should_ignore(node.name):
             return ""
-        return (
-            f"func {node.name}"
-            f"{{range_check_ptr, pedersen_ptr: HashBuiltin*"
-            f", storage_ptr: Storage*, memory_dict: DictAccess*, msize}}"
-            f"({params_repr}) -> ({returns_repr}):\n"
-            f"alloc_locals\n"
-            f"{body_repr}\n"
-            f"end\n"
-        )
+        elif node.name in self.public_functions:
+            return self.gen_external_function_def(
+                node.name, params_repr, returns_repr, return_names, body_repr
+            )
+        else:
+            func = f"""
+func {node.name}{{range_check_ptr, pedersen_ptr: HashBuiltin*, storage_ptr: Storage*, memory_dict: DictAccess*, msize}}({params_repr}) -> ({returns_repr}):
+alloc_locals
+{body_repr}
+end
+            """
+            func = parse_file(func).format()
+            if ("__warp_block" in node.name) and (DISCARD in func):
+                self.discarded_warp_blocks.append(node.name)
+                return ""
+            else:
+                return (
+                    f"func {node.name}"
+                    f"{{range_check_ptr, pedersen_ptr: HashBuiltin*"
+                    f", storage_ptr: Storage*, memory_dict: DictAccess*, msize}}"
+                    f"({params_repr}) -> ({returns_repr}):\n"
+                    f"alloc_locals\n"
+                    f"{body_repr}\n"
+                    f"end\n"
+                )
 
     def visit_if(self, node: ast.If) -> str:
         cond_repr = self.print(node.condition)

--- a/warp/yul/ToCairoVisitor.py
+++ b/warp/yul/ToCairoVisitor.py
@@ -34,7 +34,6 @@ class ToCairoVisitor(AstVisitor):
         self.n_names: int = 0
         self.imports = defaultdict(set)
         merge_imports(self.imports, COMMON_IMPORTS)
-        self.last_function: Optional[ast.FunctionDefinition] = None
 
     def translate(self, node: ast.Node) -> str:
         main_part = self.print(node)
@@ -166,13 +165,7 @@ let ({vars_repr}) = {builtin_to_cairo.function_call}
             return f"{vars_repr} = {value_repr}"
 
     def visit_block(self, node: ast.Block) -> str:
-        stmts_repr = ""
-        for stmt in node.statements:
-            try:
-                stmts_repr += self.print(stmt) + "\n"
-            except:
-                continue
-        return stmts_repr
+        return "\n".join(self.print(x) for x in node.statements)
 
     def visit_function_definition(self, node: ast.FunctionDefinition):
         params_repr = ", ".join(self.print(x) for x in node.parameters)
@@ -197,28 +190,34 @@ let ({vars_repr}) = {builtin_to_cairo.function_call}
         body_repr = self.print(node.body)
         else_repr = ""
         if node.else_body:
-            else_repr = f"\t{self.print(node.else_body)}\n"
+            else_repr = f"else:\n\t{self.print(node.else_body)}\n"
         return (
             f"if {cond_repr}.low + {cond_repr}.high != 0:\n"
-            f"{body_repr}\n"
-            f"{else_repr}\n"
+            f"\t{body_repr}\n"
+            f"{else_repr}"
             f"end"
         )
 
     def visit_case(self, node: ast.Case):
-        return ""
+        return AssertionError("There should be no cases, run SwitchToIfVisitor first")
 
     def visit_switch(self, node: ast.Switch):
-        return ""
+        return AssertionError(
+            "There should be no switches, run SwitchToIfVisitor first"
+        )
 
     def visit_for_loop(self, node: ast.ForLoop):
-        return ""
+        raise AssertionError(
+            "There should be no for loops, run ForLoopEliminator first"
+        )
 
     def visit_break(self, node: ast.Break):
-        return ""
+        raise AssertionError("There should be no breaks, run ForLoopEliminator first")
 
     def visit_continue(self, node: ast.Continue):
-        return ""
+        raise AssertionError(
+            "There should be no continues, run ForLoopEliminator first"
+        )
 
     def visit_leave(self, node: ast.Leave):
-        return ""
+        return ""  # TODO

--- a/warp/yul/main.py
+++ b/warp/yul/main.py
@@ -5,8 +5,7 @@ import sys
 
 from starkware.cairo.lang.compiler.parser import parse_file
 
-from transpiler.Imports import format_imports, merge_imports
-from yul.utils import STORAGE_DECLS
+from yul.ExpressionSplitter import ExpressionSplitter
 from yul.ForLoopSimplifier import ForLoopSimplifier
 from yul.MangleNamesVisitor import MangleNamesVisitor
 from yul.ScopeFlattener import ScopeFlattener
@@ -16,37 +15,35 @@ from yul.parse import parse_node
 
 AST_GENERATOR = "gen-yul-json-ast"
 
-MAIN_PREAMBLE = """%lang starknet
-%builtins pedersen range_check
-"""
-
 
 def main(argv):
     if len(argv) != 3:
-        sys.exit(f"Usage: python {argv[0]} SOLIDITY-FILE MAIN-CONTRACT"
-            f"where MAIN-CONTRACT is the name of the 'primary' contract (non-interface, non-library & non-abstract contract)")
+        sys.exit(
+            f"Usage: python {argv[0]} SOLIDITY-FILE MAIN-CONTRACT\n"
+            f"where MAIN-CONTRACT is the name of the 'primary' contract (non-interface, non-library & non-abstract contract)"
+        )
 
     if not shutil.which(AST_GENERATOR):
         sys.exit(f"Please install {AST_GENERATOR} first")
 
     solidity_file = argv[1]
-    result = subprocess.run(
-        [AST_GENERATOR, solidity_file, argv[2]], check=True, capture_output=True
-    )
+    try:
+        result = subprocess.run(
+            [AST_GENERATOR, solidity_file, argv[2]], check=True, capture_output=True
+        )
+    except subprocess.CalledProcessError as e:
+        print(e.stderr.decode("utf-8"), file=sys.stderr)
+        raise e
+
     yul_ast = parse_node(json.loads(result.stdout))
     yul_ast = ForLoopSimplifier().map(yul_ast)
     yul_ast = MangleNamesVisitor().map(yul_ast)
     yul_ast = SwitchToIfVisitor().map(yul_ast)
+    yul_ast = ExpressionSplitter().map(yul_ast)
     yul_ast = ScopeFlattener().map(yul_ast)
     cairo_visitor = ToCairoVisitor()
-    cairo_visitor.translate(yul_ast)
-    cairo_visitor.cairo_code = (
-        MAIN_PREAMBLE
-        + format_imports(cairo_visitor.imports)
-        + STORAGE_DECLS
-        + cairo_visitor.cairo_code
-    )
-    print(parse_file(cairo_visitor.cairo_code).format())
+    cairo_code = cairo_visitor.translate(yul_ast)
+    print(parse_file(cairo_code).format())
 
 
 if __name__ == "__main__":

--- a/warp/yul/main.py
+++ b/warp/yul/main.py
@@ -36,6 +36,8 @@ def main(argv):
     except subprocess.CalledProcessError as e:
         print(e.stderr.decode("utf-8"), file=sys.stderr)
         raise e
+    with open(solidity_file) as f:
+        sol_source = f.read()
 
     yul_ast = parse_node(json.loads(result.stdout))
     yul_ast = ForLoopSimplifier().map(yul_ast)
@@ -45,7 +47,7 @@ def main(argv):
     yul_ast = ExpressionSplitter().map(yul_ast)
     yul_ast = ScopeFlattener().map(yul_ast)
     yul_ast = LeaveNormalizer().map(yul_ast)
-    cairo_visitor = ToCairoVisitor()
+    cairo_visitor = ToCairoVisitor(sol_source)
     cairo_code = cairo_visitor.translate(yul_ast)
     print(parse_file(cairo_code).format())
 

--- a/warp/yul/main.py
+++ b/warp/yul/main.py
@@ -10,6 +10,7 @@ from yul.ForLoopSimplifier import ForLoopSimplifier
 from yul.MangleNamesVisitor import MangleNamesVisitor
 from yul.ScopeFlattener import ScopeFlattener
 from yul.SwitchToIfVisitor import SwitchToIfVisitor
+from yul.ForLoopEliminator import ForLoopEliminator
 from yul.ToCairoVisitor import ToCairoVisitor
 from yul.parse import parse_node
 
@@ -37,6 +38,7 @@ def main(argv):
 
     yul_ast = parse_node(json.loads(result.stdout))
     yul_ast = ForLoopSimplifier().map(yul_ast)
+    yul_ast = ForLoopEliminator().map(yul_ast)
     yul_ast = MangleNamesVisitor().map(yul_ast)
     yul_ast = SwitchToIfVisitor().map(yul_ast)
     yul_ast = ExpressionSplitter().map(yul_ast)

--- a/warp/yul/main.py
+++ b/warp/yul/main.py
@@ -6,11 +6,12 @@ import sys
 from starkware.cairo.lang.compiler.parser import parse_file
 
 from yul.ExpressionSplitter import ExpressionSplitter
+from yul.ForLoopEliminator import ForLoopEliminator
 from yul.ForLoopSimplifier import ForLoopSimplifier
+from yul.LeaveNormalizer import LeaveNormalizer
 from yul.MangleNamesVisitor import MangleNamesVisitor
 from yul.ScopeFlattener import ScopeFlattener
 from yul.SwitchToIfVisitor import SwitchToIfVisitor
-from yul.ForLoopEliminator import ForLoopEliminator
 from yul.ToCairoVisitor import ToCairoVisitor
 from yul.parse import parse_node
 
@@ -43,6 +44,7 @@ def main(argv):
     yul_ast = SwitchToIfVisitor().map(yul_ast)
     yul_ast = ExpressionSplitter().map(yul_ast)
     yul_ast = ScopeFlattener().map(yul_ast)
+    yul_ast = LeaveNormalizer().map(yul_ast)
     cairo_visitor = ToCairoVisitor()
     cairo_code = cairo_visitor.translate(yul_ast)
     print(parse_file(cairo_code).format())

--- a/warp/yul/parse.py
+++ b/warp/yul/parse.py
@@ -171,4 +171,4 @@ def parse_continue(yul_ast) -> ast.Continue:
 
 @register_parser
 def parse_leave(yul_ast) -> ast.Leave:
-    return ast.Leave()
+    return ast.LEAVE

--- a/warp/yul/utils.py
+++ b/warp/yul/utils.py
@@ -16,21 +16,24 @@ STATEMENT_STRINGS = {
     "Block",
 }
 
+
 def get_low_bits(string: str) -> str:
     try:
         value = int(string)
-        high, low = divmod(value, 2**128)
+        high, low = divmod(value, 2 ** 128)
         return f"Uint256({low}, 0)"
     except ValueError:
         return f"{string}.low"
 
+
 def get_low_high(string: str) -> str:
     try:
         value = int(string)
-        high, low = divmod(value, 2**128)
+        high, low = divmod(value, 2 ** 128)
         return f"{low}", f"{high}"
     except ValueError:
         return f"{string}.low", f"{string}.high"
+
 
 def is_statement(node):
     return type(node).__name__ in STATEMENT_STRINGS
@@ -60,6 +63,7 @@ def camelize(snake_case: str) -> str:
             " It probably contains several consecutive underscores."
         )
     return "".join(x.capitalize() for x in parts)
+
 
 STORAGE_DECLS = """
 

--- a/warp/yul/yul_ast.py
+++ b/warp/yul/yul_ast.py
@@ -125,6 +125,11 @@ class Leave(Node):
     pass
 
 
+# No two nodes of this class should be different from each
+# other. Thus, it's cheaper to create one object and use it in all
+# contexts, rather than create new `Leave()` each time.
+LEAVE = Leave()
+
 Expression = Union[Literal, Identifier, FunctionCall]
 Statement = Union[
     ExpressionStatement,

--- a/warp/yul/yul_ast.py
+++ b/warp/yul/yul_ast.py
@@ -177,9 +177,10 @@ def get_children(node: Node) -> Iterable[Node]:
 class AstVisitor:
     def visit(self, node: Node, *args, **kwargs):
         method_name = "visit_" + snakify(type(node).__name__)
-        try:
-            return getattr(self, method_name)(node, *args, **kwargs)
-        except AttributeError:
+        method = getattr(self, method_name, None)
+        if method:
+            return method(node, *args, **kwargs)
+        else:
             return self.common_visit(node, *args, **kwargs)
 
     def common_visit(self, node, *args, **kwargs):

--- a/warp/yul/yul_ast.py
+++ b/warp/yul/yul_ast.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from abc import ABC
 from dataclasses import dataclass
 from functools import lru_cache
@@ -139,6 +140,25 @@ Statement = Union[
     Block,
 ]
 
+NODE_TYPES = frozenset(
+    (
+        Literal,
+        Identifier,
+        FunctionCall,
+        ExpressionStatement,
+        Assignment,
+        VariableDeclaration,
+        FunctionDefinition,
+        If,
+        Switch,
+        ForLoop,
+        Break,
+        Continue,
+        Leave,
+        Block,
+    )
+)
+
 
 @dataclass
 class Scope:
@@ -175,13 +195,31 @@ def get_children(node: Node) -> Iterable[Node]:
 
 
 class AstVisitor:
+    def __init__(self):
+        self.path = []
+        # ↑ path of nodes from the AST root down to the current node,
+        # inclusively
+
+        def path_decorator(method):
+            def new_method(node, *args, **kwargs):
+                self.path.append(node)
+                res = method(node, *args, **kwargs)
+                self.path.pop()
+                return res
+
+            return new_method
+
+        for node_type in NODE_TYPES:
+            visitor_name = "visit_" + snakify(node_type.__name__)
+            method = getattr(self, visitor_name, None)
+            if method is None:
+                method = self.common_visit
+            setattr(self, visitor_name, path_decorator(method))
+
     def visit(self, node: Node, *args, **kwargs):
         method_name = "visit_" + snakify(type(node).__name__)
         method = getattr(self, method_name, None)
-        if method:
-            return method(node, *args, **kwargs)
-        else:
-            return self.common_visit(node, *args, **kwargs)
+        return method(node, *args, **kwargs)
 
     def common_visit(self, node, *args, **kwargs):
         for child in get_children(node):
@@ -193,6 +231,7 @@ class AstVisitor:
 
 class ScopeResolver(AstVisitor):
     def __init__(self):
+        super().__init__()
         self.bound_variables: dict[str, TypedName] = {}
         self.free_variables: list[Identifier] = []
         self.modified_variables: list[Identifier] = []


### PR DESCRIPTION
After this transformation there are no for-loops, breaks or continues in a Yul AST. In all places, that would require a `return` in Cairo, Yul `leave`'s are placed