### PR TITLE
copy only implicits necessary to copy

### DIFF
--- a/examples/ERC20/ERC20.cairo
+++ b/examples/ERC20/ERC20.cairo
@@ -45,9 +45,7 @@ func get_storage_high{storage_ptr : Storage*, range_check_ptr, pedersen_ptr : Ha
     return (res=storage_val_high)
 end
 
-func __warp_block_0_if{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(_4 : Uint256) -> ():
+func __warp_block_0_if(_4 : Uint256) -> ():
     alloc_locals
     if _4.low + _4.high != 0:
         assert 0 = 1
@@ -57,9 +55,7 @@ func __warp_block_0_if{
     end
 end
 
-func __warp_block_1_if{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(_4_5 : Uint256) -> ():
+func __warp_block_1_if(_4_5 : Uint256) -> ():
     alloc_locals
     if _4_5.low + _4_5.high != 0:
         assert 0 = 1
@@ -69,9 +65,7 @@ func __warp_block_1_if{
     end
 end
 
-func __warp_block_2_if{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(_4_11 : Uint256) -> ():
+func __warp_block_2_if(_4_11 : Uint256) -> ():
     alloc_locals
     if _4_11.low + _4_11.high != 0:
         assert 0 = 1
@@ -81,9 +75,7 @@ func __warp_block_2_if{
     end
 end
 
-func __warp_block_3_if{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(_4_19 : Uint256) -> ():
+func __warp_block_3_if(_4_19 : Uint256) -> ():
     alloc_locals
     if _4_19.low + _4_19.high != 0:
         assert 0 = 1
@@ -93,9 +85,7 @@ func __warp_block_3_if{
     end
 end
 
-func __warp_block_4_if{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(_4_29 : Uint256) -> ():
+func __warp_block_4_if(_4_29 : Uint256) -> ():
     alloc_locals
     if _4_29.low + _4_29.high != 0:
         assert 0 = 1
@@ -105,9 +95,7 @@ func __warp_block_4_if{
     end
 end
 
-func __warp_block_5_if{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(_2_63 : Uint256) -> ():
+func __warp_block_5_if(_2_63 : Uint256) -> ():
     alloc_locals
     if _2_63.low + _2_63.high != 0:
         assert 0 = 1
@@ -117,9 +105,7 @@ func __warp_block_5_if{
     end
 end
 
-func __warp_block_6_if{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(_1_66 : Uint256) -> ():
+func __warp_block_6_if(_1_66 : Uint256) -> ():
     alloc_locals
     if _1_66.low + _1_66.high != 0:
         assert 0 = 1
@@ -129,164 +115,137 @@ func __warp_block_6_if{
     end
 end
 
-func checked_sub_uint256{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(x_64 : Uint256, y_65 : Uint256) -> (diff : Uint256):
+func checked_sub_uint256{range_check_ptr}(x_64 : Uint256, y_65 : Uint256) -> (diff : Uint256):
     alloc_locals
+    local range_check_ptr = range_check_ptr
     let (local _1_66 : Uint256) = is_lt(x_64, y_65)
     local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     __warp_block_6_if(_1_66)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     let (local diff : Uint256) = uint256_sub(x_64, y_65)
+    local range_check_ptr = range_check_ptr
     return (diff)
 end
 
-func cleanup_from_storage_uint256{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(value_67 : Uint256) -> (cleaned : Uint256):
+func cleanup_from_storage_uint256(value_67 : Uint256) -> (cleaned : Uint256):
     alloc_locals
     local cleaned : Uint256 = value_67
     return (cleaned)
 end
 
-func extract_from_storage_value_dynamict_uint8{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(slot_value : Uint256) -> (value_68 : Uint256):
+func extract_from_storage_value_dynamict_uint8{range_check_ptr}(slot_value : Uint256) -> (
+        value_68 : Uint256):
     alloc_locals
+    local range_check_ptr = range_check_ptr
     local _1_69 : Uint256 = Uint256(low=255, high=0)
     let (local value_68 : Uint256) = uint256_and(slot_value, _1_69)
+    local range_check_ptr = range_check_ptr
     return (value_68)
 end
 
 func mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256_570{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(key_106 : Uint256) -> (dataSlot_107 : Uint256):
+        memory_dict : DictAccess*, msize, range_check_ptr}(key_106 : Uint256) -> (
+        dataSlot_107 : Uint256):
     alloc_locals
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local range_check_ptr = range_check_ptr
     local _1_108 : Uint256 = Uint256(low=0, high=0)
     mstore_(offset=_1_108.low, value=key_106)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
+    local range_check_ptr = range_check_ptr
     local msize = msize
     local _2_109 : Uint256 = Uint256(low=3, high=0)
     local _3_110 : Uint256 = Uint256(low=32, high=0)
     mstore_(offset=_3_110.low, value=_2_109)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
+    local range_check_ptr = range_check_ptr
     local msize = msize
     local _4_111 : Uint256 = Uint256(low=64, high=0)
     local _5_112 : Uint256 = _1_108
     let (local dataSlot_107 : Uint256) = sha(_1_108.low, _4_111.low)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
+    local range_check_ptr = range_check_ptr
     local msize = msize
     return (dataSlot_107)
 end
 
 func mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(slot : Uint256, key_127 : Uint256) -> (
+        memory_dict : DictAccess*, msize, range_check_ptr}(slot : Uint256, key_127 : Uint256) -> (
         dataSlot_128 : Uint256):
     alloc_locals
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local range_check_ptr = range_check_ptr
     local _1_129 : Uint256 = Uint256(low=0, high=0)
     mstore_(offset=_1_129.low, value=key_127)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
+    local range_check_ptr = range_check_ptr
     local msize = msize
     local _2_130 : Uint256 = Uint256(low=32, high=0)
     mstore_(offset=_2_130.low, value=slot)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
+    local range_check_ptr = range_check_ptr
     local msize = msize
     local _3_131 : Uint256 = Uint256(low=64, high=0)
     local _4_132 : Uint256 = _1_129
     let (local dataSlot_128 : Uint256) = sha(_1_129.low, _3_131.low)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
+    local range_check_ptr = range_check_ptr
     local msize = msize
     return (dataSlot_128)
 end
 
-func update_byte_slice_shift{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(value_147 : Uint256, toInsert : Uint256) -> (
-        result : Uint256):
+func update_byte_slice_shift(value_147 : Uint256, toInsert : Uint256) -> (result : Uint256):
     alloc_locals
     local result : Uint256 = toInsert
     return (result)
 end
 
 func update_storage_value_offsett_uint256_to_uint256{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(slot_148 : Uint256, value_149 : Uint256) -> ():
+        pedersen_ptr : HashBuiltin*, range_check_ptr, storage_ptr : Storage*}(
+        slot_148 : Uint256, value_149 : Uint256) -> ():
     alloc_locals
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    local storage_ptr : Storage* = storage_ptr
     let (local _1_150 : Uint256) = s_load(slot_148)
+    local storage_ptr : Storage* = storage_ptr
     local range_check_ptr = range_check_ptr
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     let (local _2_151 : Uint256) = update_byte_slice_shift(_1_150, value_149)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     s_store(key=slot_148, value=_2_151)
+    local storage_ptr : Storage* = storage_ptr
     local range_check_ptr = range_check_ptr
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     return ()
 end
 
 func fun_approve{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(
-        var_guy : Uint256, var_wad : Uint256, var_sender : Uint256) -> (var : Uint256):
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        storage_ptr : Storage*}(var_guy : Uint256, var_wad : Uint256, var_sender : Uint256) -> (
+        var : Uint256):
     alloc_locals
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    local storage_ptr : Storage* = storage_ptr
     let (
         local _1_70 : Uint256) = mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256_570(
         var_sender)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
+    local range_check_ptr = range_check_ptr
     let (
         local _2_71 : Uint256) = mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256(
         _1_70, var_guy)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
+    local range_check_ptr = range_check_ptr
     update_storage_value_offsett_uint256_to_uint256(_2_71, var_wad)
-    local range_check_ptr = range_check_ptr
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
     local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     local var : Uint256 = Uint256(low=1, high=0)
     return (var)
 end
@@ -305,67 +264,59 @@ func fun_approve_external{range_check_ptr, pedersen_ptr : HashBuiltin*, storage_
 end
 
 func mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256_571{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(key_113 : Uint256) -> (dataSlot_114 : Uint256):
+        memory_dict : DictAccess*, msize, range_check_ptr}(key_113 : Uint256) -> (
+        dataSlot_114 : Uint256):
     alloc_locals
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local range_check_ptr = range_check_ptr
     local _1_115 : Uint256 = Uint256(low=0, high=0)
     mstore_(offset=_1_115.low, value=key_113)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
+    local range_check_ptr = range_check_ptr
     local msize = msize
     local _2_116 : Uint256 = Uint256(low=2, high=0)
     local _3_117 : Uint256 = Uint256(low=32, high=0)
     mstore_(offset=_3_117.low, value=_2_116)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
+    local range_check_ptr = range_check_ptr
     local msize = msize
     local _4_118 : Uint256 = Uint256(low=64, high=0)
     local _5_119 : Uint256 = _1_115
     let (local dataSlot_114 : Uint256) = sha(_1_115.low, _4_118.low)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
+    local range_check_ptr = range_check_ptr
     local msize = msize
     return (dataSlot_114)
 end
 
 func fun_deposit{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(var_sender_72 : Uint256, var_value : Uint256) -> (
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        storage_ptr : Storage*}(var_sender_72 : Uint256, var_value : Uint256) -> (
         var_73 : Uint256, var_ : Uint256):
     alloc_locals
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    local storage_ptr : Storage* = storage_ptr
     let (
         local _1_74 : Uint256) = mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256_571(
         var_sender_72)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
+    local range_check_ptr = range_check_ptr
     let (local _2_75 : Uint256) = s_load(_1_74)
+    local storage_ptr : Storage* = storage_ptr
     local range_check_ptr = range_check_ptr
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     let (local _3_76 : Uint256) = cleanup_from_storage_uint256(_2_75)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     let (local _4_77 : Uint256) = u256_add(_3_76, var_value)
-    update_storage_value_offsett_uint256_to_uint256(_1_74, _4_77)
     local range_check_ptr = range_check_ptr
+    update_storage_value_offsett_uint256_to_uint256(_1_74, _4_77)
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
     local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     local var_73 : Uint256 = Uint256(low=21, high=0)
     local var_ : Uint256 = Uint256(low=12, high=0)
     return (var_73, var_)
@@ -383,27 +334,21 @@ func fun_deposit_external{range_check_ptr, pedersen_ptr : HashBuiltin*, storage_
 end
 
 func read_from_storage_split_dynamic_uint256{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(slot_139 : Uint256) -> (value_140 : Uint256):
+        pedersen_ptr : HashBuiltin*, range_check_ptr, storage_ptr : Storage*}(
+        slot_139 : Uint256) -> (value_140 : Uint256):
     alloc_locals
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    local storage_ptr : Storage* = storage_ptr
     let (local _1_141 : Uint256) = s_load(slot_139)
+    local storage_ptr : Storage* = storage_ptr
     local range_check_ptr = range_check_ptr
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     let (local value_140 : Uint256) = cleanup_from_storage_uint256(_1_141)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     return (value_140)
 end
 
-func __warp_block_8_if{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(_1_142 : Uint256) -> ():
+func __warp_block_8_if(_1_142 : Uint256) -> ():
     alloc_locals
     if _1_142.low + _1_142.high != 0:
         assert 0 = 1
@@ -413,148 +358,107 @@ func __warp_block_8_if{
     end
 end
 
-func require_helper{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(condition : Uint256) -> ():
+func require_helper{range_check_ptr}(condition : Uint256) -> ():
     alloc_locals
-    let (local _1_142 : Uint256) = is_zero(condition)
-    __warp_block_8_if(_1_142)
     local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
+    let (local _1_142 : Uint256) = is_zero(condition)
+    local range_check_ptr = range_check_ptr
+    __warp_block_8_if(_1_142)
     return ()
 end
 
 func __warp_block_9{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        storage_ptr : Storage*}(
         var_sender_79 : Uint256, var_src : Uint256, var_wad_78 : Uint256) -> ():
     alloc_locals
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    local storage_ptr : Storage* = storage_ptr
     let (
         local _3_83 : Uint256) = mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256_570(
         var_src)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
+    local range_check_ptr = range_check_ptr
     let (
         local _4_84 : Uint256) = mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256(
         _3_83, var_sender_79)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
+    local range_check_ptr = range_check_ptr
     let (local _5_85 : Uint256) = read_from_storage_split_dynamic_uint256(_4_84)
-    local range_check_ptr = range_check_ptr
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
     local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     let (local _6_86 : Uint256) = is_lt(_5_85, var_wad_78)
     local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     let (local _7_87 : Uint256) = is_zero(_6_86)
+    local range_check_ptr = range_check_ptr
     require_helper(_7_87)
     local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     let (
         local _8_88 : Uint256) = mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256_571(
         var_src)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
+    local range_check_ptr = range_check_ptr
     let (local _9 : Uint256) = read_from_storage_split_dynamic_uint256(_8_88)
-    local range_check_ptr = range_check_ptr
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
     local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     let (local _10 : Uint256) = cleanup_from_storage_uint256(_9)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     let (local _11 : Uint256) = is_lt(_10, var_wad_78)
     local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     let (local _12 : Uint256) = is_zero(_11)
+    local range_check_ptr = range_check_ptr
     require_helper(_12)
     local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     let (
         local _13 : Uint256) = mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256_570(
         var_src)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
+    local range_check_ptr = range_check_ptr
     let (
         local _14 : Uint256) = mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256(
         _13, var_sender_79)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
+    local range_check_ptr = range_check_ptr
     let (local _15 : Uint256) = s_load(_14)
+    local storage_ptr : Storage* = storage_ptr
     local range_check_ptr = range_check_ptr
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     let (local _16 : Uint256) = cleanup_from_storage_uint256(_15)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     let (local _17 : Uint256) = checked_sub_uint256(_16, var_wad_78)
     local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     update_storage_value_offsett_uint256_to_uint256(_14, _17)
-    local range_check_ptr = range_check_ptr
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
     local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     return ()
 end
 
 func __warp_block_7_if{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        storage_ptr : Storage*}(
         _2_82 : Uint256, var_sender_79 : Uint256, var_src : Uint256, var_wad_78 : Uint256) -> ():
     alloc_locals
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    local storage_ptr : Storage* = storage_ptr
     if _2_82.low + _2_82.high != 0:
         __warp_block_9(var_sender_79, var_src, var_wad_78)
-        local range_check_ptr = range_check_ptr
-        local pedersen_ptr : HashBuiltin* = pedersen_ptr
-        local storage_ptr : Storage* = storage_ptr
         local memory_dict : DictAccess* = memory_dict
         local msize = msize
+        local pedersen_ptr : HashBuiltin* = pedersen_ptr
+        local range_check_ptr = range_check_ptr
+        local storage_ptr : Storage* = storage_ptr
         return ()
     else:
         return ()
@@ -562,78 +466,60 @@ func __warp_block_7_if{
 end
 
 func fun_transferFrom{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        storage_ptr : Storage*}(
         var_src : Uint256, var_dst : Uint256, var_wad_78 : Uint256, var_sender_79 : Uint256) -> (
         var_80 : Uint256):
     alloc_locals
-    let (local _1_81 : Uint256) = is_eq(var_src, var_sender_79)
-    let (local _2_82 : Uint256) = is_zero(_1_81)
-    __warp_block_7_if(_2_82, var_sender_79, var_src, var_wad_78)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    local storage_ptr : Storage* = storage_ptr
+    let (local _1_81 : Uint256) = is_eq(var_src, var_sender_79)
+    local range_check_ptr = range_check_ptr
+    let (local _2_82 : Uint256) = is_zero(_1_81)
+    local range_check_ptr = range_check_ptr
+    __warp_block_7_if(_2_82, var_sender_79, var_src, var_wad_78)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    local storage_ptr : Storage* = storage_ptr
     let (
         local _18 : Uint256) = mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256_571(
         var_src)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
+    local range_check_ptr = range_check_ptr
     let (local _19 : Uint256) = s_load(_18)
+    local storage_ptr : Storage* = storage_ptr
     local range_check_ptr = range_check_ptr
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     let (local _20 : Uint256) = cleanup_from_storage_uint256(_19)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     let (local _21 : Uint256) = checked_sub_uint256(_20, var_wad_78)
     local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     update_storage_value_offsett_uint256_to_uint256(_18, _21)
-    local range_check_ptr = range_check_ptr
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
     local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     let (
         local _22 : Uint256) = mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256_571(
         var_dst)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
+    local range_check_ptr = range_check_ptr
     let (local _23 : Uint256) = s_load(_22)
+    local storage_ptr : Storage* = storage_ptr
     local range_check_ptr = range_check_ptr
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     let (local _24 : Uint256) = cleanup_from_storage_uint256(_23)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     let (local _25 : Uint256) = u256_add(_24, var_wad_78)
-    update_storage_value_offsett_uint256_to_uint256(_22, _25)
     local range_check_ptr = range_check_ptr
+    update_storage_value_offsett_uint256_to_uint256(_22, _25)
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
     local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     local var_80 : Uint256 = Uint256(low=1, high=0)
     return (var_80)
 end
@@ -654,75 +540,54 @@ func fun_transferFrom_external{
 end
 
 func fun_withdraw{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(var_wad_89 : Uint256, var_sender_90 : Uint256) -> ():
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        storage_ptr : Storage*}(var_wad_89 : Uint256, var_sender_90 : Uint256) -> ():
     alloc_locals
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    local storage_ptr : Storage* = storage_ptr
     let (
         local _1_91 : Uint256) = mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256_571(
         var_sender_90)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
+    local range_check_ptr = range_check_ptr
     let (local _2_92 : Uint256) = read_from_storage_split_dynamic_uint256(_1_91)
-    local range_check_ptr = range_check_ptr
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
     local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     let (local _3_93 : Uint256) = is_lt(_2_92, var_wad_89)
     local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     let (local _4_94 : Uint256) = is_zero(_3_93)
+    local range_check_ptr = range_check_ptr
     require_helper(_4_94)
     local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     let (
         local _5_95 : Uint256) = mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256_571(
         var_sender_90)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
+    local range_check_ptr = range_check_ptr
     let (local _6_96 : Uint256) = s_load(_5_95)
+    local storage_ptr : Storage* = storage_ptr
     local range_check_ptr = range_check_ptr
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     let (local _7_97 : Uint256) = cleanup_from_storage_uint256(_6_96)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     let (local _8_98 : Uint256) = checked_sub_uint256(_7_97, var_wad_89)
     local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     update_storage_value_offsett_uint256_to_uint256(_5_95, _8_98)
-    local range_check_ptr = range_check_ptr
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
     local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     let (local expr_component : Uint256, local expr_component_1 : Uint256) = fun_deposit(
         var_sender_90, var_wad_89)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    local storage_ptr : Storage* = storage_ptr
     return ()
 end
 
@@ -737,61 +602,55 @@ func fun_withdraw_external{range_check_ptr, pedersen_ptr : HashBuiltin*, storage
 end
 
 func mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256_579{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(key_120 : Uint256) -> (dataSlot_121 : Uint256):
+        memory_dict : DictAccess*, msize, range_check_ptr}(key_120 : Uint256) -> (
+        dataSlot_121 : Uint256):
     alloc_locals
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local range_check_ptr = range_check_ptr
     local _1_122 : Uint256 = Uint256(low=0, high=0)
     mstore_(offset=_1_122.low, value=key_120)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
+    local range_check_ptr = range_check_ptr
     local msize = msize
     local _2_123 : Uint256 = Uint256(low=2, high=0)
     local _3_124 : Uint256 = Uint256(low=32, high=0)
     mstore_(offset=_3_124.low, value=_2_123)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
+    local range_check_ptr = range_check_ptr
     local msize = msize
     local _4_125 : Uint256 = Uint256(low=64, high=0)
     local _5_126 : Uint256 = _1_122
     let (local dataSlot_121 : Uint256) = sha(_1_122.low, _4_125.low)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
+    local range_check_ptr = range_check_ptr
     local msize = msize
     return (dataSlot_121)
 end
 
 func mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256_567{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(key_100 : Uint256) -> (dataSlot : Uint256):
+        memory_dict : DictAccess*, msize, range_check_ptr}(key_100 : Uint256) -> (
+        dataSlot : Uint256):
     alloc_locals
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local range_check_ptr = range_check_ptr
     local _1_101 : Uint256 = Uint256(low=0, high=0)
     mstore_(offset=_1_101.low, value=key_100)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
+    local range_check_ptr = range_check_ptr
     local msize = msize
     local _2_102 : Uint256 = Uint256(low=3, high=0)
     local _3_103 : Uint256 = Uint256(low=32, high=0)
     mstore_(offset=_3_103.low, value=_2_102)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
+    local range_check_ptr = range_check_ptr
     local msize = msize
     local _4_104 : Uint256 = Uint256(low=64, high=0)
     local _5_105 : Uint256 = _1_101
     let (local dataSlot : Uint256) = sha(_1_101.low, _4_104.low)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
+    local range_check_ptr = range_check_ptr
     local msize = msize
     return (dataSlot)
 end

--- a/warp/for-loop-with-break.cairo
+++ b/warp/for-loop-with-break.cairo
@@ -43,9 +43,7 @@ func get_storage_high{storage_ptr : Storage*, range_check_ptr, pedersen_ptr : Ha
     return (res=storage_val_high)
 end
 
-func __warp_block_0_if{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(_4 : Uint256) -> ():
+func __warp_block_0_if(_4 : Uint256) -> ():
     alloc_locals
     if _4.low + _4.high != 0:
         assert 0 = 1
@@ -55,9 +53,7 @@ func __warp_block_0_if{
     end
 end
 
-func __warp_block_1_if{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(_2_6 : Uint256) -> ():
+func __warp_block_1_if(_2_6 : Uint256) -> ():
     alloc_locals
     if _2_6.low + _2_6.high != 0:
         assert 0 = 1
@@ -67,9 +63,7 @@ func __warp_block_1_if{
     end
 end
 
-func __warp_block_2_if{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(_2_9 : Uint256) -> ():
+func __warp_block_2_if(_2_9 : Uint256) -> ():
     alloc_locals
     if _2_9.low + _2_9.high != 0:
         assert 0 = 1
@@ -79,32 +73,21 @@ func __warp_block_2_if{
     end
 end
 
-func checked_sub_uint256{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(x_7 : Uint256) -> (diff : Uint256):
+func checked_sub_uint256{range_check_ptr}(x_7 : Uint256) -> (diff : Uint256):
     alloc_locals
+    local range_check_ptr = range_check_ptr
     local _1_8 : Uint256 = Uint256(low=1, high=0)
     let (local _2_9 : Uint256) = is_lt(x_7, _1_8)
     local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     __warp_block_2_if(_2_9)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     let (local _3_10 : Uint256) = uint256_not(Uint256(low=0, high=0))
+    local range_check_ptr = range_check_ptr
     let (local diff : Uint256) = u256_add(x_7, _3_10)
+    local range_check_ptr = range_check_ptr
     return (diff)
 end
 
-func __warp_block_3_if{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(_1_11 : Uint256, __warp_break_0 : Uint256) -> (
-        __warp_break_0 : Uint256):
+func __warp_block_3_if(_1_11 : Uint256, __warp_break_0 : Uint256) -> (__warp_break_0 : Uint256):
     alloc_locals
     if _1_11.low + _1_11.high != 0:
         local __warp_break_0 : Uint256 = Uint256(low=1, high=0)
@@ -114,32 +97,22 @@ func __warp_block_3_if{
     end
 end
 
-func __warp_loop_body_0{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(
+func __warp_loop_body_0{range_check_ptr}(
         __warp_break_0 : Uint256, var_j : Uint256, var_k : Uint256) -> (
         __warp_break_0 : Uint256, var_k : Uint256):
     alloc_locals
-    let (local _1_11 : Uint256) = is_gt(var_k, var_j)
-    let (local __warp_break_0 : Uint256) = __warp_block_3_if(_1_11, __warp_break_0)
     local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
+    let (local _1_11 : Uint256) = is_gt(var_k, var_j)
+    local range_check_ptr = range_check_ptr
+    let (local __warp_break_0 : Uint256) = __warp_block_3_if(_1_11, __warp_break_0)
     let (local var_k : Uint256) = checked_sub_uint256(var_k)
     local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     let (local var_k : Uint256) = u256_add(var_k, var_j)
+    local range_check_ptr = range_check_ptr
     return (__warp_break_0, var_k)
 end
 
-func __warp_block_6_if{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(
+func __warp_block_6_if(
         __warp_break_0 : Uint256, var_i : Uint256, var_j : Uint256, var_k : Uint256) -> (
         var_k : Uint256):
     alloc_locals
@@ -147,87 +120,53 @@ func __warp_block_6_if{
         return (var_k)
     else:
         let (local var_k : Uint256) = __warp_loop_0(var_i, var_j, var_k)
-        local range_check_ptr = range_check_ptr
-        local pedersen_ptr : HashBuiltin* = pedersen_ptr
-        local storage_ptr : Storage* = storage_ptr
-        local memory_dict : DictAccess* = memory_dict
-        local msize = msize
         return (var_k)
     end
 end
 
-func __warp_block_5{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(var_i : Uint256, var_j : Uint256, var_k : Uint256) -> (
+func __warp_block_5{range_check_ptr}(var_i : Uint256, var_j : Uint256, var_k : Uint256) -> (
         var_k : Uint256):
     alloc_locals
+    local range_check_ptr = range_check_ptr
     local __warp_break_0 : Uint256 = Uint256(low=0, high=0)
     let (local __warp_break_0 : Uint256, local var_k : Uint256) = __warp_loop_body_0(
         __warp_break_0, var_j, var_k)
     local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     let (local var_k : Uint256) = __warp_block_6_if(__warp_break_0, var_i, var_j, var_k)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     return (var_k)
 end
 
-func __warp_block_4_if{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(
+func __warp_block_4_if{range_check_ptr}(
         __warp_subexpr_0 : Uint256, var_i : Uint256, var_j : Uint256, var_k : Uint256) -> (
         var_k : Uint256):
     alloc_locals
+    local range_check_ptr = range_check_ptr
     if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
         let (local var_k : Uint256) = __warp_block_5(var_i, var_j, var_k)
         local range_check_ptr = range_check_ptr
-        local pedersen_ptr : HashBuiltin* = pedersen_ptr
-        local storage_ptr : Storage* = storage_ptr
-        local memory_dict : DictAccess* = memory_dict
-        local msize = msize
         return (var_k)
     else:
         return (var_k)
     end
 end
 
-func __warp_loop_0{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(var_i : Uint256, var_j : Uint256, var_k : Uint256) -> (
+func __warp_loop_0{range_check_ptr}(var_i : Uint256, var_j : Uint256, var_k : Uint256) -> (
         var_k : Uint256):
     alloc_locals
+    local range_check_ptr = range_check_ptr
     let (local __warp_subexpr_0 : Uint256) = is_lt(var_k, var_i)
     local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     let (local var_k : Uint256) = __warp_block_4_if(__warp_subexpr_0, var_i, var_j, var_k)
     local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     return (var_k)
 end
 
-func fun_transferFrom{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(var_i : Uint256, var_j : Uint256) -> (var : Uint256):
+func fun_transferFrom{range_check_ptr}(var_i : Uint256, var_j : Uint256) -> (var : Uint256):
     alloc_locals
+    local range_check_ptr = range_check_ptr
     local var_k : Uint256 = Uint256(low=0, high=0)
     let (local var_k : Uint256) = __warp_loop_0(var_i, var_j, var_k)
     local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     local var : Uint256 = Uint256(low=1, high=0)
     return (var)
 end

--- a/warp/for-loop-with-continue.cairo
+++ b/warp/for-loop-with-continue.cairo
@@ -43,9 +43,7 @@ func get_storage_high{storage_ptr : Storage*, range_check_ptr, pedersen_ptr : Ha
     return (res=storage_val_high)
 end
 
-func __warp_block_0_if{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(_4 : Uint256) -> ():
+func __warp_block_0_if(_4 : Uint256) -> ():
     alloc_locals
     if _4.low + _4.high != 0:
         assert 0 = 1
@@ -55,9 +53,7 @@ func __warp_block_0_if{
     end
 end
 
-func __warp_block_1_if{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(_2_6 : Uint256) -> ():
+func __warp_block_1_if(_2_6 : Uint256) -> ():
     alloc_locals
     if _2_6.low + _2_6.high != 0:
         assert 0 = 1
@@ -67,9 +63,7 @@ func __warp_block_1_if{
     end
 end
 
-func __warp_block_2_if{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(_2_9 : Uint256) -> ():
+func __warp_block_2_if(_2_9 : Uint256) -> ():
     alloc_locals
     if _2_9.low + _2_9.high != 0:
         assert 0 = 1
@@ -79,31 +73,21 @@ func __warp_block_2_if{
     end
 end
 
-func checked_sub_uint256{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(x_7 : Uint256) -> (diff : Uint256):
+func checked_sub_uint256{range_check_ptr}(x_7 : Uint256) -> (diff : Uint256):
     alloc_locals
+    local range_check_ptr = range_check_ptr
     local _1_8 : Uint256 = Uint256(low=1, high=0)
     let (local _2_9 : Uint256) = is_lt(x_7, _1_8)
     local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     __warp_block_2_if(_2_9)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     let (local _3_10 : Uint256) = uint256_not(Uint256(low=0, high=0))
+    local range_check_ptr = range_check_ptr
     let (local diff : Uint256) = u256_add(x_7, _3_10)
+    local range_check_ptr = range_check_ptr
     return (diff)
 end
 
-func __warp_block_3_if{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(_1_11 : Uint256) -> ():
+func __warp_block_3_if(_1_11 : Uint256) -> ():
     alloc_locals
     if _1_11.low + _1_11.high != 0:
         return ()
@@ -112,83 +96,51 @@ func __warp_block_3_if{
     end
 end
 
-func __warp_loop_body_0{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(var_j : Uint256, var_k : Uint256) -> (var_k : Uint256):
+func __warp_loop_body_0{range_check_ptr}(var_j : Uint256, var_k : Uint256) -> (var_k : Uint256):
     alloc_locals
-    let (local _1_11 : Uint256) = is_gt(var_k, var_j)
-    __warp_block_3_if(_1_11)
     local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
+    let (local _1_11 : Uint256) = is_gt(var_k, var_j)
+    local range_check_ptr = range_check_ptr
+    __warp_block_3_if(_1_11)
     let (local var_k : Uint256) = checked_sub_uint256(var_k)
     local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     let (local var_k : Uint256) = u256_add(var_k, var_j)
+    local range_check_ptr = range_check_ptr
     return (var_k)
 end
 
-func __warp_block_4_if{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(
+func __warp_block_4_if{range_check_ptr}(
         __warp_subexpr_0 : Uint256, var_i : Uint256, var_j : Uint256, var_k : Uint256) -> (
         var_k : Uint256):
     alloc_locals
+    local range_check_ptr = range_check_ptr
     if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
         let (local var_k : Uint256) = __warp_loop_body_0(var_j, var_k)
         local range_check_ptr = range_check_ptr
-        local pedersen_ptr : HashBuiltin* = pedersen_ptr
-        local storage_ptr : Storage* = storage_ptr
-        local memory_dict : DictAccess* = memory_dict
-        local msize = msize
         let (local var_k : Uint256) = __warp_loop_0(var_i, var_j, var_k)
-        local range_check_ptr = range_check_ptr
-        local pedersen_ptr : HashBuiltin* = pedersen_ptr
-        local storage_ptr : Storage* = storage_ptr
-        local memory_dict : DictAccess* = memory_dict
-        local msize = msize
         return (var_k)
     else:
         return (var_k)
     end
 end
 
-func __warp_loop_0{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(var_i : Uint256, var_j : Uint256, var_k : Uint256) -> (
+func __warp_loop_0{range_check_ptr}(var_i : Uint256, var_j : Uint256, var_k : Uint256) -> (
         var_k : Uint256):
     alloc_locals
+    local range_check_ptr = range_check_ptr
     let (local __warp_subexpr_0 : Uint256) = is_lt(var_k, var_i)
     local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     let (local var_k : Uint256) = __warp_block_4_if(__warp_subexpr_0, var_i, var_j, var_k)
     local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     return (var_k)
 end
 
-func fun_transferFrom{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(var_i : Uint256, var_j : Uint256) -> (var : Uint256):
+func fun_transferFrom{range_check_ptr}(var_i : Uint256, var_j : Uint256) -> (var : Uint256):
     alloc_locals
+    local range_check_ptr = range_check_ptr
     local var_k : Uint256 = Uint256(low=0, high=0)
     let (local var_k : Uint256) = __warp_loop_0(var_i, var_j, var_k)
     local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     local var : Uint256 = Uint256(low=1, high=0)
     return (var)
 end

--- a/warp/if-flattening.cairo
+++ b/warp/if-flattening.cairo
@@ -45,9 +45,7 @@ func get_storage_high{storage_ptr : Storage*, range_check_ptr, pedersen_ptr : Ha
     return (res=storage_val_high)
 end
 
-func __warp_block_0_if{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(_4 : Uint256) -> ():
+func __warp_block_0_if(_4 : Uint256) -> ():
     alloc_locals
     if _4.low + _4.high != 0:
         assert 0 = 1
@@ -57,9 +55,7 @@ func __warp_block_0_if{
     end
 end
 
-func __warp_block_1_if{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(_4_7 : Uint256) -> ():
+func __warp_block_1_if(_4_7 : Uint256) -> ():
     alloc_locals
     if _4_7.low + _4_7.high != 0:
         assert 0 = 1
@@ -69,9 +65,7 @@ func __warp_block_1_if{
     end
 end
 
-func __warp_block_2_if{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(_1_12 : Uint256) -> ():
+func __warp_block_2_if(_1_12 : Uint256) -> ():
     alloc_locals
     if _1_12.low + _1_12.high != 0:
         assert 0 = 1
@@ -81,245 +75,229 @@ func __warp_block_2_if{
     end
 end
 
-func checked_sub_uint256{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(x : Uint256, y : Uint256) -> (diff : Uint256):
+func checked_sub_uint256{range_check_ptr}(x : Uint256, y : Uint256) -> (diff : Uint256):
     alloc_locals
+    local range_check_ptr = range_check_ptr
     let (local _1_12 : Uint256) = is_lt(x, y)
     local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     __warp_block_2_if(_1_12)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     let (local diff : Uint256) = uint256_sub(x, y)
+    local range_check_ptr = range_check_ptr
     return (diff)
 end
 
-func extract_from_storage_value_dynamict_uint256{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(slot_value : Uint256) -> (value_13 : Uint256):
+func extract_from_storage_value_dynamict_uint256(slot_value : Uint256) -> (value_13 : Uint256):
     alloc_locals
     local value_13 : Uint256 = slot_value
     return (value_13)
 end
 
 func mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256_280{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(key_26 : Uint256) -> (dataSlot_27 : Uint256):
+        memory_dict : DictAccess*, msize, range_check_ptr}(key_26 : Uint256) -> (
+        dataSlot_27 : Uint256):
     alloc_locals
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local range_check_ptr = range_check_ptr
     local _1_28 : Uint256 = Uint256(low=0, high=0)
     mstore_(offset=_1_28.low, value=key_26)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
+    local range_check_ptr = range_check_ptr
     local msize = msize
     local _2_29 : Uint256 = _1_28
     local _3_30 : Uint256 = Uint256(low=32, high=0)
     mstore_(offset=_3_30.low, value=_1_28)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
+    local range_check_ptr = range_check_ptr
     local msize = msize
     local _4_31 : Uint256 = Uint256(low=64, high=0)
     local _5_32 : Uint256 = _1_28
     let (local dataSlot_27 : Uint256) = sha(_1_28.low, _4_31.low)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
+    local range_check_ptr = range_check_ptr
     local msize = msize
     return (dataSlot_27)
 end
 
 func mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(slot : Uint256, key_33 : Uint256) -> (
+        memory_dict : DictAccess*, msize, range_check_ptr}(slot : Uint256, key_33 : Uint256) -> (
         dataSlot_34 : Uint256):
     alloc_locals
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local range_check_ptr = range_check_ptr
     local _1_35 : Uint256 = Uint256(low=0, high=0)
     mstore_(offset=_1_35.low, value=key_33)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
+    local range_check_ptr = range_check_ptr
     local msize = msize
     local _2_36 : Uint256 = Uint256(low=32, high=0)
     mstore_(offset=_2_36.low, value=slot)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
+    local range_check_ptr = range_check_ptr
     local msize = msize
     local _3_37 : Uint256 = Uint256(low=64, high=0)
     local _4_38 : Uint256 = _1_35
     let (local dataSlot_34 : Uint256) = sha(_1_35.low, _3_37.low)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
+    local range_check_ptr = range_check_ptr
     local msize = msize
     return (dataSlot_34)
 end
 
-func update_byte_slice_shift{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(value_50 : Uint256, toInsert : Uint256) -> (
-        result : Uint256):
+func update_byte_slice_shift(value_50 : Uint256, toInsert : Uint256) -> (result : Uint256):
     alloc_locals
     local result : Uint256 = toInsert
     return (result)
 end
 
 func update_storage_value_offsett_uint256_to_uint256{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(slot_51 : Uint256, value_52 : Uint256) -> ():
+        pedersen_ptr : HashBuiltin*, range_check_ptr, storage_ptr : Storage*}(
+        slot_51 : Uint256, value_52 : Uint256) -> ():
     alloc_locals
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    local storage_ptr : Storage* = storage_ptr
     let (local _1_53 : Uint256) = s_load(slot_51)
+    local storage_ptr : Storage* = storage_ptr
     local range_check_ptr = range_check_ptr
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     let (local _2_54 : Uint256) = update_byte_slice_shift(_1_53, value_52)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     s_store(key=slot_51, value=_2_54)
+    local storage_ptr : Storage* = storage_ptr
     local range_check_ptr = range_check_ptr
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     return ()
 end
 
 func __warp_block_6{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        storage_ptr : Storage*}(
         var_res : Uint256, var_sender : Uint256, var_src : Uint256, var_wad : Uint256) -> (
         var_res : Uint256):
     alloc_locals
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    local storage_ptr : Storage* = storage_ptr
     let (
         local _3_16 : Uint256) = mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256_280(
         var_src)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
+    local range_check_ptr = range_check_ptr
     let (
         local _4_17 : Uint256) = mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256(
         _3_16, var_sender)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
+    local range_check_ptr = range_check_ptr
     let (local _5_18 : Uint256) = s_load(_4_17)
+    local storage_ptr : Storage* = storage_ptr
     local range_check_ptr = range_check_ptr
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     let (local _6_19 : Uint256) = extract_from_storage_value_dynamict_uint256(_5_18)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     let (local _7_20 : Uint256) = checked_sub_uint256(_6_19, var_wad)
     local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     update_storage_value_offsett_uint256_to_uint256(_4_17, _7_20)
-    local range_check_ptr = range_check_ptr
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
     local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     local var_res : Uint256 = Uint256(low=1, high=0)
     return (var_res)
 end
 
 func __warp_block_5_if{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        storage_ptr : Storage*}(
         __warp_subexpr_0 : Uint256, var_res : Uint256, var_sender : Uint256, var_src : Uint256,
         var_wad : Uint256) -> (var_res : Uint256):
     alloc_locals
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    local storage_ptr : Storage* = storage_ptr
     if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
         local var_res : Uint256 = Uint256(low=2, high=0)
         return (var_res)
     else:
         let (local var_res : Uint256) = __warp_block_6(var_res, var_sender, var_src, var_wad)
-        local range_check_ptr = range_check_ptr
-        local pedersen_ptr : HashBuiltin* = pedersen_ptr
-        local storage_ptr : Storage* = storage_ptr
         local memory_dict : DictAccess* = memory_dict
         local msize = msize
+        local pedersen_ptr : HashBuiltin* = pedersen_ptr
+        local range_check_ptr = range_check_ptr
+        local storage_ptr : Storage* = storage_ptr
         return (var_res)
     end
 end
 
 func __warp_block_4{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        storage_ptr : Storage*}(
         match_var : Uint256, var_res : Uint256, var_sender : Uint256, var_src : Uint256,
         var_wad : Uint256) -> (var_res : Uint256):
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = is_eq(match_var, Uint256(low=0, high=0))
-    let (local var_res : Uint256) = __warp_block_5_if(
-        __warp_subexpr_0, var_res, var_sender, var_src, var_wad)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    local storage_ptr : Storage* = storage_ptr
+    let (local __warp_subexpr_0 : Uint256) = is_eq(match_var, Uint256(low=0, high=0))
+    local range_check_ptr = range_check_ptr
+    let (local var_res : Uint256) = __warp_block_5_if(
+        __warp_subexpr_0, var_res, var_sender, var_src, var_wad)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    local storage_ptr : Storage* = storage_ptr
     return (var_res)
 end
 
 func __warp_block_3{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        storage_ptr : Storage*}(
         _2_15 : Uint256, var_res : Uint256, var_sender : Uint256, var_src : Uint256,
         var_wad : Uint256) -> (var_res : Uint256):
     alloc_locals
-    local match_var : Uint256 = _2_15
-    let (local var_res : Uint256) = __warp_block_4(match_var, var_res, var_sender, var_src, var_wad)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    local storage_ptr : Storage* = storage_ptr
+    local match_var : Uint256 = _2_15
+    let (local var_res : Uint256) = __warp_block_4(match_var, var_res, var_sender, var_src, var_wad)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    local storage_ptr : Storage* = storage_ptr
     return (var_res)
 end
 
 func fun_transferFrom{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(
-        var_src : Uint256, var_wad : Uint256, var_sender : Uint256) -> (var : Uint256):
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        storage_ptr : Storage*}(var_src : Uint256, var_wad : Uint256, var_sender : Uint256) -> (
+        var : Uint256):
     alloc_locals
-    local var_res : Uint256 = Uint256(low=0, high=0)
-    let (local _1_14 : Uint256) = is_eq(var_src, var_sender)
-    let (local _2_15 : Uint256) = is_zero(_1_14)
-    let (local var_res : Uint256) = __warp_block_3(_2_15, var_res, var_sender, var_src, var_wad)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    local storage_ptr : Storage* = storage_ptr
+    local var_res : Uint256 = Uint256(low=0, high=0)
+    let (local _1_14 : Uint256) = is_eq(var_src, var_sender)
+    local range_check_ptr = range_check_ptr
+    let (local _2_15 : Uint256) = is_zero(_1_14)
+    local range_check_ptr = range_check_ptr
+    let (local var_res : Uint256) = __warp_block_3(_2_15, var_res, var_sender, var_src, var_wad)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    local storage_ptr : Storage* = storage_ptr
     local var : Uint256 = var_res
     return (var)
 end
@@ -339,51 +317,43 @@ func fun_transferFrom_external{
 end
 
 func mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256_278{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(key : Uint256) -> (dataSlot : Uint256):
+        memory_dict : DictAccess*, msize, range_check_ptr}(key : Uint256) -> (dataSlot : Uint256):
     alloc_locals
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local range_check_ptr = range_check_ptr
     local _1_21 : Uint256 = Uint256(low=0, high=0)
     mstore_(offset=_1_21.low, value=key)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
+    local range_check_ptr = range_check_ptr
     local msize = msize
     local _2_22 : Uint256 = _1_21
     local _3_23 : Uint256 = Uint256(low=32, high=0)
     mstore_(offset=_3_23.low, value=_1_21)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
+    local range_check_ptr = range_check_ptr
     local msize = msize
     local _4_24 : Uint256 = Uint256(low=64, high=0)
     local _5_25 : Uint256 = _1_21
     let (local dataSlot : Uint256) = sha(_1_21.low, _4_24.low)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
     local memory_dict : DictAccess* = memory_dict
+    local range_check_ptr = range_check_ptr
     local msize = msize
     return (dataSlot)
 end
 
 func read_from_storage_split_dynamic_uint256{
-        range_check_ptr, pedersen_ptr : HashBuiltin*, storage_ptr : Storage*,
-        memory_dict : DictAccess*, msize}(slot_45 : Uint256) -> (value_46 : Uint256):
+        pedersen_ptr : HashBuiltin*, range_check_ptr, storage_ptr : Storage*}(
+        slot_45 : Uint256) -> (value_46 : Uint256):
     alloc_locals
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    local storage_ptr : Storage* = storage_ptr
     let (local _1_47 : Uint256) = s_load(slot_45)
+    local storage_ptr : Storage* = storage_ptr
     local range_check_ptr = range_check_ptr
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     let (local value_46 : Uint256) = extract_from_storage_value_dynamict_uint256(_1_47)
-    local range_check_ptr = range_check_ptr
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
     return (value_46)
 end
 

--- a/warp/yul/BuiltinHandler.py
+++ b/warp/yul/BuiltinHandler.py
@@ -10,12 +10,12 @@ class BuiltinHandler:
         module: str,
         function_name: str,
         function_args: str,
-        ref_copy: str = "",  # TODO replace with a simple bool
+        used_implicits: tuple[str] = ("range_check_ptr",),
     ):
         self.module = module
         self.function_name = function_name
         self.function_args = function_args
-        self.ref_copy = ref_copy
+        self.used_implicits = used_implicits
         self.function_call = f"{self.function_name}({self.function_args})"
 
     def required_imports(self):
@@ -49,7 +49,6 @@ class Lt(BuiltinHandler):
             module="evm.uint256",
             function_name="is_lt",
             function_args=function_args,
-            ref_copy="local memory_dict : DictAccess* = memory_dict",
         )
 
 
@@ -59,7 +58,6 @@ class Gt(BuiltinHandler):
             module="evm.uint256",
             function_name="is_gt",
             function_args=function_args,
-            ref_copy="",
         )
 
 
@@ -263,7 +261,7 @@ class MStore(BuiltinHandler):
             module="evm.memory",
             function_name="mstore_",
             function_args=function_args,
-            ref_copy="local memory_dict : DictAccess* = memory_dict",
+            used_implicits=("memory_dict", "range_check_ptr", "msize"),
         )
         self.function_call = f"mstore_(offset={self.address}, value={self.value})"
 
@@ -276,7 +274,7 @@ class MStore8(BuiltinHandler):
             module="evm.memory",
             function_name="mstore8_",
             function_args=function_args,
-            ref_copy="local memory_dict : DictAccess* = memory_dict",
+            used_implicits=("memory_dict", "range_check_ptr", "msize"),
         )
         self.function_call = f"mstore8_(offset={self.address}, byte={self.value})"
 
@@ -288,7 +286,7 @@ class MLoad(BuiltinHandler):
             module="evm.memory",
             function_name="mload_",
             function_args=function_args,
-            ref_copy="local memory_dict : DictAccess* = memory_dict",
+            used_implicits=("memory_dict", "range_check_ptr", "msize"),
         )
         self.function_call = f"mload_({self.offset})"
 
@@ -299,6 +297,7 @@ class MSize(BuiltinHandler):
             module="evm.memory",
             function_name="get_msize",
             function_args=function_args,
+            used_implicits=("range_check_ptr", "msize"),
         )
 
 
@@ -311,8 +310,7 @@ class SStore(BuiltinHandler):
             module="",
             function_name="s_store",
             function_args=function_args,
-            ref_copy="local pedersen_ptr : HashBuiltin* = pedersen_ptr\n\
-            local storage_ptr : Storage* = storage_ptr",
+            used_implicits=("storage_ptr", "range_check_ptr", "pedersen_ptr"),
         )
         self.function_call = f"s_store(key={self.key},value={self.value})"
 
@@ -324,8 +322,7 @@ class SLoad(BuiltinHandler):
             module="",
             function_name="s_store",
             function_args=function_args,
-            ref_copy="local pedersen_ptr : HashBuiltin* = pedersen_ptr\n\
-            local storage_ptr : Storage* = storage_ptr",
+            used_implicits=("storage_ptr", "range_check_ptr", "pedersen_ptr"),
         )
         self.function_call = f"s_load({self.key})"
 
@@ -339,8 +336,7 @@ class SHA3(BuiltinHandler):
             module="",
             function_name="sha",
             function_args=function_args,
-            ref_copy=f"local msize = msize\n"
-            "local memory_dict : DictAccess* = memory_dict",
+            used_implicits=("memory_dict", "range_check_ptr", "msize"),
         )
         self.function_call = f"sha({self.offset}, {self.length})"
 
@@ -355,6 +351,7 @@ class Caller(BuiltinHandler):
             module="evm.calls",
             function_name="get_caller_data_uint256",
             function_args=function_args,
+            used_implicits=("syscall_ptr", "range_check_ptr"),
         )
 
 


### PR DESCRIPTION
The algorithm relies on several assumptions. The first one is that
     before each function call all implicit arguments are stored as
     'local's.

The second one is that each builtin function defines a set of implicit
     arguments that it uses. Due to the nature of how cairo rebinds
     implicit arguments, these get rebound as non-local, revokable
     references. So, we need to make a local copy of them. Complex
     functions defined in the cairo file gather their set of implicit
     arguments from functions that are used in them. The yul contract
     is supposed to be topologically sorted, so it should be generally
     fine. In the case of mutually recursive functions a set of
     required implicit arguments can't be gathered before the function
     call. So we simply assign to such functions all possible implicit
     arguments.