### PR TITLE
Remove unused functions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 autohooks~=21.7.0
 autohooks-plugin-black~=21.7.1
 pytest==6.2.4
-py-solc-x
+py-solc-x==1.1.0

--- a/tests/yul/ERC20.cairo
+++ b/tests/yul/ERC20.cairo
@@ -46,7 +46,7 @@ func get_storage_high{storage_ptr : Storage*, range_check_ptr, pedersen_ptr : Ha
     return (res=storage_val_high)
 end
 
-func __warp_block_0_if(_4 : Uint256) -> ():
+func __warp_block_00(_4 : Uint256) -> ():
     alloc_locals
     if _4.low + _4.high != 0:
         assert 0 = 1
@@ -65,18 +65,8 @@ func abi_decode{range_check_ptr}(dataEnd : Uint256) -> ():
     local range_check_ptr = range_check_ptr
     let (local _4 : Uint256) = slt(_3, _1)
     local range_check_ptr = range_check_ptr
-    __warp_block_0_if(_4)
+    __warp_block_00(_4)
     return ()
-end
-
-func __warp_block_1_if(_4_5 : Uint256) -> ():
-    alloc_locals
-    if _4_5.low + _4_5.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
 end
 
 func abi_decode_uint256{range_check_ptr}(dataEnd_1 : Uint256) -> (value0 : Uint256):
@@ -88,20 +78,10 @@ func abi_decode_uint256{range_check_ptr}(dataEnd_1 : Uint256) -> (value0 : Uint2
     local range_check_ptr = range_check_ptr
     let (local _4_5 : Uint256) = slt(_3_4, _1_2)
     local range_check_ptr = range_check_ptr
-    __warp_block_1_if(_4_5)
+    __warp_block_00(_4_5)
     local _5 : Uint256 = Uint256(low=4, high=0)
     local value0 : Uint256 = Uint256(31597865, 9284653)
     return (value0)
-end
-
-func __warp_block_2_if(_4_11 : Uint256) -> ():
-    alloc_locals
-    if _4_11.low + _4_11.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
 end
 
 func abi_decode_uint256t_uint256{range_check_ptr}(dataEnd_6 : Uint256) -> (
@@ -114,22 +94,12 @@ func abi_decode_uint256t_uint256{range_check_ptr}(dataEnd_6 : Uint256) -> (
     local range_check_ptr = range_check_ptr
     let (local _4_11 : Uint256) = slt(_3_10, _1_8)
     local range_check_ptr = range_check_ptr
-    __warp_block_2_if(_4_11)
+    __warp_block_00(_4_11)
     local _5_12 : Uint256 = Uint256(low=4, high=0)
     local value0_7 : Uint256 = Uint256(31597865, 9284653)
     local _6 : Uint256 = Uint256(low=36, high=0)
     local value1 : Uint256 = Uint256(31597865, 9284653)
     return (value0_7, value1)
-end
-
-func __warp_block_3_if(_4_19 : Uint256) -> ():
-    alloc_locals
-    if _4_19.low + _4_19.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
 end
 
 func abi_decode_uint256t_uint256t_uint256{range_check_ptr}(dataEnd_13 : Uint256) -> (
@@ -142,7 +112,7 @@ func abi_decode_uint256t_uint256t_uint256{range_check_ptr}(dataEnd_13 : Uint256)
     local range_check_ptr = range_check_ptr
     let (local _4_19 : Uint256) = slt(_3_18, _1_16)
     local range_check_ptr = range_check_ptr
-    __warp_block_3_if(_4_19)
+    __warp_block_00(_4_19)
     local _5_20 : Uint256 = Uint256(low=4, high=0)
     local value0_14 : Uint256 = Uint256(31597865, 9284653)
     local _6_21 : Uint256 = Uint256(low=36, high=0)
@@ -150,16 +120,6 @@ func abi_decode_uint256t_uint256t_uint256{range_check_ptr}(dataEnd_13 : Uint256)
     local _7 : Uint256 = Uint256(low=68, high=0)
     local value2 : Uint256 = Uint256(31597865, 9284653)
     return (value0_14, value1_15, value2)
-end
-
-func __warp_block_4_if(_4_29 : Uint256) -> ():
-    alloc_locals
-    if _4_29.low + _4_29.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
 end
 
 func abi_decode_uint256t_uint256t_uint256t_uint256{range_check_ptr}(dataEnd_22 : Uint256) -> (
@@ -172,7 +132,7 @@ func abi_decode_uint256t_uint256t_uint256t_uint256{range_check_ptr}(dataEnd_22 :
     local range_check_ptr = range_check_ptr
     let (local _4_29 : Uint256) = slt(_3_28, _1_26)
     local range_check_ptr = range_check_ptr
-    __warp_block_4_if(_4_29)
+    __warp_block_00(_4_29)
     local _5_30 : Uint256 = Uint256(low=4, high=0)
     local value0_23 : Uint256 = Uint256(31597865, 9284653)
     local _6_31 : Uint256 = Uint256(low=36, high=0)
@@ -301,31 +261,11 @@ func abi_encode_uint8{memory_dict : DictAccess*, msize, range_check_ptr}(
     return (tail_60)
 end
 
-func __warp_block_5_if(_2_63 : Uint256) -> ():
-    alloc_locals
-    if _2_63.low + _2_63.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
-func __warp_block_6_if(_1_66 : Uint256) -> ():
-    alloc_locals
-    if _1_66.low + _1_66.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
 func checked_sub_uint256{range_check_ptr}(x_64 : Uint256, y_65 : Uint256) -> (diff : Uint256):
     alloc_locals
     let (local _1_66 : Uint256) = is_lt(x_64, y_65)
     local range_check_ptr = range_check_ptr
-    __warp_block_6_if(_1_66)
+    __warp_block_00(_1_66)
     let (local diff : Uint256) = uint256_sub(x_64, y_65)
     local range_check_ptr = range_check_ptr
     return (diff)
@@ -531,25 +471,15 @@ func read_from_storage_split_dynamic_uint256{
     return (value_140)
 end
 
-func __warp_block_8_if(_1_142 : Uint256) -> ():
-    alloc_locals
-    if _1_142.low + _1_142.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
 func require_helper{range_check_ptr}(condition : Uint256) -> ():
     alloc_locals
     let (local _1_142 : Uint256) = is_zero(condition)
     local range_check_ptr = range_check_ptr
-    __warp_block_8_if(_1_142)
+    __warp_block_00(_1_142)
     return ()
 end
 
-func __warp_block_10{
+func __warp_block_2{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(
         var_sender_79 : Uint256, var_src : Uint256, var_wad_78 : Uint256) -> ():
@@ -615,13 +545,13 @@ func __warp_block_10{
     return ()
 end
 
-func __warp_block_7_if{
+func __warp_block_0_if{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(
         _2_82 : Uint256, var_sender_79 : Uint256, var_src : Uint256, var_wad_78 : Uint256) -> ():
     alloc_locals
     if _2_82.low + _2_82.high != 0:
-        __warp_block_10{
+        __warp_block_2{
             memory_dict=memory_dict,
             msize=msize,
             pedersen_ptr=pedersen_ptr,
@@ -648,7 +578,7 @@ func fun_transferFrom{
     local range_check_ptr = range_check_ptr
     let (local _2_82 : Uint256) = is_zero(_1_81)
     local range_check_ptr = range_check_ptr
-    __warp_block_7_if{
+    __warp_block_0_if{
         memory_dict=memory_dict,
         msize=msize,
         pedersen_ptr=pedersen_ptr,
@@ -838,22 +768,12 @@ func mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256_567
     return (dataSlot)
 end
 
-func __warp_block_18_if(_11_162 : Uint256) -> ():
-    alloc_locals
-    if _11_162.low + _11_162.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
-func __warp_block_16{
+func __warp_block_7{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(_2_153 : Uint256, _4_155 : Uint256) -> ():
     alloc_locals
     local _11_162 : Uint256 = Uint256(0, 0)
-    __warp_block_18_if(_11_162)
+    __warp_block_00(_11_162)
     local _12_163 : Uint256 = _4_155
     abi_decode{range_check_ptr=range_check_ptr}(_4_155)
     local range_check_ptr = range_check_ptr
@@ -877,22 +797,12 @@ func __warp_block_16{
     return ()
 end
 
-func __warp_block_22_if(_20_171 : Uint256) -> ():
-    alloc_locals
-    if _20_171.low + _20_171.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
-func __warp_block_20{
+func __warp_block_10{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(_1_152 : Uint256, _4_155 : Uint256, _7_158 : Uint256) -> ():
     alloc_locals
     local _20_171 : Uint256 = Uint256(0, 0)
-    __warp_block_22_if(_20_171)
+    __warp_block_00(_20_171)
     local _21_172 : Uint256 = _4_155
     abi_decode{range_check_ptr=range_check_ptr}(_4_155)
     local range_check_ptr = range_check_ptr
@@ -919,7 +829,7 @@ func __warp_block_20{
     return ()
 end
 
-func __warp_block_24{
+func __warp_block_13{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(_1_152 : Uint256, _4_155 : Uint256, _7_158 : Uint256) -> ():
     alloc_locals
@@ -947,7 +857,7 @@ func __warp_block_24{
     return ()
 end
 
-func __warp_block_27{
+func __warp_block_16{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(_1_152 : Uint256, _4_155 : Uint256) -> ():
     alloc_locals
@@ -982,22 +892,12 @@ func __warp_block_27{
     return ()
 end
 
-func __warp_block_32_if(_32 : Uint256) -> ():
-    alloc_locals
-    if _32.low + _32.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
-func __warp_block_30{
+func __warp_block_19{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(_1_152 : Uint256, _4_155 : Uint256) -> ():
     alloc_locals
     local _32 : Uint256 = Uint256(0, 0)
-    __warp_block_32_if(_32)
+    __warp_block_00(_32)
     local _33 : Uint256 = _4_155
     let (local _34 : Uint256) = abi_decode_uint256{range_check_ptr=range_check_ptr}(_4_155)
     local range_check_ptr = range_check_ptr
@@ -1023,7 +923,7 @@ func __warp_block_30{
     return ()
 end
 
-func __warp_block_34{
+func __warp_block_22{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(_1_152 : Uint256, _4_155 : Uint256) -> ():
     alloc_locals
@@ -1054,22 +954,12 @@ func __warp_block_34{
     return ()
 end
 
-func __warp_block_39_if(_40 : Uint256) -> ():
-    alloc_locals
-    if _40.low + _40.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
-func __warp_block_37{
+func __warp_block_25{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(_1_152 : Uint256, _4_155 : Uint256) -> ():
     alloc_locals
     local _40 : Uint256 = Uint256(0, 0)
-    __warp_block_39_if(_40)
+    __warp_block_00(_40)
     local _41 : Uint256 = _4_155
     let (local param_9 : Uint256, local param_10 : Uint256) = abi_decode_uint256t_uint256{
         range_check_ptr=range_check_ptr}(_4_155)
@@ -1103,7 +993,7 @@ func __warp_block_37{
     return ()
 end
 
-func __warp_block_41{
+func __warp_block_28{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(_1_152 : Uint256, _4_155 : Uint256) -> ():
     alloc_locals
@@ -1138,13 +1028,13 @@ func __warp_block_41{
     return ()
 end
 
-func __warp_block_40_if{
+func __warp_block_27_if{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(_1_152 : Uint256, _4_155 : Uint256, __warp_subexpr_0 : Uint256) -> (
         ):
     alloc_locals
     if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        __warp_block_41{
+        __warp_block_28{
             memory_dict=memory_dict,
             msize=msize,
             pedersen_ptr=pedersen_ptr,
@@ -1161,13 +1051,13 @@ func __warp_block_40_if{
     end
 end
 
-func __warp_block_38{
+func __warp_block_26{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(_1_152 : Uint256, _4_155 : Uint256, match_var : Uint256) -> ():
     alloc_locals
     let (local __warp_subexpr_0 : Uint256) = is_eq(match_var, Uint256(low=3803951448, high=0))
     local range_check_ptr = range_check_ptr
-    __warp_block_40_if{
+    __warp_block_27_if{
         memory_dict=memory_dict,
         msize=msize,
         pedersen_ptr=pedersen_ptr,
@@ -1181,247 +1071,30 @@ func __warp_block_38{
     return ()
 end
 
-func __warp_block_36_if{
+func __warp_block_24_if{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(
         _1_152 : Uint256, _4_155 : Uint256, __warp_subexpr_0 : Uint256, match_var : Uint256) -> ():
     alloc_locals
     if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        __warp_block_37{
-            memory_dict=memory_dict,
-            msize=msize,
-            pedersen_ptr=pedersen_ptr,
-            range_check_ptr=range_check_ptr,
-            storage_ptr=storage_ptr}(_1_152, _4_155)
-        local memory_dict : DictAccess* = memory_dict
-        local msize = msize
-        local pedersen_ptr : HashBuiltin* = pedersen_ptr
-        local range_check_ptr = range_check_ptr
-        local storage_ptr : Storage* = storage_ptr
-        return ()
-    else:
-        __warp_block_38{
-            memory_dict=memory_dict,
-            msize=msize,
-            pedersen_ptr=pedersen_ptr,
-            range_check_ptr=range_check_ptr,
-            storage_ptr=storage_ptr}(_1_152, _4_155, match_var)
-        local memory_dict : DictAccess* = memory_dict
-        local msize = msize
-        local pedersen_ptr : HashBuiltin* = pedersen_ptr
-        local range_check_ptr = range_check_ptr
-        local storage_ptr : Storage* = storage_ptr
-        return ()
-    end
-end
-
-func __warp_block_35{
-        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
-        storage_ptr : Storage*}(_1_152 : Uint256, _4_155 : Uint256, match_var : Uint256) -> ():
-    alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = is_eq(match_var, Uint256(low=3433131944, high=0))
-    local range_check_ptr = range_check_ptr
-    __warp_block_36_if{
-        memory_dict=memory_dict,
-        msize=msize,
-        pedersen_ptr=pedersen_ptr,
-        range_check_ptr=range_check_ptr,
-        storage_ptr=storage_ptr}(_1_152, _4_155, __warp_subexpr_0, match_var)
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local range_check_ptr = range_check_ptr
-    local storage_ptr : Storage* = storage_ptr
-    return ()
-end
-
-func __warp_block_33_if{
-        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
-        storage_ptr : Storage*}(
-        _1_152 : Uint256, _4_155 : Uint256, __warp_subexpr_0 : Uint256, match_var : Uint256) -> ():
-    alloc_locals
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        __warp_block_34{
-            memory_dict=memory_dict,
-            msize=msize,
-            pedersen_ptr=pedersen_ptr,
-            range_check_ptr=range_check_ptr,
-            storage_ptr=storage_ptr}(_1_152, _4_155)
-        local memory_dict : DictAccess* = memory_dict
-        local msize = msize
-        local pedersen_ptr : HashBuiltin* = pedersen_ptr
-        local range_check_ptr = range_check_ptr
-        local storage_ptr : Storage* = storage_ptr
-        return ()
-    else:
-        __warp_block_35{
-            memory_dict=memory_dict,
-            msize=msize,
-            pedersen_ptr=pedersen_ptr,
-            range_check_ptr=range_check_ptr,
-            storage_ptr=storage_ptr}(_1_152, _4_155, match_var)
-        local memory_dict : DictAccess* = memory_dict
-        local msize = msize
-        local pedersen_ptr : HashBuiltin* = pedersen_ptr
-        local range_check_ptr = range_check_ptr
-        local storage_ptr : Storage* = storage_ptr
-        return ()
-    end
-end
-
-func __warp_block_31{
-        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
-        storage_ptr : Storage*}(_1_152 : Uint256, _4_155 : Uint256, match_var : Uint256) -> ():
-    alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = is_eq(match_var, Uint256(low=3093743780, high=0))
-    local range_check_ptr = range_check_ptr
-    __warp_block_33_if{
-        memory_dict=memory_dict,
-        msize=msize,
-        pedersen_ptr=pedersen_ptr,
-        range_check_ptr=range_check_ptr,
-        storage_ptr=storage_ptr}(_1_152, _4_155, __warp_subexpr_0, match_var)
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local range_check_ptr = range_check_ptr
-    local storage_ptr : Storage* = storage_ptr
-    return ()
-end
-
-func __warp_block_29_if{
-        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
-        storage_ptr : Storage*}(
-        _1_152 : Uint256, _4_155 : Uint256, __warp_subexpr_0 : Uint256, match_var : Uint256) -> ():
-    alloc_locals
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        __warp_block_30{
-            memory_dict=memory_dict,
-            msize=msize,
-            pedersen_ptr=pedersen_ptr,
-            range_check_ptr=range_check_ptr,
-            storage_ptr=storage_ptr}(_1_152, _4_155)
-        local memory_dict : DictAccess* = memory_dict
-        local msize = msize
-        local pedersen_ptr : HashBuiltin* = pedersen_ptr
-        local range_check_ptr = range_check_ptr
-        local storage_ptr : Storage* = storage_ptr
-        return ()
-    else:
-        __warp_block_31{
-            memory_dict=memory_dict,
-            msize=msize,
-            pedersen_ptr=pedersen_ptr,
-            range_check_ptr=range_check_ptr,
-            storage_ptr=storage_ptr}(_1_152, _4_155, match_var)
-        local memory_dict : DictAccess* = memory_dict
-        local msize = msize
-        local pedersen_ptr : HashBuiltin* = pedersen_ptr
-        local range_check_ptr = range_check_ptr
-        local storage_ptr : Storage* = storage_ptr
-        return ()
-    end
-end
-
-func __warp_block_28{
-        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
-        storage_ptr : Storage*}(_1_152 : Uint256, _4_155 : Uint256, match_var : Uint256) -> ():
-    alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = is_eq(match_var, Uint256(low=2630350600, high=0))
-    local range_check_ptr = range_check_ptr
-    __warp_block_29_if{
-        memory_dict=memory_dict,
-        msize=msize,
-        pedersen_ptr=pedersen_ptr,
-        range_check_ptr=range_check_ptr,
-        storage_ptr=storage_ptr}(_1_152, _4_155, __warp_subexpr_0, match_var)
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local range_check_ptr = range_check_ptr
-    local storage_ptr : Storage* = storage_ptr
-    return ()
-end
-
-func __warp_block_26_if{
-        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
-        storage_ptr : Storage*}(
-        _1_152 : Uint256, _4_155 : Uint256, __warp_subexpr_0 : Uint256, match_var : Uint256) -> ():
-    alloc_locals
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        __warp_block_27{
-            memory_dict=memory_dict,
-            msize=msize,
-            pedersen_ptr=pedersen_ptr,
-            range_check_ptr=range_check_ptr,
-            storage_ptr=storage_ptr}(_1_152, _4_155)
-        local memory_dict : DictAccess* = memory_dict
-        local msize = msize
-        local pedersen_ptr : HashBuiltin* = pedersen_ptr
-        local range_check_ptr = range_check_ptr
-        local storage_ptr : Storage* = storage_ptr
-        return ()
-    else:
-        __warp_block_28{
-            memory_dict=memory_dict,
-            msize=msize,
-            pedersen_ptr=pedersen_ptr,
-            range_check_ptr=range_check_ptr,
-            storage_ptr=storage_ptr}(_1_152, _4_155, match_var)
-        local memory_dict : DictAccess* = memory_dict
-        local msize = msize
-        local pedersen_ptr : HashBuiltin* = pedersen_ptr
-        local range_check_ptr = range_check_ptr
-        local storage_ptr : Storage* = storage_ptr
-        return ()
-    end
-end
-
-func __warp_block_25{
-        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
-        storage_ptr : Storage*}(_1_152 : Uint256, _4_155 : Uint256, match_var : Uint256) -> ():
-    alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = is_eq(match_var, Uint256(low=2287400825, high=0))
-    local range_check_ptr = range_check_ptr
-    __warp_block_26_if{
-        memory_dict=memory_dict,
-        msize=msize,
-        pedersen_ptr=pedersen_ptr,
-        range_check_ptr=range_check_ptr,
-        storage_ptr=storage_ptr}(_1_152, _4_155, __warp_subexpr_0, match_var)
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local range_check_ptr = range_check_ptr
-    local storage_ptr : Storage* = storage_ptr
-    return ()
-end
-
-func __warp_block_23_if{
-        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
-        storage_ptr : Storage*}(
-        _1_152 : Uint256, _4_155 : Uint256, _7_158 : Uint256, __warp_subexpr_0 : Uint256,
-        match_var : Uint256) -> ():
-    alloc_locals
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        __warp_block_24{
-            memory_dict=memory_dict,
-            msize=msize,
-            pedersen_ptr=pedersen_ptr,
-            range_check_ptr=range_check_ptr,
-            storage_ptr=storage_ptr}(_1_152, _4_155, _7_158)
-        local memory_dict : DictAccess* = memory_dict
-        local msize = msize
-        local pedersen_ptr : HashBuiltin* = pedersen_ptr
-        local range_check_ptr = range_check_ptr
-        local storage_ptr : Storage* = storage_ptr
-        return ()
-    else:
         __warp_block_25{
             memory_dict=memory_dict,
             msize=msize,
             pedersen_ptr=pedersen_ptr,
             range_check_ptr=range_check_ptr,
+            storage_ptr=storage_ptr}(_1_152, _4_155)
+        local memory_dict : DictAccess* = memory_dict
+        local msize = msize
+        local pedersen_ptr : HashBuiltin* = pedersen_ptr
+        local range_check_ptr = range_check_ptr
+        local storage_ptr : Storage* = storage_ptr
+        return ()
+    else:
+        __warp_block_26{
+            memory_dict=memory_dict,
+            msize=msize,
+            pedersen_ptr=pedersen_ptr,
+            range_check_ptr=range_check_ptr,
             storage_ptr=storage_ptr}(_1_152, _4_155, match_var)
         local memory_dict : DictAccess* = memory_dict
         local msize = msize
@@ -1432,19 +1105,18 @@ func __warp_block_23_if{
     end
 end
 
-func __warp_block_21{
+func __warp_block_23{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
-        storage_ptr : Storage*}(
-        _1_152 : Uint256, _4_155 : Uint256, _7_158 : Uint256, match_var : Uint256) -> ():
+        storage_ptr : Storage*}(_1_152 : Uint256, _4_155 : Uint256, match_var : Uint256) -> ():
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = is_eq(match_var, Uint256(low=1142570608, high=0))
+    let (local __warp_subexpr_0 : Uint256) = is_eq(match_var, Uint256(low=3433131944, high=0))
     local range_check_ptr = range_check_ptr
-    __warp_block_23_if{
+    __warp_block_24_if{
         memory_dict=memory_dict,
         msize=msize,
         pedersen_ptr=pedersen_ptr,
         range_check_ptr=range_check_ptr,
-        storage_ptr=storage_ptr}(_1_152, _4_155, _7_158, __warp_subexpr_0, match_var)
+        storage_ptr=storage_ptr}(_1_152, _4_155, __warp_subexpr_0, match_var)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
@@ -1453,19 +1125,18 @@ func __warp_block_21{
     return ()
 end
 
-func __warp_block_19_if{
+func __warp_block_21_if{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(
-        _1_152 : Uint256, _4_155 : Uint256, _7_158 : Uint256, __warp_subexpr_0 : Uint256,
-        match_var : Uint256) -> ():
+        _1_152 : Uint256, _4_155 : Uint256, __warp_subexpr_0 : Uint256, match_var : Uint256) -> ():
     alloc_locals
     if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        __warp_block_20{
+        __warp_block_22{
             memory_dict=memory_dict,
             msize=msize,
             pedersen_ptr=pedersen_ptr,
             range_check_ptr=range_check_ptr,
-            storage_ptr=storage_ptr}(_1_152, _4_155, _7_158)
+            storage_ptr=storage_ptr}(_1_152, _4_155)
         local memory_dict : DictAccess* = memory_dict
         local msize = msize
         local pedersen_ptr : HashBuiltin* = pedersen_ptr
@@ -1473,12 +1144,66 @@ func __warp_block_19_if{
         local storage_ptr : Storage* = storage_ptr
         return ()
     else:
-        __warp_block_21{
+        __warp_block_23{
             memory_dict=memory_dict,
             msize=msize,
             pedersen_ptr=pedersen_ptr,
             range_check_ptr=range_check_ptr,
-            storage_ptr=storage_ptr}(_1_152, _4_155, _7_158, match_var)
+            storage_ptr=storage_ptr}(_1_152, _4_155, match_var)
+        local memory_dict : DictAccess* = memory_dict
+        local msize = msize
+        local pedersen_ptr : HashBuiltin* = pedersen_ptr
+        local range_check_ptr = range_check_ptr
+        local storage_ptr : Storage* = storage_ptr
+        return ()
+    end
+end
+
+func __warp_block_20{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        storage_ptr : Storage*}(_1_152 : Uint256, _4_155 : Uint256, match_var : Uint256) -> ():
+    alloc_locals
+    let (local __warp_subexpr_0 : Uint256) = is_eq(match_var, Uint256(low=3093743780, high=0))
+    local range_check_ptr = range_check_ptr
+    __warp_block_21_if{
+        memory_dict=memory_dict,
+        msize=msize,
+        pedersen_ptr=pedersen_ptr,
+        range_check_ptr=range_check_ptr,
+        storage_ptr=storage_ptr}(_1_152, _4_155, __warp_subexpr_0, match_var)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    local storage_ptr : Storage* = storage_ptr
+    return ()
+end
+
+func __warp_block_18_if{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        storage_ptr : Storage*}(
+        _1_152 : Uint256, _4_155 : Uint256, __warp_subexpr_0 : Uint256, match_var : Uint256) -> ():
+    alloc_locals
+    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
+        __warp_block_19{
+            memory_dict=memory_dict,
+            msize=msize,
+            pedersen_ptr=pedersen_ptr,
+            range_check_ptr=range_check_ptr,
+            storage_ptr=storage_ptr}(_1_152, _4_155)
+        local memory_dict : DictAccess* = memory_dict
+        local msize = msize
+        local pedersen_ptr : HashBuiltin* = pedersen_ptr
+        local range_check_ptr = range_check_ptr
+        local storage_ptr : Storage* = storage_ptr
+        return ()
+    else:
+        __warp_block_20{
+            memory_dict=memory_dict,
+            msize=msize,
+            pedersen_ptr=pedersen_ptr,
+            range_check_ptr=range_check_ptr,
+            storage_ptr=storage_ptr}(_1_152, _4_155, match_var)
         local memory_dict : DictAccess* = memory_dict
         local msize = msize
         local pedersen_ptr : HashBuiltin* = pedersen_ptr
@@ -1490,17 +1215,16 @@ end
 
 func __warp_block_17{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
-        storage_ptr : Storage*}(
-        _1_152 : Uint256, _4_155 : Uint256, _7_158 : Uint256, match_var : Uint256) -> ():
+        storage_ptr : Storage*}(_1_152 : Uint256, _4_155 : Uint256, match_var : Uint256) -> ():
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = is_eq(match_var, Uint256(low=826074471, high=0))
+    let (local __warp_subexpr_0 : Uint256) = is_eq(match_var, Uint256(low=2630350600, high=0))
     local range_check_ptr = range_check_ptr
-    __warp_block_19_if{
+    __warp_block_18_if{
         memory_dict=memory_dict,
         msize=msize,
         pedersen_ptr=pedersen_ptr,
         range_check_ptr=range_check_ptr,
-        storage_ptr=storage_ptr}(_1_152, _4_155, _7_158, __warp_subexpr_0, match_var)
+        storage_ptr=storage_ptr}(_1_152, _4_155, __warp_subexpr_0, match_var)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
@@ -1512,8 +1236,7 @@ end
 func __warp_block_15_if{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(
-        _1_152 : Uint256, _2_153 : Uint256, _4_155 : Uint256, _7_158 : Uint256,
-        __warp_subexpr_0 : Uint256, match_var : Uint256) -> ():
+        _1_152 : Uint256, _4_155 : Uint256, __warp_subexpr_0 : Uint256, match_var : Uint256) -> ():
     alloc_locals
     if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
         __warp_block_16{
@@ -1521,7 +1244,7 @@ func __warp_block_15_if{
             msize=msize,
             pedersen_ptr=pedersen_ptr,
             range_check_ptr=range_check_ptr,
-            storage_ptr=storage_ptr}(_2_153, _4_155)
+            storage_ptr=storage_ptr}(_1_152, _4_155)
         local memory_dict : DictAccess* = memory_dict
         local msize = msize
         local pedersen_ptr : HashBuiltin* = pedersen_ptr
@@ -1534,7 +1257,7 @@ func __warp_block_15_if{
             msize=msize,
             pedersen_ptr=pedersen_ptr,
             range_check_ptr=range_check_ptr,
-            storage_ptr=storage_ptr}(_1_152, _4_155, _7_158, match_var)
+            storage_ptr=storage_ptr}(_1_152, _4_155, match_var)
         local memory_dict : DictAccess* = memory_dict
         local msize = msize
         local pedersen_ptr : HashBuiltin* = pedersen_ptr
@@ -1546,13 +1269,180 @@ end
 
 func __warp_block_14{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        storage_ptr : Storage*}(_1_152 : Uint256, _4_155 : Uint256, match_var : Uint256) -> ():
+    alloc_locals
+    let (local __warp_subexpr_0 : Uint256) = is_eq(match_var, Uint256(low=2287400825, high=0))
+    local range_check_ptr = range_check_ptr
+    __warp_block_15_if{
+        memory_dict=memory_dict,
+        msize=msize,
+        pedersen_ptr=pedersen_ptr,
+        range_check_ptr=range_check_ptr,
+        storage_ptr=storage_ptr}(_1_152, _4_155, __warp_subexpr_0, match_var)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    local storage_ptr : Storage* = storage_ptr
+    return ()
+end
+
+func __warp_block_12_if{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        storage_ptr : Storage*}(
+        _1_152 : Uint256, _4_155 : Uint256, _7_158 : Uint256, __warp_subexpr_0 : Uint256,
+        match_var : Uint256) -> ():
+    alloc_locals
+    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
+        __warp_block_13{
+            memory_dict=memory_dict,
+            msize=msize,
+            pedersen_ptr=pedersen_ptr,
+            range_check_ptr=range_check_ptr,
+            storage_ptr=storage_ptr}(_1_152, _4_155, _7_158)
+        local memory_dict : DictAccess* = memory_dict
+        local msize = msize
+        local pedersen_ptr : HashBuiltin* = pedersen_ptr
+        local range_check_ptr = range_check_ptr
+        local storage_ptr : Storage* = storage_ptr
+        return ()
+    else:
+        __warp_block_14{
+            memory_dict=memory_dict,
+            msize=msize,
+            pedersen_ptr=pedersen_ptr,
+            range_check_ptr=range_check_ptr,
+            storage_ptr=storage_ptr}(_1_152, _4_155, match_var)
+        local memory_dict : DictAccess* = memory_dict
+        local msize = msize
+        local pedersen_ptr : HashBuiltin* = pedersen_ptr
+        local range_check_ptr = range_check_ptr
+        local storage_ptr : Storage* = storage_ptr
+        return ()
+    end
+end
+
+func __warp_block_11{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        storage_ptr : Storage*}(
+        _1_152 : Uint256, _4_155 : Uint256, _7_158 : Uint256, match_var : Uint256) -> ():
+    alloc_locals
+    let (local __warp_subexpr_0 : Uint256) = is_eq(match_var, Uint256(low=1142570608, high=0))
+    local range_check_ptr = range_check_ptr
+    __warp_block_12_if{
+        memory_dict=memory_dict,
+        msize=msize,
+        pedersen_ptr=pedersen_ptr,
+        range_check_ptr=range_check_ptr,
+        storage_ptr=storage_ptr}(_1_152, _4_155, _7_158, __warp_subexpr_0, match_var)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    local storage_ptr : Storage* = storage_ptr
+    return ()
+end
+
+func __warp_block_9_if{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        storage_ptr : Storage*}(
+        _1_152 : Uint256, _4_155 : Uint256, _7_158 : Uint256, __warp_subexpr_0 : Uint256,
+        match_var : Uint256) -> ():
+    alloc_locals
+    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
+        __warp_block_10{
+            memory_dict=memory_dict,
+            msize=msize,
+            pedersen_ptr=pedersen_ptr,
+            range_check_ptr=range_check_ptr,
+            storage_ptr=storage_ptr}(_1_152, _4_155, _7_158)
+        local memory_dict : DictAccess* = memory_dict
+        local msize = msize
+        local pedersen_ptr : HashBuiltin* = pedersen_ptr
+        local range_check_ptr = range_check_ptr
+        local storage_ptr : Storage* = storage_ptr
+        return ()
+    else:
+        __warp_block_11{
+            memory_dict=memory_dict,
+            msize=msize,
+            pedersen_ptr=pedersen_ptr,
+            range_check_ptr=range_check_ptr,
+            storage_ptr=storage_ptr}(_1_152, _4_155, _7_158, match_var)
+        local memory_dict : DictAccess* = memory_dict
+        local msize = msize
+        local pedersen_ptr : HashBuiltin* = pedersen_ptr
+        local range_check_ptr = range_check_ptr
+        local storage_ptr : Storage* = storage_ptr
+        return ()
+    end
+end
+
+func __warp_block_8{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        storage_ptr : Storage*}(
+        _1_152 : Uint256, _4_155 : Uint256, _7_158 : Uint256, match_var : Uint256) -> ():
+    alloc_locals
+    let (local __warp_subexpr_0 : Uint256) = is_eq(match_var, Uint256(low=826074471, high=0))
+    local range_check_ptr = range_check_ptr
+    __warp_block_9_if{
+        memory_dict=memory_dict,
+        msize=msize,
+        pedersen_ptr=pedersen_ptr,
+        range_check_ptr=range_check_ptr,
+        storage_ptr=storage_ptr}(_1_152, _4_155, _7_158, __warp_subexpr_0, match_var)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    local storage_ptr : Storage* = storage_ptr
+    return ()
+end
+
+func __warp_block_6_if{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        storage_ptr : Storage*}(
+        _1_152 : Uint256, _2_153 : Uint256, _4_155 : Uint256, _7_158 : Uint256,
+        __warp_subexpr_0 : Uint256, match_var : Uint256) -> ():
+    alloc_locals
+    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
+        __warp_block_7{
+            memory_dict=memory_dict,
+            msize=msize,
+            pedersen_ptr=pedersen_ptr,
+            range_check_ptr=range_check_ptr,
+            storage_ptr=storage_ptr}(_2_153, _4_155)
+        local memory_dict : DictAccess* = memory_dict
+        local msize = msize
+        local pedersen_ptr : HashBuiltin* = pedersen_ptr
+        local range_check_ptr = range_check_ptr
+        local storage_ptr : Storage* = storage_ptr
+        return ()
+    else:
+        __warp_block_8{
+            memory_dict=memory_dict,
+            msize=msize,
+            pedersen_ptr=pedersen_ptr,
+            range_check_ptr=range_check_ptr,
+            storage_ptr=storage_ptr}(_1_152, _4_155, _7_158, match_var)
+        local memory_dict : DictAccess* = memory_dict
+        local msize = msize
+        local pedersen_ptr : HashBuiltin* = pedersen_ptr
+        local range_check_ptr = range_check_ptr
+        local storage_ptr : Storage* = storage_ptr
+        return ()
+    end
+end
+
+func __warp_block_5{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(
         _1_152 : Uint256, _2_153 : Uint256, _4_155 : Uint256, _7_158 : Uint256,
         match_var : Uint256) -> ():
     alloc_locals
     let (local __warp_subexpr_0 : Uint256) = is_eq(match_var, Uint256(low=404098525, high=0))
     local range_check_ptr = range_check_ptr
-    __warp_block_15_if{
+    __warp_block_6_if{
         memory_dict=memory_dict,
         msize=msize,
         pedersen_ptr=pedersen_ptr,
@@ -1566,14 +1456,14 @@ func __warp_block_14{
     return ()
 end
 
-func __warp_block_13{
+func __warp_block_4{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(
         _10_161 : Uint256, _1_152 : Uint256, _2_153 : Uint256, _4_155 : Uint256,
         _7_158 : Uint256) -> ():
     alloc_locals
     local match_var : Uint256 = _10_161
-    __warp_block_14{
+    __warp_block_5{
         memory_dict=memory_dict,
         msize=msize,
         pedersen_ptr=pedersen_ptr,
@@ -1587,7 +1477,7 @@ func __warp_block_13{
     return ()
 end
 
-func __warp_block_12{
+func __warp_block_3{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(_1_152 : Uint256, _2_153 : Uint256, _4_155 : Uint256) -> ():
     alloc_locals
@@ -1596,7 +1486,7 @@ func __warp_block_12{
     local _9_160 : Uint256 = Uint256(low=224, high=0)
     let (local _10_161 : Uint256) = uint256_shr(_9_160, _8_159)
     local range_check_ptr = range_check_ptr
-    __warp_block_13{
+    __warp_block_4{
         memory_dict=memory_dict,
         msize=msize,
         pedersen_ptr=pedersen_ptr,
@@ -1610,13 +1500,13 @@ func __warp_block_12{
     return ()
 end
 
-func __warp_block_9_if{
+func __warp_block_1_if{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(
         _1_152 : Uint256, _2_153 : Uint256, _4_155 : Uint256, _6_157 : Uint256) -> ():
     alloc_locals
     if _6_157.low + _6_157.high != 0:
-        __warp_block_12{
+        __warp_block_3{
             memory_dict=memory_dict,
             msize=msize,
             pedersen_ptr=pedersen_ptr,
@@ -1652,7 +1542,7 @@ func fun_ENTRY_POINT{
     local range_check_ptr = range_check_ptr
     let (local _6_157 : Uint256) = is_zero(_5_156)
     local range_check_ptr = range_check_ptr
-    __warp_block_9_if{
+    __warp_block_1_if{
         memory_dict=memory_dict,
         msize=msize,
         pedersen_ptr=pedersen_ptr,

--- a/tests/yul/ERC20.cairo
+++ b/tests/yul/ERC20.cairo
@@ -301,12 +301,6 @@ func abi_encode_uint8{memory_dict : DictAccess*, msize, range_check_ptr}(
     return (tail_60)
 end
 
-func panic_error_0x11() -> ():
-    alloc_locals
-    assert 0 = 1
-    jmp rel 0
-end
-
 func __warp_block_5_if(_2_63 : Uint256) -> ():
     alloc_locals
     if _2_63.low + _2_63.high != 0:
@@ -535,12 +529,6 @@ func read_from_storage_split_dynamic_uint256{
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     let (local value_140 : Uint256) = cleanup_from_storage_uint256(_1_141)
     return (value_140)
-end
-
-func __warp_block_11() -> ():
-    alloc_locals
-    assert 0 = 1
-    jmp rel 0
 end
 
 func __warp_block_8_if(_1_142 : Uint256) -> ():

--- a/tests/yul/ERC20_storage.cairo
+++ b/tests/yul/ERC20_storage.cairo
@@ -46,7 +46,7 @@ func get_storage_high{storage_ptr : Storage*, range_check_ptr, pedersen_ptr : Ha
     return (res=storage_val_high)
 end
 
-func __warp_block_0_if(_4 : Uint256) -> ():
+func __warp_block_00(_4 : Uint256) -> ():
     alloc_locals
     if _4.low + _4.high != 0:
         assert 0 = 1
@@ -65,18 +65,8 @@ func abi_decode{range_check_ptr}(dataEnd : Uint256) -> ():
     local range_check_ptr = range_check_ptr
     let (local _4 : Uint256) = slt(_3, _1)
     local range_check_ptr = range_check_ptr
-    __warp_block_0_if(_4)
+    __warp_block_00(_4)
     return ()
-end
-
-func __warp_block_1_if(_4_5 : Uint256) -> ():
-    alloc_locals
-    if _4_5.low + _4_5.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
 end
 
 func abi_decode_uint256{range_check_ptr}(dataEnd_1 : Uint256) -> (value0 : Uint256):
@@ -88,20 +78,10 @@ func abi_decode_uint256{range_check_ptr}(dataEnd_1 : Uint256) -> (value0 : Uint2
     local range_check_ptr = range_check_ptr
     let (local _4_5 : Uint256) = slt(_3_4, _1_2)
     local range_check_ptr = range_check_ptr
-    __warp_block_1_if(_4_5)
+    __warp_block_00(_4_5)
     local _5 : Uint256 = Uint256(low=4, high=0)
     local value0 : Uint256 = Uint256(31597865, 9284653)
     return (value0)
-end
-
-func __warp_block_2_if(_4_11 : Uint256) -> ():
-    alloc_locals
-    if _4_11.low + _4_11.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
 end
 
 func abi_decode_uint256t_uint256{range_check_ptr}(dataEnd_6 : Uint256) -> (
@@ -114,22 +94,12 @@ func abi_decode_uint256t_uint256{range_check_ptr}(dataEnd_6 : Uint256) -> (
     local range_check_ptr = range_check_ptr
     let (local _4_11 : Uint256) = slt(_3_10, _1_8)
     local range_check_ptr = range_check_ptr
-    __warp_block_2_if(_4_11)
+    __warp_block_00(_4_11)
     local _5_12 : Uint256 = Uint256(low=4, high=0)
     local value0_7 : Uint256 = Uint256(31597865, 9284653)
     local _6 : Uint256 = Uint256(low=36, high=0)
     local value1 : Uint256 = Uint256(31597865, 9284653)
     return (value0_7, value1)
-end
-
-func __warp_block_3_if(_4_19 : Uint256) -> ():
-    alloc_locals
-    if _4_19.low + _4_19.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
 end
 
 func abi_decode_uint256t_uint256t_uint256{range_check_ptr}(dataEnd_13 : Uint256) -> (
@@ -142,7 +112,7 @@ func abi_decode_uint256t_uint256t_uint256{range_check_ptr}(dataEnd_13 : Uint256)
     local range_check_ptr = range_check_ptr
     let (local _4_19 : Uint256) = slt(_3_18, _1_16)
     local range_check_ptr = range_check_ptr
-    __warp_block_3_if(_4_19)
+    __warp_block_00(_4_19)
     local _5_20 : Uint256 = Uint256(low=4, high=0)
     local value0_14 : Uint256 = Uint256(31597865, 9284653)
     local _6_21 : Uint256 = Uint256(low=36, high=0)
@@ -150,16 +120,6 @@ func abi_decode_uint256t_uint256t_uint256{range_check_ptr}(dataEnd_13 : Uint256)
     local _7 : Uint256 = Uint256(low=68, high=0)
     local value2 : Uint256 = Uint256(31597865, 9284653)
     return (value0_14, value1_15, value2)
-end
-
-func __warp_block_4_if(_4_29 : Uint256) -> ():
-    alloc_locals
-    if _4_29.low + _4_29.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
 end
 
 func abi_decode_uint256t_uint256t_uint256t_uint256{range_check_ptr}(dataEnd_22 : Uint256) -> (
@@ -172,7 +132,7 @@ func abi_decode_uint256t_uint256t_uint256t_uint256{range_check_ptr}(dataEnd_22 :
     local range_check_ptr = range_check_ptr
     let (local _4_29 : Uint256) = slt(_3_28, _1_26)
     local range_check_ptr = range_check_ptr
-    __warp_block_4_if(_4_29)
+    __warp_block_00(_4_29)
     local _5_30 : Uint256 = Uint256(low=4, high=0)
     local value0_23 : Uint256 = Uint256(31597865, 9284653)
     local _6_31 : Uint256 = Uint256(low=36, high=0)
@@ -283,31 +243,11 @@ func abi_encode_uint8{memory_dict : DictAccess*, msize, range_check_ptr}(
     return (tail_53)
 end
 
-func __warp_block_5_if(_2_56 : Uint256) -> ():
-    alloc_locals
-    if _2_56.low + _2_56.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
-func __warp_block_6_if(_1_59 : Uint256) -> ():
-    alloc_locals
-    if _1_59.low + _1_59.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
 func checked_sub_uint256{range_check_ptr}(x_57 : Uint256, y_58 : Uint256) -> (diff : Uint256):
     alloc_locals
     let (local _1_59 : Uint256) = is_lt(x_57, y_58)
     local range_check_ptr = range_check_ptr
-    __warp_block_6_if(_1_59)
+    __warp_block_00(_1_59)
     let (local diff : Uint256) = uint256_sub(x_57, y_58)
     local range_check_ptr = range_check_ptr
     return (diff)
@@ -536,25 +476,15 @@ func fun_get_balance_external{
     return (var.low, var.high)
 end
 
-func __warp_block_8_if(_1_136 : Uint256) -> ():
-    alloc_locals
-    if _1_136.low + _1_136.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
 func require_helper{range_check_ptr}(condition : Uint256) -> ():
     alloc_locals
     let (local _1_136 : Uint256) = is_zero(condition)
     local range_check_ptr = range_check_ptr
-    __warp_block_8_if(_1_136)
+    __warp_block_00(_1_136)
     return ()
 end
 
-func __warp_block_10{
+func __warp_block_2{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(
         var_sender_73 : Uint256, var_src_71 : Uint256, var_wad_72 : Uint256) -> ():
@@ -620,13 +550,13 @@ func __warp_block_10{
     return ()
 end
 
-func __warp_block_7_if{
+func __warp_block_0_if{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(
         _2_76 : Uint256, var_sender_73 : Uint256, var_src_71 : Uint256, var_wad_72 : Uint256) -> ():
     alloc_locals
     if _2_76.low + _2_76.high != 0:
-        __warp_block_10{
+        __warp_block_2{
             memory_dict=memory_dict,
             msize=msize,
             pedersen_ptr=pedersen_ptr,
@@ -653,7 +583,7 @@ func fun_transferFrom{
     local range_check_ptr = range_check_ptr
     let (local _2_76 : Uint256) = is_zero(_1_75)
     local range_check_ptr = range_check_ptr
-    __warp_block_7_if{
+    __warp_block_0_if{
         memory_dict=memory_dict,
         msize=msize,
         pedersen_ptr=pedersen_ptr,
@@ -831,22 +761,12 @@ func mapping_index_access_mapping_uint256_mapping_uint256_uint256_of_uint256_563
     return (dataSlot)
 end
 
-func __warp_block_18_if(_11_156 : Uint256) -> ():
-    alloc_locals
-    if _11_156.low + _11_156.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
-func __warp_block_16{
+func __warp_block_7{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(_2_147 : Uint256, _4_149 : Uint256) -> ():
     alloc_locals
     local _11_156 : Uint256 = Uint256(0, 0)
-    __warp_block_18_if(_11_156)
+    __warp_block_00(_11_156)
     local _12_157 : Uint256 = _4_149
     abi_decode{range_check_ptr=range_check_ptr}(_4_149)
     local range_check_ptr = range_check_ptr
@@ -870,22 +790,12 @@ func __warp_block_16{
     return ()
 end
 
-func __warp_block_22_if(_20_165 : Uint256) -> ():
-    alloc_locals
-    if _20_165.low + _20_165.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
-func __warp_block_20{
+func __warp_block_10{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(_1_146 : Uint256, _4_149 : Uint256, _7_152 : Uint256) -> ():
     alloc_locals
     local _20_165 : Uint256 = Uint256(0, 0)
-    __warp_block_22_if(_20_165)
+    __warp_block_00(_20_165)
     local _21_166 : Uint256 = _4_149
     abi_decode{range_check_ptr=range_check_ptr}(_4_149)
     local range_check_ptr = range_check_ptr
@@ -912,7 +822,7 @@ func __warp_block_20{
     return ()
 end
 
-func __warp_block_24{
+func __warp_block_13{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(_1_146 : Uint256, _4_149 : Uint256, _7_152 : Uint256) -> ():
     alloc_locals
@@ -940,22 +850,12 @@ func __warp_block_24{
     return ()
 end
 
-func __warp_block_29_if(_29 : Uint256) -> ():
-    alloc_locals
-    if _29.low + _29.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
-func __warp_block_27{
+func __warp_block_16{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(_1_146 : Uint256, _4_149 : Uint256) -> ():
     alloc_locals
     local _29 : Uint256 = Uint256(0, 0)
-    __warp_block_29_if(_29)
+    __warp_block_00(_29)
     local _30 : Uint256 = _4_149
     let (local _31 : Uint256) = abi_decode_uint256{range_check_ptr=range_check_ptr}(_4_149)
     local range_check_ptr = range_check_ptr
@@ -981,7 +881,7 @@ func __warp_block_27{
     return ()
 end
 
-func __warp_block_31{
+func __warp_block_19{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(_1_146 : Uint256, _4_149 : Uint256) -> ():
     alloc_locals
@@ -1016,22 +916,12 @@ func __warp_block_31{
     return ()
 end
 
-func __warp_block_36_if(_37 : Uint256) -> ():
-    alloc_locals
-    if _37.low + _37.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
-func __warp_block_34{
+func __warp_block_22{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(_1_146 : Uint256, _4_149 : Uint256) -> ():
     alloc_locals
     local _37 : Uint256 = Uint256(0, 0)
-    __warp_block_36_if(_37)
+    __warp_block_00(_37)
     local _38 : Uint256 = _4_149
     let (local _39 : Uint256) = abi_decode_uint256{range_check_ptr=range_check_ptr}(_4_149)
     local range_check_ptr = range_check_ptr
@@ -1057,7 +947,7 @@ func __warp_block_34{
     return ()
 end
 
-func __warp_block_38{
+func __warp_block_25{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(_1_146 : Uint256, _4_149 : Uint256) -> ():
     alloc_locals
@@ -1088,22 +978,12 @@ func __warp_block_38{
     return ()
 end
 
-func __warp_block_43_if(_45 : Uint256) -> ():
-    alloc_locals
-    if _45.low + _45.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
-func __warp_block_41{
+func __warp_block_28{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(_1_146 : Uint256, _4_149 : Uint256) -> ():
     alloc_locals
     local _45 : Uint256 = Uint256(0, 0)
-    __warp_block_43_if(_45)
+    __warp_block_00(_45)
     local _46 : Uint256 = _4_149
     let (local param_9 : Uint256, local param_10 : Uint256) = abi_decode_uint256t_uint256{
         range_check_ptr=range_check_ptr}(_4_149)
@@ -1137,7 +1017,7 @@ func __warp_block_41{
     return ()
 end
 
-func __warp_block_45{
+func __warp_block_31{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(_1_146 : Uint256, _4_149 : Uint256, _7_152 : Uint256) -> ():
     alloc_locals
@@ -1165,13 +1045,13 @@ func __warp_block_45{
     return ()
 end
 
-func __warp_block_44_if{
+func __warp_block_30_if{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(
         _1_146 : Uint256, _4_149 : Uint256, _7_152 : Uint256, __warp_subexpr_0 : Uint256) -> ():
     alloc_locals
     if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        __warp_block_45{
+        __warp_block_31{
             memory_dict=memory_dict,
             msize=msize,
             pedersen_ptr=pedersen_ptr,
@@ -1188,14 +1068,14 @@ func __warp_block_44_if{
     end
 end
 
-func __warp_block_42{
+func __warp_block_29{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(
         _1_146 : Uint256, _4_149 : Uint256, _7_152 : Uint256, match_var : Uint256) -> ():
     alloc_locals
     let (local __warp_subexpr_0 : Uint256) = is_eq(match_var, Uint256(low=3803951448, high=0))
     local range_check_ptr = range_check_ptr
-    __warp_block_44_if{
+    __warp_block_30_if{
         memory_dict=memory_dict,
         msize=msize,
         pedersen_ptr=pedersen_ptr,
@@ -1209,14 +1089,14 @@ func __warp_block_42{
     return ()
 end
 
-func __warp_block_40_if{
+func __warp_block_27_if{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(
         _1_146 : Uint256, _4_149 : Uint256, _7_152 : Uint256, __warp_subexpr_0 : Uint256,
         match_var : Uint256) -> ():
     alloc_locals
     if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        __warp_block_41{
+        __warp_block_28{
             memory_dict=memory_dict,
             msize=msize,
             pedersen_ptr=pedersen_ptr,
@@ -1229,7 +1109,7 @@ func __warp_block_40_if{
         local storage_ptr : Storage* = storage_ptr
         return ()
     else:
-        __warp_block_42{
+        __warp_block_29{
             memory_dict=memory_dict,
             msize=msize,
             pedersen_ptr=pedersen_ptr,
@@ -1244,14 +1124,14 @@ func __warp_block_40_if{
     end
 end
 
-func __warp_block_39{
+func __warp_block_26{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(
         _1_146 : Uint256, _4_149 : Uint256, _7_152 : Uint256, match_var : Uint256) -> ():
     alloc_locals
     let (local __warp_subexpr_0 : Uint256) = is_eq(match_var, Uint256(low=3433131944, high=0))
     local range_check_ptr = range_check_ptr
-    __warp_block_40_if{
+    __warp_block_27_if{
         memory_dict=memory_dict,
         msize=msize,
         pedersen_ptr=pedersen_ptr,
@@ -1265,14 +1145,14 @@ func __warp_block_39{
     return ()
 end
 
-func __warp_block_37_if{
+func __warp_block_24_if{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(
         _1_146 : Uint256, _4_149 : Uint256, _7_152 : Uint256, __warp_subexpr_0 : Uint256,
         match_var : Uint256) -> ():
     alloc_locals
     if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        __warp_block_38{
+        __warp_block_25{
             memory_dict=memory_dict,
             msize=msize,
             pedersen_ptr=pedersen_ptr,
@@ -1285,7 +1165,7 @@ func __warp_block_37_if{
         local storage_ptr : Storage* = storage_ptr
         return ()
     else:
-        __warp_block_39{
+        __warp_block_26{
             memory_dict=memory_dict,
             msize=msize,
             pedersen_ptr=pedersen_ptr,
@@ -1300,14 +1180,14 @@ func __warp_block_37_if{
     end
 end
 
-func __warp_block_35{
+func __warp_block_23{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(
         _1_146 : Uint256, _4_149 : Uint256, _7_152 : Uint256, match_var : Uint256) -> ():
     alloc_locals
     let (local __warp_subexpr_0 : Uint256) = is_eq(match_var, Uint256(low=3093743780, high=0))
     local range_check_ptr = range_check_ptr
-    __warp_block_37_if{
+    __warp_block_24_if{
         memory_dict=memory_dict,
         msize=msize,
         pedersen_ptr=pedersen_ptr,
@@ -1321,14 +1201,14 @@ func __warp_block_35{
     return ()
 end
 
-func __warp_block_33_if{
+func __warp_block_21_if{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(
         _1_146 : Uint256, _4_149 : Uint256, _7_152 : Uint256, __warp_subexpr_0 : Uint256,
         match_var : Uint256) -> ():
     alloc_locals
     if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        __warp_block_34{
+        __warp_block_22{
             memory_dict=memory_dict,
             msize=msize,
             pedersen_ptr=pedersen_ptr,
@@ -1341,7 +1221,7 @@ func __warp_block_33_if{
         local storage_ptr : Storage* = storage_ptr
         return ()
     else:
-        __warp_block_35{
+        __warp_block_23{
             memory_dict=memory_dict,
             msize=msize,
             pedersen_ptr=pedersen_ptr,
@@ -1356,14 +1236,14 @@ func __warp_block_33_if{
     end
 end
 
-func __warp_block_32{
+func __warp_block_20{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(
         _1_146 : Uint256, _4_149 : Uint256, _7_152 : Uint256, match_var : Uint256) -> ():
     alloc_locals
     let (local __warp_subexpr_0 : Uint256) = is_eq(match_var, Uint256(low=2630350600, high=0))
     local range_check_ptr = range_check_ptr
-    __warp_block_33_if{
+    __warp_block_21_if{
         memory_dict=memory_dict,
         msize=msize,
         pedersen_ptr=pedersen_ptr,
@@ -1377,14 +1257,14 @@ func __warp_block_32{
     return ()
 end
 
-func __warp_block_30_if{
+func __warp_block_18_if{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(
         _1_146 : Uint256, _4_149 : Uint256, _7_152 : Uint256, __warp_subexpr_0 : Uint256,
         match_var : Uint256) -> ():
     alloc_locals
     if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        __warp_block_31{
+        __warp_block_19{
             memory_dict=memory_dict,
             msize=msize,
             pedersen_ptr=pedersen_ptr,
@@ -1397,175 +1277,7 @@ func __warp_block_30_if{
         local storage_ptr : Storage* = storage_ptr
         return ()
     else:
-        __warp_block_32{
-            memory_dict=memory_dict,
-            msize=msize,
-            pedersen_ptr=pedersen_ptr,
-            range_check_ptr=range_check_ptr,
-            storage_ptr=storage_ptr}(_1_146, _4_149, _7_152, match_var)
-        local memory_dict : DictAccess* = memory_dict
-        local msize = msize
-        local pedersen_ptr : HashBuiltin* = pedersen_ptr
-        local range_check_ptr = range_check_ptr
-        local storage_ptr : Storage* = storage_ptr
-        return ()
-    end
-end
-
-func __warp_block_28{
-        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
-        storage_ptr : Storage*}(
-        _1_146 : Uint256, _4_149 : Uint256, _7_152 : Uint256, match_var : Uint256) -> ():
-    alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = is_eq(match_var, Uint256(low=2287400825, high=0))
-    local range_check_ptr = range_check_ptr
-    __warp_block_30_if{
-        memory_dict=memory_dict,
-        msize=msize,
-        pedersen_ptr=pedersen_ptr,
-        range_check_ptr=range_check_ptr,
-        storage_ptr=storage_ptr}(_1_146, _4_149, _7_152, __warp_subexpr_0, match_var)
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local range_check_ptr = range_check_ptr
-    local storage_ptr : Storage* = storage_ptr
-    return ()
-end
-
-func __warp_block_26_if{
-        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
-        storage_ptr : Storage*}(
-        _1_146 : Uint256, _4_149 : Uint256, _7_152 : Uint256, __warp_subexpr_0 : Uint256,
-        match_var : Uint256) -> ():
-    alloc_locals
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        __warp_block_27{
-            memory_dict=memory_dict,
-            msize=msize,
-            pedersen_ptr=pedersen_ptr,
-            range_check_ptr=range_check_ptr,
-            storage_ptr=storage_ptr}(_1_146, _4_149)
-        local memory_dict : DictAccess* = memory_dict
-        local msize = msize
-        local pedersen_ptr : HashBuiltin* = pedersen_ptr
-        local range_check_ptr = range_check_ptr
-        local storage_ptr : Storage* = storage_ptr
-        return ()
-    else:
-        __warp_block_28{
-            memory_dict=memory_dict,
-            msize=msize,
-            pedersen_ptr=pedersen_ptr,
-            range_check_ptr=range_check_ptr,
-            storage_ptr=storage_ptr}(_1_146, _4_149, _7_152, match_var)
-        local memory_dict : DictAccess* = memory_dict
-        local msize = msize
-        local pedersen_ptr : HashBuiltin* = pedersen_ptr
-        local range_check_ptr = range_check_ptr
-        local storage_ptr : Storage* = storage_ptr
-        return ()
-    end
-end
-
-func __warp_block_25{
-        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
-        storage_ptr : Storage*}(
-        _1_146 : Uint256, _4_149 : Uint256, _7_152 : Uint256, match_var : Uint256) -> ():
-    alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = is_eq(match_var, Uint256(low=1530952232, high=0))
-    local range_check_ptr = range_check_ptr
-    __warp_block_26_if{
-        memory_dict=memory_dict,
-        msize=msize,
-        pedersen_ptr=pedersen_ptr,
-        range_check_ptr=range_check_ptr,
-        storage_ptr=storage_ptr}(_1_146, _4_149, _7_152, __warp_subexpr_0, match_var)
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local range_check_ptr = range_check_ptr
-    local storage_ptr : Storage* = storage_ptr
-    return ()
-end
-
-func __warp_block_23_if{
-        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
-        storage_ptr : Storage*}(
-        _1_146 : Uint256, _4_149 : Uint256, _7_152 : Uint256, __warp_subexpr_0 : Uint256,
-        match_var : Uint256) -> ():
-    alloc_locals
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        __warp_block_24{
-            memory_dict=memory_dict,
-            msize=msize,
-            pedersen_ptr=pedersen_ptr,
-            range_check_ptr=range_check_ptr,
-            storage_ptr=storage_ptr}(_1_146, _4_149, _7_152)
-        local memory_dict : DictAccess* = memory_dict
-        local msize = msize
-        local pedersen_ptr : HashBuiltin* = pedersen_ptr
-        local range_check_ptr = range_check_ptr
-        local storage_ptr : Storage* = storage_ptr
-        return ()
-    else:
-        __warp_block_25{
-            memory_dict=memory_dict,
-            msize=msize,
-            pedersen_ptr=pedersen_ptr,
-            range_check_ptr=range_check_ptr,
-            storage_ptr=storage_ptr}(_1_146, _4_149, _7_152, match_var)
-        local memory_dict : DictAccess* = memory_dict
-        local msize = msize
-        local pedersen_ptr : HashBuiltin* = pedersen_ptr
-        local range_check_ptr = range_check_ptr
-        local storage_ptr : Storage* = storage_ptr
-        return ()
-    end
-end
-
-func __warp_block_21{
-        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
-        storage_ptr : Storage*}(
-        _1_146 : Uint256, _4_149 : Uint256, _7_152 : Uint256, match_var : Uint256) -> ():
-    alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = is_eq(match_var, Uint256(low=1142570608, high=0))
-    local range_check_ptr = range_check_ptr
-    __warp_block_23_if{
-        memory_dict=memory_dict,
-        msize=msize,
-        pedersen_ptr=pedersen_ptr,
-        range_check_ptr=range_check_ptr,
-        storage_ptr=storage_ptr}(_1_146, _4_149, _7_152, __warp_subexpr_0, match_var)
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local range_check_ptr = range_check_ptr
-    local storage_ptr : Storage* = storage_ptr
-    return ()
-end
-
-func __warp_block_19_if{
-        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
-        storage_ptr : Storage*}(
-        _1_146 : Uint256, _4_149 : Uint256, _7_152 : Uint256, __warp_subexpr_0 : Uint256,
-        match_var : Uint256) -> ():
-    alloc_locals
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
         __warp_block_20{
-            memory_dict=memory_dict,
-            msize=msize,
-            pedersen_ptr=pedersen_ptr,
-            range_check_ptr=range_check_ptr,
-            storage_ptr=storage_ptr}(_1_146, _4_149, _7_152)
-        local memory_dict : DictAccess* = memory_dict
-        local msize = msize
-        local pedersen_ptr : HashBuiltin* = pedersen_ptr
-        local range_check_ptr = range_check_ptr
-        local storage_ptr : Storage* = storage_ptr
-        return ()
-    else:
-        __warp_block_21{
             memory_dict=memory_dict,
             msize=msize,
             pedersen_ptr=pedersen_ptr,
@@ -1585,9 +1297,9 @@ func __warp_block_17{
         storage_ptr : Storage*}(
         _1_146 : Uint256, _4_149 : Uint256, _7_152 : Uint256, match_var : Uint256) -> ():
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = is_eq(match_var, Uint256(low=826074471, high=0))
+    let (local __warp_subexpr_0 : Uint256) = is_eq(match_var, Uint256(low=2287400825, high=0))
     local range_check_ptr = range_check_ptr
-    __warp_block_19_if{
+    __warp_block_18_if{
         memory_dict=memory_dict,
         msize=msize,
         pedersen_ptr=pedersen_ptr,
@@ -1604,8 +1316,8 @@ end
 func __warp_block_15_if{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(
-        _1_146 : Uint256, _2_147 : Uint256, _4_149 : Uint256, _7_152 : Uint256,
-        __warp_subexpr_0 : Uint256, match_var : Uint256) -> ():
+        _1_146 : Uint256, _4_149 : Uint256, _7_152 : Uint256, __warp_subexpr_0 : Uint256,
+        match_var : Uint256) -> ():
     alloc_locals
     if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
         __warp_block_16{
@@ -1613,7 +1325,7 @@ func __warp_block_15_if{
             msize=msize,
             pedersen_ptr=pedersen_ptr,
             range_check_ptr=range_check_ptr,
-            storage_ptr=storage_ptr}(_2_147, _4_149)
+            storage_ptr=storage_ptr}(_1_146, _4_149)
         local memory_dict : DictAccess* = memory_dict
         local msize = msize
         local pedersen_ptr : HashBuiltin* = pedersen_ptr
@@ -1639,12 +1351,180 @@ end
 func __warp_block_14{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(
+        _1_146 : Uint256, _4_149 : Uint256, _7_152 : Uint256, match_var : Uint256) -> ():
+    alloc_locals
+    let (local __warp_subexpr_0 : Uint256) = is_eq(match_var, Uint256(low=1530952232, high=0))
+    local range_check_ptr = range_check_ptr
+    __warp_block_15_if{
+        memory_dict=memory_dict,
+        msize=msize,
+        pedersen_ptr=pedersen_ptr,
+        range_check_ptr=range_check_ptr,
+        storage_ptr=storage_ptr}(_1_146, _4_149, _7_152, __warp_subexpr_0, match_var)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    local storage_ptr : Storage* = storage_ptr
+    return ()
+end
+
+func __warp_block_12_if{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        storage_ptr : Storage*}(
+        _1_146 : Uint256, _4_149 : Uint256, _7_152 : Uint256, __warp_subexpr_0 : Uint256,
+        match_var : Uint256) -> ():
+    alloc_locals
+    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
+        __warp_block_13{
+            memory_dict=memory_dict,
+            msize=msize,
+            pedersen_ptr=pedersen_ptr,
+            range_check_ptr=range_check_ptr,
+            storage_ptr=storage_ptr}(_1_146, _4_149, _7_152)
+        local memory_dict : DictAccess* = memory_dict
+        local msize = msize
+        local pedersen_ptr : HashBuiltin* = pedersen_ptr
+        local range_check_ptr = range_check_ptr
+        local storage_ptr : Storage* = storage_ptr
+        return ()
+    else:
+        __warp_block_14{
+            memory_dict=memory_dict,
+            msize=msize,
+            pedersen_ptr=pedersen_ptr,
+            range_check_ptr=range_check_ptr,
+            storage_ptr=storage_ptr}(_1_146, _4_149, _7_152, match_var)
+        local memory_dict : DictAccess* = memory_dict
+        local msize = msize
+        local pedersen_ptr : HashBuiltin* = pedersen_ptr
+        local range_check_ptr = range_check_ptr
+        local storage_ptr : Storage* = storage_ptr
+        return ()
+    end
+end
+
+func __warp_block_11{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        storage_ptr : Storage*}(
+        _1_146 : Uint256, _4_149 : Uint256, _7_152 : Uint256, match_var : Uint256) -> ():
+    alloc_locals
+    let (local __warp_subexpr_0 : Uint256) = is_eq(match_var, Uint256(low=1142570608, high=0))
+    local range_check_ptr = range_check_ptr
+    __warp_block_12_if{
+        memory_dict=memory_dict,
+        msize=msize,
+        pedersen_ptr=pedersen_ptr,
+        range_check_ptr=range_check_ptr,
+        storage_ptr=storage_ptr}(_1_146, _4_149, _7_152, __warp_subexpr_0, match_var)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    local storage_ptr : Storage* = storage_ptr
+    return ()
+end
+
+func __warp_block_9_if{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        storage_ptr : Storage*}(
+        _1_146 : Uint256, _4_149 : Uint256, _7_152 : Uint256, __warp_subexpr_0 : Uint256,
+        match_var : Uint256) -> ():
+    alloc_locals
+    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
+        __warp_block_10{
+            memory_dict=memory_dict,
+            msize=msize,
+            pedersen_ptr=pedersen_ptr,
+            range_check_ptr=range_check_ptr,
+            storage_ptr=storage_ptr}(_1_146, _4_149, _7_152)
+        local memory_dict : DictAccess* = memory_dict
+        local msize = msize
+        local pedersen_ptr : HashBuiltin* = pedersen_ptr
+        local range_check_ptr = range_check_ptr
+        local storage_ptr : Storage* = storage_ptr
+        return ()
+    else:
+        __warp_block_11{
+            memory_dict=memory_dict,
+            msize=msize,
+            pedersen_ptr=pedersen_ptr,
+            range_check_ptr=range_check_ptr,
+            storage_ptr=storage_ptr}(_1_146, _4_149, _7_152, match_var)
+        local memory_dict : DictAccess* = memory_dict
+        local msize = msize
+        local pedersen_ptr : HashBuiltin* = pedersen_ptr
+        local range_check_ptr = range_check_ptr
+        local storage_ptr : Storage* = storage_ptr
+        return ()
+    end
+end
+
+func __warp_block_8{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        storage_ptr : Storage*}(
+        _1_146 : Uint256, _4_149 : Uint256, _7_152 : Uint256, match_var : Uint256) -> ():
+    alloc_locals
+    let (local __warp_subexpr_0 : Uint256) = is_eq(match_var, Uint256(low=826074471, high=0))
+    local range_check_ptr = range_check_ptr
+    __warp_block_9_if{
+        memory_dict=memory_dict,
+        msize=msize,
+        pedersen_ptr=pedersen_ptr,
+        range_check_ptr=range_check_ptr,
+        storage_ptr=storage_ptr}(_1_146, _4_149, _7_152, __warp_subexpr_0, match_var)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    local storage_ptr : Storage* = storage_ptr
+    return ()
+end
+
+func __warp_block_6_if{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        storage_ptr : Storage*}(
+        _1_146 : Uint256, _2_147 : Uint256, _4_149 : Uint256, _7_152 : Uint256,
+        __warp_subexpr_0 : Uint256, match_var : Uint256) -> ():
+    alloc_locals
+    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
+        __warp_block_7{
+            memory_dict=memory_dict,
+            msize=msize,
+            pedersen_ptr=pedersen_ptr,
+            range_check_ptr=range_check_ptr,
+            storage_ptr=storage_ptr}(_2_147, _4_149)
+        local memory_dict : DictAccess* = memory_dict
+        local msize = msize
+        local pedersen_ptr : HashBuiltin* = pedersen_ptr
+        local range_check_ptr = range_check_ptr
+        local storage_ptr : Storage* = storage_ptr
+        return ()
+    else:
+        __warp_block_8{
+            memory_dict=memory_dict,
+            msize=msize,
+            pedersen_ptr=pedersen_ptr,
+            range_check_ptr=range_check_ptr,
+            storage_ptr=storage_ptr}(_1_146, _4_149, _7_152, match_var)
+        local memory_dict : DictAccess* = memory_dict
+        local msize = msize
+        local pedersen_ptr : HashBuiltin* = pedersen_ptr
+        local range_check_ptr = range_check_ptr
+        local storage_ptr : Storage* = storage_ptr
+        return ()
+    end
+end
+
+func __warp_block_5{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        storage_ptr : Storage*}(
         _1_146 : Uint256, _2_147 : Uint256, _4_149 : Uint256, _7_152 : Uint256,
         match_var : Uint256) -> ():
     alloc_locals
     let (local __warp_subexpr_0 : Uint256) = is_eq(match_var, Uint256(low=404098525, high=0))
     local range_check_ptr = range_check_ptr
-    __warp_block_15_if{
+    __warp_block_6_if{
         memory_dict=memory_dict,
         msize=msize,
         pedersen_ptr=pedersen_ptr,
@@ -1658,14 +1538,14 @@ func __warp_block_14{
     return ()
 end
 
-func __warp_block_13{
+func __warp_block_4{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(
         _10_155 : Uint256, _1_146 : Uint256, _2_147 : Uint256, _4_149 : Uint256,
         _7_152 : Uint256) -> ():
     alloc_locals
     local match_var : Uint256 = _10_155
-    __warp_block_14{
+    __warp_block_5{
         memory_dict=memory_dict,
         msize=msize,
         pedersen_ptr=pedersen_ptr,
@@ -1679,7 +1559,7 @@ func __warp_block_13{
     return ()
 end
 
-func __warp_block_12{
+func __warp_block_3{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(_1_146 : Uint256, _2_147 : Uint256, _4_149 : Uint256) -> ():
     alloc_locals
@@ -1688,7 +1568,7 @@ func __warp_block_12{
     local _9_154 : Uint256 = Uint256(low=224, high=0)
     let (local _10_155 : Uint256) = uint256_shr(_9_154, _8_153)
     local range_check_ptr = range_check_ptr
-    __warp_block_13{
+    __warp_block_4{
         memory_dict=memory_dict,
         msize=msize,
         pedersen_ptr=pedersen_ptr,
@@ -1702,13 +1582,13 @@ func __warp_block_12{
     return ()
 end
 
-func __warp_block_9_if{
+func __warp_block_1_if{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(
         _1_146 : Uint256, _2_147 : Uint256, _4_149 : Uint256, _6_151 : Uint256) -> ():
     alloc_locals
     if _6_151.low + _6_151.high != 0:
-        __warp_block_12{
+        __warp_block_3{
             memory_dict=memory_dict,
             msize=msize,
             pedersen_ptr=pedersen_ptr,
@@ -1744,7 +1624,7 @@ func fun_ENTRY_POINT{
     local range_check_ptr = range_check_ptr
     let (local _6_151 : Uint256) = is_zero(_5_150)
     local range_check_ptr = range_check_ptr
-    __warp_block_9_if{
+    __warp_block_1_if{
         memory_dict=memory_dict,
         msize=msize,
         pedersen_ptr=pedersen_ptr,

--- a/tests/yul/ERC20_storage.cairo
+++ b/tests/yul/ERC20_storage.cairo
@@ -283,12 +283,6 @@ func abi_encode_uint8{memory_dict : DictAccess*, msize, range_check_ptr}(
     return (tail_53)
 end
 
-func panic_error_0x11() -> ():
-    alloc_locals
-    assert 0 = 1
-    jmp rel 0
-end
-
 func __warp_block_5_if(_2_56 : Uint256) -> ():
     alloc_locals
     if _2_56.low + _2_56.high != 0:
@@ -540,12 +534,6 @@ func fun_get_balance_external{
     let (var) = fun_get_balance{memory_dict=memory_dict, msize=msize}(
         Uint256(var_src_low, var_src_high))
     return (var.low, var.high)
-end
-
-func __warp_block_11() -> ():
-    alloc_locals
-    assert 0 = 1
-    jmp rel 0
 end
 
 func __warp_block_8_if(_1_136 : Uint256) -> ():

--- a/tests/yul/for-loop-with-break.cairo
+++ b/tests/yul/for-loop-with-break.cairo
@@ -101,12 +101,6 @@ func abi_encode_bool{memory_dict : DictAccess*, msize, range_check_ptr}(
     return (tail)
 end
 
-func panic_error_0x11() -> ():
-    alloc_locals
-    assert 0 = 1
-    jmp rel 0
-end
-
 func __warp_block_1_if(_2_6 : Uint256) -> ():
     alloc_locals
     if _2_6.low + _2_6.high != 0:

--- a/tests/yul/for-loop-with-break.cairo
+++ b/tests/yul/for-loop-with-break.cairo
@@ -45,7 +45,7 @@ func get_storage_high{storage_ptr : Storage*, range_check_ptr, pedersen_ptr : Ha
     return (res=storage_val_high)
 end
 
-func __warp_block_0_if(_4 : Uint256) -> ():
+func __warp_block_00(_4 : Uint256) -> ():
     alloc_locals
     if _4.low + _4.high != 0:
         assert 0 = 1
@@ -65,7 +65,7 @@ func abi_decode_uint256t_uint256{range_check_ptr}(dataEnd : Uint256) -> (
     local range_check_ptr = range_check_ptr
     let (local _4 : Uint256) = slt(_3, _1)
     local range_check_ptr = range_check_ptr
-    __warp_block_0_if(_4)
+    __warp_block_00(_4)
     local _5 : Uint256 = Uint256(low=4, high=0)
     local value0 : Uint256 = Uint256(31597865, 9284653)
     local _6 : Uint256 = Uint256(low=36, high=0)
@@ -101,32 +101,12 @@ func abi_encode_bool{memory_dict : DictAccess*, msize, range_check_ptr}(
     return (tail)
 end
 
-func __warp_block_1_if(_2_6 : Uint256) -> ():
-    alloc_locals
-    if _2_6.low + _2_6.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
-func __warp_block_2_if(_2_9 : Uint256) -> ():
-    alloc_locals
-    if _2_9.low + _2_9.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
 func checked_sub_uint256{range_check_ptr}(x_7 : Uint256) -> (diff : Uint256):
     alloc_locals
     local _1_8 : Uint256 = Uint256(low=1, high=0)
     let (local _2_9 : Uint256) = is_lt(x_7, _1_8)
     local range_check_ptr = range_check_ptr
-    __warp_block_2_if(_2_9)
+    __warp_block_00(_2_9)
     let (local _3_10 : Uint256) = uint256_not(Uint256(low=0, high=0))
     local range_check_ptr = range_check_ptr
     let (local diff : Uint256) = u256_add(x_7, _3_10)
@@ -134,7 +114,7 @@ func checked_sub_uint256{range_check_ptr}(x_7 : Uint256) -> (diff : Uint256):
     return (diff)
 end
 
-func __warp_block_4_if(_1_11 : Uint256, __warp_break_0 : Uint256) -> (__warp_break_0 : Uint256):
+func __warp_block_0_if(_1_11 : Uint256, __warp_break_0 : Uint256) -> (__warp_break_0 : Uint256):
     alloc_locals
     if _1_11.low + _1_11.high != 0:
         local __warp_break_0 : Uint256 = Uint256(low=1, high=0)
@@ -150,7 +130,7 @@ func __warp_loop_body_0{range_check_ptr}(
     alloc_locals
     let (local _1_11 : Uint256) = is_gt(var_k, var_j)
     local range_check_ptr = range_check_ptr
-    let (local __warp_break_0 : Uint256) = __warp_block_4_if(_1_11, __warp_break_0)
+    let (local __warp_break_0 : Uint256) = __warp_block_0_if(_1_11, __warp_break_0)
     let (local var_k : Uint256) = checked_sub_uint256{range_check_ptr=range_check_ptr}(var_k)
     local range_check_ptr = range_check_ptr
     let (local var_k : Uint256) = u256_add(var_k, var_j)
@@ -158,12 +138,15 @@ func __warp_loop_body_0{range_check_ptr}(
     return (__warp_break_0, var_k)
 end
 
-func __warp_block_9_if{
+func __warp_block_3{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*, syscall_ptr : felt*}(
-        __warp_break_0 : Uint256, var_i : Uint256, var_j : Uint256, var_k : Uint256) -> (
-        var_k : Uint256):
+        var_i : Uint256, var_j : Uint256, var_k : Uint256) -> (var_k : Uint256):
     alloc_locals
+    local __warp_break_0 : Uint256 = Uint256(low=0, high=0)
+    let (local __warp_break_0 : Uint256, local var_k : Uint256) = __warp_loop_body_0{
+        range_check_ptr=range_check_ptr}(__warp_break_0, var_j, var_k)
+    local range_check_ptr = range_check_ptr
     if __warp_break_0.low + __warp_break_0.high != 0:
         return (var_k)
     else:
@@ -180,43 +163,18 @@ func __warp_block_9_if{
         local range_check_ptr = range_check_ptr
         local storage_ptr : Storage* = storage_ptr
         local syscall_ptr : felt* = syscall_ptr
-        return (var_k)
     end
-end
-
-func __warp_block_7{
-        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
-        storage_ptr : Storage*, syscall_ptr : felt*}(
-        var_i : Uint256, var_j : Uint256, var_k : Uint256) -> (var_k : Uint256):
-    alloc_locals
-    local __warp_break_0 : Uint256 = Uint256(low=0, high=0)
-    let (local __warp_break_0 : Uint256, local var_k : Uint256) = __warp_loop_body_0{
-        range_check_ptr=range_check_ptr}(__warp_break_0, var_j, var_k)
-    local range_check_ptr = range_check_ptr
-    let (local var_k : Uint256) = __warp_block_9_if{
-        memory_dict=memory_dict,
-        msize=msize,
-        pedersen_ptr=pedersen_ptr,
-        range_check_ptr=range_check_ptr,
-        storage_ptr=storage_ptr,
-        syscall_ptr=syscall_ptr}(__warp_break_0, var_i, var_j, var_k)
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local range_check_ptr = range_check_ptr
-    local storage_ptr : Storage* = storage_ptr
-    local syscall_ptr : felt* = syscall_ptr
     return (var_k)
 end
 
-func __warp_block_5_if{
+func __warp_block_1_if{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*, syscall_ptr : felt*}(
         __warp_subexpr_0 : Uint256, var_i : Uint256, var_j : Uint256, var_k : Uint256) -> (
         var_k : Uint256):
     alloc_locals
     if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        let (local var_k : Uint256) = __warp_block_7{
+        let (local var_k : Uint256) = __warp_block_3{
             memory_dict=memory_dict,
             msize=msize,
             pedersen_ptr=pedersen_ptr,
@@ -242,7 +200,7 @@ func __warp_loop_0{
     alloc_locals
     let (local __warp_subexpr_0 : Uint256) = is_lt(var_k, var_i)
     local range_check_ptr = range_check_ptr
-    let (local var_k : Uint256) = __warp_block_5_if{
+    let (local var_k : Uint256) = __warp_block_1_if{
         memory_dict=memory_dict,
         msize=msize,
         pedersen_ptr=pedersen_ptr,
@@ -292,7 +250,7 @@ func fun_transferFrom_external{
     return (var.low, var.high)
 end
 
-func __warp_block_10{
+func __warp_block_6{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*, syscall_ptr : felt*}(_2_21 : Uint256, _4_23 : Uint256) -> ():
     alloc_locals
@@ -330,13 +288,13 @@ func __warp_block_10{
     return ()
 end
 
-func __warp_block_8_if{
+func __warp_block_5_if{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*, syscall_ptr : felt*}(
         _12 : Uint256, _2_21 : Uint256, _4_23 : Uint256) -> ():
     alloc_locals
     if _12.low + _12.high != 0:
-        __warp_block_10{
+        __warp_block_6{
             memory_dict=memory_dict,
             msize=msize,
             pedersen_ptr=pedersen_ptr,
@@ -355,7 +313,7 @@ func __warp_block_8_if{
     end
 end
 
-func __warp_block_6{
+func __warp_block_4{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*, syscall_ptr : felt*}(_2_21 : Uint256, _4_23 : Uint256) -> ():
     alloc_locals
@@ -367,7 +325,7 @@ func __warp_block_6{
     local _11 : Uint256 = Uint256(low=105102910, high=0)
     let (local _12 : Uint256) = is_eq(_11, _10)
     local range_check_ptr = range_check_ptr
-    __warp_block_8_if{
+    __warp_block_5_if{
         memory_dict=memory_dict,
         msize=msize,
         pedersen_ptr=pedersen_ptr,
@@ -383,13 +341,13 @@ func __warp_block_6{
     return ()
 end
 
-func __warp_block_3_if{
+func __warp_block_2_if{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*, syscall_ptr : felt*}(
         _2_21 : Uint256, _4_23 : Uint256, _6_25 : Uint256) -> ():
     alloc_locals
     if _6_25.low + _6_25.high != 0:
-        __warp_block_6{
+        __warp_block_4{
             memory_dict=memory_dict,
             msize=msize,
             pedersen_ptr=pedersen_ptr,
@@ -427,7 +385,7 @@ func fun_ENTRY_POINT{
     local range_check_ptr = range_check_ptr
     let (local _6_25 : Uint256) = is_zero(_5_24)
     local range_check_ptr = range_check_ptr
-    __warp_block_3_if{
+    __warp_block_2_if{
         memory_dict=memory_dict,
         msize=msize,
         pedersen_ptr=pedersen_ptr,

--- a/tests/yul/for-loop-with-continue.cairo
+++ b/tests/yul/for-loop-with-continue.cairo
@@ -45,7 +45,7 @@ func get_storage_high{storage_ptr : Storage*, range_check_ptr, pedersen_ptr : Ha
     return (res=storage_val_high)
 end
 
-func __warp_block_0_if(_4 : Uint256) -> ():
+func __warp_block_00(_4 : Uint256) -> ():
     alloc_locals
     if _4.low + _4.high != 0:
         assert 0 = 1
@@ -65,7 +65,7 @@ func abi_decode_uint256t_uint256{range_check_ptr}(dataEnd : Uint256) -> (
     local range_check_ptr = range_check_ptr
     let (local _4 : Uint256) = slt(_3, _1)
     local range_check_ptr = range_check_ptr
-    __warp_block_0_if(_4)
+    __warp_block_00(_4)
     local _5 : Uint256 = Uint256(low=4, high=0)
     local value0 : Uint256 = Uint256(31597865, 9284653)
     local _6 : Uint256 = Uint256(low=36, high=0)
@@ -101,32 +101,12 @@ func abi_encode_bool{memory_dict : DictAccess*, msize, range_check_ptr}(
     return (tail)
 end
 
-func __warp_block_1_if(_2_6 : Uint256) -> ():
-    alloc_locals
-    if _2_6.low + _2_6.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
-func __warp_block_2_if(_2_9 : Uint256) -> ():
-    alloc_locals
-    if _2_9.low + _2_9.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
 func checked_sub_uint256{range_check_ptr}(x_7 : Uint256) -> (diff : Uint256):
     alloc_locals
     local _1_8 : Uint256 = Uint256(low=1, high=0)
     let (local _2_9 : Uint256) = is_lt(x_7, _1_8)
     local range_check_ptr = range_check_ptr
-    __warp_block_2_if(_2_9)
+    __warp_block_00(_2_9)
     let (local _3_10 : Uint256) = uint256_not(Uint256(low=0, high=0))
     local range_check_ptr = range_check_ptr
     let (local diff : Uint256) = u256_add(x_7, _3_10)
@@ -134,20 +114,13 @@ func checked_sub_uint256{range_check_ptr}(x_7 : Uint256) -> (diff : Uint256):
     return (diff)
 end
 
-func __warp_block_4_if(_1_11 : Uint256) -> ():
-    alloc_locals
-    if _1_11.low + _1_11.high != 0:
-        return ()
-    else:
-        return ()
-    end
-end
-
 func __warp_loop_body_0{range_check_ptr}(var_j : Uint256, var_k : Uint256) -> (var_k : Uint256):
     alloc_locals
     let (local _1_11 : Uint256) = is_gt(var_k, var_j)
     local range_check_ptr = range_check_ptr
-    __warp_block_4_if(_1_11)
+    if _1_11.low + _1_11.high != 0:
+        return (var_k)
+    end
     let (local var_k : Uint256) = checked_sub_uint256{range_check_ptr=range_check_ptr}(var_k)
     local range_check_ptr = range_check_ptr
     let (local var_k : Uint256) = u256_add(var_k, var_j)
@@ -155,7 +128,7 @@ func __warp_loop_body_0{range_check_ptr}(var_j : Uint256, var_k : Uint256) -> (v
     return (var_k)
 end
 
-func __warp_block_5_if{
+func __warp_block_0_if{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*, syscall_ptr : felt*}(
         __warp_subexpr_0 : Uint256, var_i : Uint256, var_j : Uint256, var_k : Uint256) -> (
@@ -191,7 +164,7 @@ func __warp_loop_0{
     alloc_locals
     let (local __warp_subexpr_0 : Uint256) = is_lt(var_k, var_i)
     local range_check_ptr = range_check_ptr
-    let (local var_k : Uint256) = __warp_block_5_if{
+    let (local var_k : Uint256) = __warp_block_0_if{
         memory_dict=memory_dict,
         msize=msize,
         pedersen_ptr=pedersen_ptr,
@@ -241,7 +214,7 @@ func fun_transferFrom_external{
     return (var.low, var.high)
 end
 
-func __warp_block_8{
+func __warp_block_4{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*, syscall_ptr : felt*}(_2_21 : Uint256, _4_23 : Uint256) -> ():
     alloc_locals
@@ -279,13 +252,13 @@ func __warp_block_8{
     return ()
 end
 
-func __warp_block_7_if{
+func __warp_block_3_if{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*, syscall_ptr : felt*}(
         _12 : Uint256, _2_21 : Uint256, _4_23 : Uint256) -> ():
     alloc_locals
     if _12.low + _12.high != 0:
-        __warp_block_8{
+        __warp_block_4{
             memory_dict=memory_dict,
             msize=msize,
             pedersen_ptr=pedersen_ptr,
@@ -304,7 +277,7 @@ func __warp_block_7_if{
     end
 end
 
-func __warp_block_6{
+func __warp_block_2{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*, syscall_ptr : felt*}(_2_21 : Uint256, _4_23 : Uint256) -> ():
     alloc_locals
@@ -316,7 +289,7 @@ func __warp_block_6{
     local _11 : Uint256 = Uint256(low=105102910, high=0)
     let (local _12 : Uint256) = is_eq(_11, _10)
     local range_check_ptr = range_check_ptr
-    __warp_block_7_if{
+    __warp_block_3_if{
         memory_dict=memory_dict,
         msize=msize,
         pedersen_ptr=pedersen_ptr,
@@ -332,13 +305,13 @@ func __warp_block_6{
     return ()
 end
 
-func __warp_block_3_if{
+func __warp_block_1_if{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*, syscall_ptr : felt*}(
         _2_21 : Uint256, _4_23 : Uint256, _6_25 : Uint256) -> ():
     alloc_locals
     if _6_25.low + _6_25.high != 0:
-        __warp_block_6{
+        __warp_block_2{
             memory_dict=memory_dict,
             msize=msize,
             pedersen_ptr=pedersen_ptr,
@@ -376,7 +349,7 @@ func fun_ENTRY_POINT{
     local range_check_ptr = range_check_ptr
     let (local _6_25 : Uint256) = is_zero(_5_24)
     local range_check_ptr = range_check_ptr
-    __warp_block_3_if{
+    __warp_block_1_if{
         memory_dict=memory_dict,
         msize=msize,
         pedersen_ptr=pedersen_ptr,

--- a/tests/yul/for-loop-with-continue.cairo
+++ b/tests/yul/for-loop-with-continue.cairo
@@ -101,12 +101,6 @@ func abi_encode_bool{memory_dict : DictAccess*, msize, range_check_ptr}(
     return (tail)
 end
 
-func panic_error_0x11() -> ():
-    alloc_locals
-    assert 0 = 1
-    jmp rel 0
-end
-
 func __warp_block_1_if(_2_6 : Uint256) -> ():
     alloc_locals
     if _2_6.low + _2_6.high != 0:

--- a/tests/yul/if-flattening.cairo
+++ b/tests/yul/if-flattening.cairo
@@ -46,7 +46,7 @@ func get_storage_high{storage_ptr : Storage*, range_check_ptr, pedersen_ptr : Ha
     return (res=storage_val_high)
 end
 
-func __warp_block_0_if(_4 : Uint256) -> ():
+func __warp_block_00(_4 : Uint256) -> ():
     alloc_locals
     if _4.low + _4.high != 0:
         assert 0 = 1
@@ -66,22 +66,12 @@ func abi_decode_uint256t_uint256{range_check_ptr}(dataEnd : Uint256) -> (
     local range_check_ptr = range_check_ptr
     let (local _4 : Uint256) = slt(_3, _1)
     local range_check_ptr = range_check_ptr
-    __warp_block_0_if(_4)
+    __warp_block_00(_4)
     local _5 : Uint256 = Uint256(low=4, high=0)
     local value0 : Uint256 = Uint256(31597865, 9284653)
     local _6 : Uint256 = Uint256(low=36, high=0)
     local value1 : Uint256 = Uint256(31597865, 9284653)
     return (value0, value1)
-end
-
-func __warp_block_1_if(_4_7 : Uint256) -> ():
-    alloc_locals
-    if _4_7.low + _4_7.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
 end
 
 func abi_decode_uint256t_uint256t_uint256t_uint256{range_check_ptr}(dataEnd_1 : Uint256) -> (
@@ -94,7 +84,7 @@ func abi_decode_uint256t_uint256t_uint256t_uint256{range_check_ptr}(dataEnd_1 : 
     local range_check_ptr = range_check_ptr
     let (local _4_7 : Uint256) = slt(_3_6, _1_4)
     local range_check_ptr = range_check_ptr
-    __warp_block_1_if(_4_7)
+    __warp_block_00(_4_7)
     local _5_8 : Uint256 = Uint256(low=4, high=0)
     local value0_2 : Uint256 = Uint256(31597865, 9284653)
     local _6_9 : Uint256 = Uint256(low=36, high=0)
@@ -128,21 +118,11 @@ func abi_encode_uint256{memory_dict : DictAccess*, msize, range_check_ptr}(
     return (tail)
 end
 
-func __warp_block_2_if(_1_12 : Uint256) -> ():
-    alloc_locals
-    if _1_12.low + _1_12.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
 func checked_sub_uint256{range_check_ptr}(x : Uint256, y : Uint256) -> (diff : Uint256):
     alloc_locals
     let (local _1_12 : Uint256) = is_lt(x, y)
     local range_check_ptr = range_check_ptr
-    __warp_block_2_if(_1_12)
+    __warp_block_00(_1_12)
     let (local diff : Uint256) = uint256_sub(x, y)
     local range_check_ptr = range_check_ptr
     return (diff)
@@ -224,7 +204,7 @@ func update_storage_value_offsett_uint256_to_uint256{
     return ()
 end
 
-func __warp_block_9{
+func __warp_block_6{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(
         var_res : Uint256, var_sender : Uint256, var_src : Uint256, var_wad : Uint256) -> (
@@ -256,7 +236,7 @@ func __warp_block_9{
     return (var_res)
 end
 
-func __warp_block_7_if{
+func __warp_block_4_if{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(
         __warp_subexpr_0 : Uint256, var_res : Uint256, var_sender : Uint256, var_src : Uint256,
@@ -266,7 +246,7 @@ func __warp_block_7_if{
         local var_res : Uint256 = Uint256(low=2, high=0)
         return (var_res)
     else:
-        let (local var_res : Uint256) = __warp_block_9{
+        let (local var_res : Uint256) = __warp_block_6{
             memory_dict=memory_dict,
             msize=msize,
             pedersen_ptr=pedersen_ptr,
@@ -281,7 +261,7 @@ func __warp_block_7_if{
     end
 end
 
-func __warp_block_5{
+func __warp_block_2{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(
         match_var : Uint256, var_res : Uint256, var_sender : Uint256, var_src : Uint256,
@@ -289,7 +269,7 @@ func __warp_block_5{
     alloc_locals
     let (local __warp_subexpr_0 : Uint256) = is_eq(match_var, Uint256(low=0, high=0))
     local range_check_ptr = range_check_ptr
-    let (local var_res : Uint256) = __warp_block_7_if{
+    let (local var_res : Uint256) = __warp_block_4_if{
         memory_dict=memory_dict,
         msize=msize,
         pedersen_ptr=pedersen_ptr,
@@ -303,14 +283,14 @@ func __warp_block_5{
     return (var_res)
 end
 
-func __warp_block_3{
+func __warp_block_0{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(
         _2_15 : Uint256, var_res : Uint256, var_sender : Uint256, var_src : Uint256,
         var_wad : Uint256) -> (var_res : Uint256):
     alloc_locals
     local match_var : Uint256 = _2_15
-    let (local var_res : Uint256) = __warp_block_5{
+    let (local var_res : Uint256) = __warp_block_2{
         memory_dict=memory_dict,
         msize=msize,
         pedersen_ptr=pedersen_ptr,
@@ -334,7 +314,7 @@ func fun_transferFrom{
     local range_check_ptr = range_check_ptr
     let (local _2_15 : Uint256) = is_zero(_1_14)
     local range_check_ptr = range_check_ptr
-    let (local var_res : Uint256) = __warp_block_3{
+    let (local var_res : Uint256) = __warp_block_0{
         memory_dict=memory_dict,
         msize=msize,
         pedersen_ptr=pedersen_ptr,
@@ -399,7 +379,7 @@ func read_from_storage_split_dynamic_uint256{
     return (value_46)
 end
 
-func __warp_block_12{
+func __warp_block_9{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(_2_56 : Uint256, _4_58 : Uint256) -> ():
     alloc_locals
@@ -436,22 +416,12 @@ func __warp_block_12{
     return ()
 end
 
-func __warp_block_16_if(_15 : Uint256) -> ():
-    alloc_locals
-    if _15.low + _15.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
-func __warp_block_15{
+func __warp_block_12{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(_2_56 : Uint256, _4_58 : Uint256) -> ():
     alloc_locals
     local _15 : Uint256 = Uint256(0, 0)
-    __warp_block_16_if(_15)
+    __warp_block_00(_15)
     local _16 : Uint256 = _4_58
     let (local param_4 : Uint256, local param_5 : Uint256) = abi_decode_uint256t_uint256{
         range_check_ptr=range_check_ptr}(_4_58)
@@ -486,52 +456,9 @@ func __warp_block_15{
     return ()
 end
 
-func __warp_block_14_if{
-        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
-        storage_ptr : Storage*}(_2_56 : Uint256, _4_58 : Uint256, __warp_subexpr_0 : Uint256) -> ():
-    alloc_locals
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        __warp_block_15{
-            memory_dict=memory_dict,
-            msize=msize,
-            pedersen_ptr=pedersen_ptr,
-            range_check_ptr=range_check_ptr,
-            storage_ptr=storage_ptr}(_2_56, _4_58)
-        local memory_dict : DictAccess* = memory_dict
-        local msize = msize
-        local pedersen_ptr : HashBuiltin* = pedersen_ptr
-        local range_check_ptr = range_check_ptr
-        local storage_ptr : Storage* = storage_ptr
-        return ()
-    else:
-        return ()
-    end
-end
-
-func __warp_block_13{
-        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
-        storage_ptr : Storage*}(_2_56 : Uint256, _4_58 : Uint256, match_var : Uint256) -> ():
-    alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = is_eq(match_var, Uint256(low=3433131944, high=0))
-    local range_check_ptr = range_check_ptr
-    __warp_block_14_if{
-        memory_dict=memory_dict,
-        msize=msize,
-        pedersen_ptr=pedersen_ptr,
-        range_check_ptr=range_check_ptr,
-        storage_ptr=storage_ptr}(_2_56, _4_58, __warp_subexpr_0)
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local range_check_ptr = range_check_ptr
-    local storage_ptr : Storage* = storage_ptr
-    return ()
-end
-
 func __warp_block_11_if{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
-        storage_ptr : Storage*}(
-        _2_56 : Uint256, _4_58 : Uint256, __warp_subexpr_0 : Uint256, match_var : Uint256) -> ():
+        storage_ptr : Storage*}(_2_56 : Uint256, _4_58 : Uint256, __warp_subexpr_0 : Uint256) -> ():
     alloc_locals
     if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
         __warp_block_12{
@@ -547,7 +474,50 @@ func __warp_block_11_if{
         local storage_ptr : Storage* = storage_ptr
         return ()
     else:
-        __warp_block_13{
+        return ()
+    end
+end
+
+func __warp_block_10{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        storage_ptr : Storage*}(_2_56 : Uint256, _4_58 : Uint256, match_var : Uint256) -> ():
+    alloc_locals
+    let (local __warp_subexpr_0 : Uint256) = is_eq(match_var, Uint256(low=3433131944, high=0))
+    local range_check_ptr = range_check_ptr
+    __warp_block_11_if{
+        memory_dict=memory_dict,
+        msize=msize,
+        pedersen_ptr=pedersen_ptr,
+        range_check_ptr=range_check_ptr,
+        storage_ptr=storage_ptr}(_2_56, _4_58, __warp_subexpr_0)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    local storage_ptr : Storage* = storage_ptr
+    return ()
+end
+
+func __warp_block_8_if{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        storage_ptr : Storage*}(
+        _2_56 : Uint256, _4_58 : Uint256, __warp_subexpr_0 : Uint256, match_var : Uint256) -> ():
+    alloc_locals
+    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
+        __warp_block_9{
+            memory_dict=memory_dict,
+            msize=msize,
+            pedersen_ptr=pedersen_ptr,
+            range_check_ptr=range_check_ptr,
+            storage_ptr=storage_ptr}(_2_56, _4_58)
+        local memory_dict : DictAccess* = memory_dict
+        local msize = msize
+        local pedersen_ptr : HashBuiltin* = pedersen_ptr
+        local range_check_ptr = range_check_ptr
+        local storage_ptr : Storage* = storage_ptr
+        return ()
+    else:
+        __warp_block_10{
             memory_dict=memory_dict,
             msize=msize,
             pedersen_ptr=pedersen_ptr,
@@ -562,13 +532,13 @@ func __warp_block_11_if{
     end
 end
 
-func __warp_block_10{
+func __warp_block_7{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(_2_56 : Uint256, _4_58 : Uint256, match_var : Uint256) -> ():
     alloc_locals
     let (local __warp_subexpr_0 : Uint256) = is_eq(match_var, Uint256(low=2287400825, high=0))
     local range_check_ptr = range_check_ptr
-    __warp_block_11_if{
+    __warp_block_8_if{
         memory_dict=memory_dict,
         msize=msize,
         pedersen_ptr=pedersen_ptr,
@@ -582,12 +552,12 @@ func __warp_block_10{
     return ()
 end
 
-func __warp_block_8{
+func __warp_block_5{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(_10 : Uint256, _2_56 : Uint256, _4_58 : Uint256) -> ():
     alloc_locals
     local match_var : Uint256 = _10
-    __warp_block_10{
+    __warp_block_7{
         memory_dict=memory_dict,
         msize=msize,
         pedersen_ptr=pedersen_ptr,
@@ -601,7 +571,7 @@ func __warp_block_8{
     return ()
 end
 
-func __warp_block_6{
+func __warp_block_3{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(_2_56 : Uint256, _4_58 : Uint256) -> ():
     alloc_locals
@@ -610,7 +580,7 @@ func __warp_block_6{
     local _9 : Uint256 = Uint256(low=224, high=0)
     let (local _10 : Uint256) = uint256_shr(_9, _8_62)
     local range_check_ptr = range_check_ptr
-    __warp_block_8{
+    __warp_block_5{
         memory_dict=memory_dict,
         msize=msize,
         pedersen_ptr=pedersen_ptr,
@@ -624,12 +594,12 @@ func __warp_block_6{
     return ()
 end
 
-func __warp_block_4_if{
+func __warp_block_1_if{
         memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
         storage_ptr : Storage*}(_2_56 : Uint256, _4_58 : Uint256, _6_60 : Uint256) -> ():
     alloc_locals
     if _6_60.low + _6_60.high != 0:
-        __warp_block_6{
+        __warp_block_3{
             memory_dict=memory_dict,
             msize=msize,
             pedersen_ptr=pedersen_ptr,
@@ -665,7 +635,7 @@ func fun_ENTRY_POINT{
     local range_check_ptr = range_check_ptr
     let (local _6_60 : Uint256) = is_zero(_5_59)
     local range_check_ptr = range_check_ptr
-    __warp_block_4_if{
+    __warp_block_1_if{
         memory_dict=memory_dict,
         msize=msize,
         pedersen_ptr=pedersen_ptr,

--- a/tests/yul/if-flattening.cairo
+++ b/tests/yul/if-flattening.cairo
@@ -128,12 +128,6 @@ func abi_encode_uint256{memory_dict : DictAccess*, msize, range_check_ptr}(
     return (tail)
 end
 
-func panic_error_0x11() -> ():
-    alloc_locals
-    assert 0 = 1
-    jmp rel 0
-end
-
 func __warp_block_2_if(_1_12 : Uint256) -> ():
     alloc_locals
     if _1_12.low + _1_12.high != 0:

--- a/warp/yul/FunctionPruner.py
+++ b/warp/yul/FunctionPruner.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import yul.yul_ast as ast
+from yul.AstMapper import AstMapper
+from yul.top_sort import CallGraphBuilder, cleanup_callgraph
+
+
+class FunctionPruner(AstMapper):
+    def __init__(self, public_functions: list[str]):
+        super().__init__()
+        self.public_functions: set[str] = public_functions
+        self.callgraph: dict[ast.FunctionDefinition, tuple[ast.FunctionDefinition]] = {}
+        self.visited_functions: set[str] = set()
+
+    def map(self, node: ast.Node, *args, **kwargs) -> ast.Node:
+        if not isinstance(node, ast.Block):
+            return self.visit(node)
+        
+        self.callgraph = cleanup_callgraph(CallGraphBuilder().gather(node))
+        
+        for function in self.callgraph:
+            f_name = function.name
+            if f_name in self.public_functions or "ENTRY_POINT" in f_name:
+                if not f_name in self.visited_functions:
+                    self._dfs(function)
+
+        return self.visit(node, *args, **kwargs)
+
+    def visit_block(self, node: ast.Block):
+        statements = []
+        for stmt in node.statements:
+            if self._is_unused_function(stmt):
+                continue
+            statements.append(self.visit(stmt))
+
+        return ast.Block(statements=tuple(statements))
+
+    def _dfs(self, function: ast.FunctionDefinition):
+        self.visited_functions.add(function.name)
+
+        for f in self.callgraph[function]:
+            if not f.name in self.visited_functions:
+                self._dfs(f)
+        
+    def _is_unused_function(self, node):
+        return (
+            isinstance(node, ast.FunctionDefinition) and 
+            not node.name in self.visited_functions
+        )

--- a/warp/yul/main.py
+++ b/warp/yul/main.py
@@ -45,6 +45,7 @@ def generate_cairo(sol_src_path, main_contract):
     yul_ast = MangleNamesVisitor().map(yul_ast)
     yul_ast = SwitchToIfVisitor().map(yul_ast)
     yul_ast = ExpressionSplitter().map(yul_ast)
+    yul_ast = RevertNormalizer().map(yul_ast)
     yul_ast = ScopeFlattener().map(yul_ast)
     yul_ast = LeaveNormalizer().map(yul_ast)
     yul_ast = RevertNormalizer().map(yul_ast)

--- a/warp/yul/main.py
+++ b/warp/yul/main.py
@@ -8,12 +8,14 @@ from starkware.cairo.lang.compiler.parser import parse_file
 from yul.ExpressionSplitter import ExpressionSplitter
 from yul.ForLoopEliminator import ForLoopEliminator
 from yul.ForLoopSimplifier import ForLoopSimplifier
+from yul.FunctionPruner import FunctionPruner
 from yul.LeaveNormalizer import LeaveNormalizer
 from yul.MangleNamesVisitor import MangleNamesVisitor
 from yul.RevertNormalizer import RevertNormalizer
 from yul.ScopeFlattener import ScopeFlattener
 from yul.SwitchToIfVisitor import SwitchToIfVisitor
 from yul.ToCairoVisitor import ToCairoVisitor
+from yul.utils import get_public_functions
 from yul.parse import parse_node
 
 AST_GENERATOR = "gen-yul-json-ast"
@@ -25,6 +27,7 @@ def generate_cairo(sol_src_path, main_contract):
 
     with open(sol_src_path) as f:
         sol_source = f.read()
+        public_functions = get_public_functions(sol_source)
 
     try:
         result = subprocess.run(
@@ -45,6 +48,7 @@ def generate_cairo(sol_src_path, main_contract):
     yul_ast = ScopeFlattener().map(yul_ast)
     yul_ast = LeaveNormalizer().map(yul_ast)
     yul_ast = RevertNormalizer().map(yul_ast)
-    cairo_visitor = ToCairoVisitor(sol_source)
+    yul_ast = FunctionPruner(public_functions).map(yul_ast)
+    cairo_visitor = ToCairoVisitor(sol_source, public_functions)
     cairo_code = cairo_visitor.translate(yul_ast)
     return parse_file(cairo_code).format()

--- a/warp/yul/utils.py
+++ b/warp/yul/utils.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import re
+import solcx
 
 UPPERCASE_PATTERN = re.compile(r"[A-Z]")
 
@@ -103,3 +106,41 @@ func get_storage_high{
     return (res=storage_val_high)
 end
 """
+
+
+def get_public_functions(sol_source: str) -> list[str]:
+    validate_solc_ver(sol_source)
+
+    public_functions = set()
+    abi = solcx.compile_source(sol_source, output_values=["hashes"])
+    for value in abi.values():
+        for v in value["hashes"]:
+            public_functions.add(f"fun_{v[:v.find('(')]}")
+    return list(public_functions)
+
+def validate_solc_ver(sol_source):
+    solc_version: float = get_source_version(sol_source)
+    src_ver: str = check_installed_solc(solc_version)
+    solcx.set_solc_version(src_ver)
+
+def get_source_version(sol_source: str) -> float:
+    code_split = sol_source.split("\n")
+    for line in code_split:
+        if "pragma" in line:
+            ver: float = float(line[line.index("0.") + 2 :].replace(";", ""))
+            if ver < 8.0:
+                raise Exception(
+                    "Please use a version of solidity that is at least 0.8.0"
+                )
+            return ver
+    raise Exception("No Solidity version specified in contract")
+
+def check_installed_solc(source_version: float) -> str:
+    solc_vers = solcx.get_installed_solc_versions()
+    vers_clean = []
+    src_ver = "0." + str(source_version)
+    for ver in solc_vers:
+        vers_clean.append(".".join(str(x) for x in list(ver.precedence_key)[:3]))
+    if src_ver not in vers_clean:
+        solcx.install_solc(src_ver)
+    return src_ver


### PR DESCRIPTION
- Create `FunctionPruner` class to remove unused functions.
- Modify `ScopeFlattener` class to obtain a single reverting block, instead of creating a new one every time an if branch was reverting