### PR TITLE
Replace yul caller() with get_caller_data_uint265()

### DIFF
--- a/warp/cairo-src/evm/calls.cairo
+++ b/warp/cairo-src/evm/calls.cairo
@@ -1,0 +1,12 @@
+from starkware.cairo.common.uint256 import Uint256
+from starkware.cairo.common.math import split_felt
+from starkware.starknet.common.syscalls import get_caller_address
+
+func get_caller_data_uint256{syscall_ptr : felt*, range_check_ptr}() -> (caller_data: Uint256):
+  alloc_locals
+  let (local caller_address) = get_caller_address()
+  let (local high, local low) = split_felt(caller_address)
+  let caller_data = Uint256(low=low, high=high)
+
+  return (caller_data=caller_data)
+end

--- a/warp/yul/BuiltinHandler.py
+++ b/warp/yul/BuiltinHandler.py
@@ -431,6 +431,16 @@ class SHA3(BuiltinHandler):
     def required_imports(self):
         return {"evm.sha3": {"sha"}}
 
+# ============ Call Data ============
+class Caller(BuiltinHandler):
+    def __init__(self, function_args: str):
+        super().__init__(
+            function_name="get_caller_address",
+            function_args=function_args,
+        )
+
+    def required_imports(self):
+        return {"starkware.starknet.common.syscall": {"get_caller_address"}}
 
 YUL_BUILTINS_MAP = {
     "iszero": IsZero,
@@ -465,4 +475,5 @@ YUL_BUILTINS_MAP = {
     "sar": Sar,
     "addmod": AddMod,
     "signextend": SignExtend,
+    "caller": Caller,
 }

--- a/warp/yul/BuiltinHandler.py
+++ b/warp/yul/BuiltinHandler.py
@@ -435,13 +435,10 @@ class SHA3(BuiltinHandler):
 class Caller(BuiltinHandler):
     def __init__(self, function_args: str):
         super().__init__(
-            module="",
+            module="evm.calls",
             function_name="get_caller_data_uint256",
             function_args=function_args,
         )
-
-    def required_imports(self):
-        return {"evm.calls": {"get_caller_address_uint256"}}
 
 YUL_BUILTINS_MAP = {
     "iszero": IsZero,

--- a/warp/yul/BuiltinHandler.py
+++ b/warp/yul/BuiltinHandler.py
@@ -435,12 +435,13 @@ class SHA3(BuiltinHandler):
 class Caller(BuiltinHandler):
     def __init__(self, function_args: str):
         super().__init__(
-            function_name="get_caller_address",
+            module="",
+            function_name="get_caller_data_uint256",
             function_args=function_args,
         )
 
     def required_imports(self):
-        return {"starkware.starknet.common.syscall": {"get_caller_address"}}
+        return {"evm.calls": {"get_caller_address_uint256"}}
 
 YUL_BUILTINS_MAP = {
     "iszero": IsZero,


### PR DESCRIPTION
Before this change generated cairo code for solidity contracts which used `msg.sender`, looked like this:
```
let (local a: Uint256) = caller()
```
After the changes:
```
from evm.calls import get_caller_address_uint256
# ...
let (local a: Uint256) = get_caller_address_uint256()
```