### PR TITLE
Remove splitting of variable returns in external functions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
       # cairo-run assert
       - name: Install Cairo
         run: |
-          pip install cairo-lang==0.4.1
+          pip install cairo-lang==0.4.2
 
       - name: Test yul tests
         run: |

--- a/tests/yul/ERC20.cairo
+++ b/tests/yul/ERC20.cairo
@@ -111,7 +111,7 @@ end
 @external
 func fun_approve_external{
         pedersen_ptr : HashBuiltin*, range_check_ptr, storage_ptr : Storage*, syscall_ptr : felt*}(
-        var_guy : Uint256, var_wad : Uint256, var_sender : Uint256) -> (var_low, var_high):
+        var_guy : Uint256, var_wad : Uint256, var_sender : Uint256) -> (var : Uint256):
     alloc_locals
     let (local memory_dict) = default_dict_new(0)
     local memory_dict_start : DictAccess* = memory_dict
@@ -124,7 +124,7 @@ func fun_approve_external{
     local storage_ptr : Storage* = storage_ptr
     local syscall_ptr : felt* = syscall_ptr
     default_dict_finalize(memory_dict_start, memory_dict, 0)
-    return (var.low, var.high)
+    return (var=var)
 end
 
 func getter_fun_balanceOf{pedersen_ptr : HashBuiltin*, range_check_ptr, storage_ptr : Storage*}(
@@ -162,8 +162,7 @@ end
 @external
 func fun_deposit_external{
         pedersen_ptr : HashBuiltin*, range_check_ptr, storage_ptr : Storage*, syscall_ptr : felt*}(
-        var_sender_68 : Uint256, var_value : Uint256) -> (
-        var_69_low, var_69_high, var__low, var__high):
+        var_sender_68 : Uint256, var_value : Uint256) -> (var_69 : Uint256, var_ : Uint256):
     alloc_locals
     let (local memory_dict) = default_dict_new(0)
     local memory_dict_start : DictAccess* = memory_dict
@@ -176,7 +175,7 @@ func fun_deposit_external{
     local storage_ptr : Storage* = storage_ptr
     local syscall_ptr : felt* = syscall_ptr
     default_dict_finalize(memory_dict_start, memory_dict, 0)
-    return (var_69.low, var_69.high, var_.low, var_.high)
+    return (var_69=var_69, var_=var_)
 end
 
 func getter_fun_allowance{pedersen_ptr : HashBuiltin*, range_check_ptr, storage_ptr : Storage*}(
@@ -285,7 +284,7 @@ end
 func fun_transferFrom_external{
         pedersen_ptr : HashBuiltin*, range_check_ptr, storage_ptr : Storage*, syscall_ptr : felt*}(
         var_src : Uint256, var_dst : Uint256, var_wad_72 : Uint256, var_sender_73 : Uint256) -> (
-        var_74_low, var_74_high):
+        var_74 : Uint256):
     alloc_locals
     let (local memory_dict) = default_dict_new(0)
     local memory_dict_start : DictAccess* = memory_dict
@@ -298,7 +297,7 @@ func fun_transferFrom_external{
     local storage_ptr : Storage* = storage_ptr
     local syscall_ptr : felt* = syscall_ptr
     default_dict_finalize(memory_dict_start, memory_dict, 0)
-    return (var_74.low, var_74.high)
+    return (var_74=var_74)
 end
 
 func fun_withdraw{pedersen_ptr : HashBuiltin*, range_check_ptr, storage_ptr : Storage*}(

--- a/tests/yul/ERC20_storage.cairo
+++ b/tests/yul/ERC20_storage.cairo
@@ -111,7 +111,7 @@ end
 @external
 func fun_approve_external{
         pedersen_ptr : HashBuiltin*, range_check_ptr, storage_ptr : Storage*, syscall_ptr : felt*}(
-        var_guy : Uint256, var_wad : Uint256, var_sender : Uint256) -> (var__low, var__high):
+        var_guy : Uint256, var_wad : Uint256, var_sender : Uint256) -> (var_ : Uint256):
     alloc_locals
     let (local memory_dict) = default_dict_new(0)
     local memory_dict_start : DictAccess* = memory_dict
@@ -124,7 +124,7 @@ func fun_approve_external{
     local storage_ptr : Storage* = storage_ptr
     local syscall_ptr : felt* = syscall_ptr
     default_dict_finalize(memory_dict_start, memory_dict, 0)
-    return (var_.low, var_.high)
+    return (var_=var_)
 end
 
 func getter_fun_balanceOf{pedersen_ptr : HashBuiltin*, range_check_ptr, storage_ptr : Storage*}(
@@ -189,7 +189,7 @@ end
 @external
 func fun_get_balance_external{
         pedersen_ptr : HashBuiltin*, range_check_ptr, storage_ptr : Storage*, syscall_ptr : felt*}(
-        var_src : Uint256) -> (var_low, var_high):
+        var_src : Uint256) -> (var : Uint256):
     alloc_locals
     let (local memory_dict) = default_dict_new(0)
     local memory_dict_start : DictAccess* = memory_dict
@@ -202,7 +202,7 @@ func fun_get_balance_external{
     local storage_ptr : Storage* = storage_ptr
     local syscall_ptr : felt* = syscall_ptr
     default_dict_finalize(memory_dict_start, memory_dict, 0)
-    return (var.low, var.high)
+    return (var=var)
 end
 
 func getter_fun_allowance{pedersen_ptr : HashBuiltin*, range_check_ptr, storage_ptr : Storage*}(
@@ -311,7 +311,7 @@ end
 func fun_transferFrom_external{
         pedersen_ptr : HashBuiltin*, range_check_ptr, storage_ptr : Storage*, syscall_ptr : felt*}(
         var_src_64 : Uint256, var_dst : Uint256, var_wad_65 : Uint256, var_sender_66 : Uint256) -> (
-        var_67_low, var_67_high):
+        var_67 : Uint256):
     alloc_locals
     let (local memory_dict) = default_dict_new(0)
     local memory_dict_start : DictAccess* = memory_dict
@@ -325,7 +325,7 @@ func fun_transferFrom_external{
     local storage_ptr : Storage* = storage_ptr
     local syscall_ptr : felt* = syscall_ptr
     default_dict_finalize(memory_dict_start, memory_dict, 0)
-    return (var_67.low, var_67.high)
+    return (var_67=var_67)
 end
 
 func fun_withdraw{pedersen_ptr : HashBuiltin*, range_check_ptr, storage_ptr : Storage*}(

--- a/tests/yul/calldatacopy.cairo
+++ b/tests/yul/calldatacopy.cairo
@@ -66,7 +66,7 @@ end
 @external
 func fun_callMe_external{
         pedersen_ptr : HashBuiltin*, range_check_ptr, storage_ptr : Storage*, syscall_ptr : felt*}(
-        calldata_size, calldata_len, calldata : felt*) -> (var_low, var_high):
+        calldata_size, calldata_len, calldata : felt*) -> (var : Uint256):
     alloc_locals
     let (local memory_dict) = default_dict_new(0)
     local memory_dict_start : DictAccess* = memory_dict
@@ -80,5 +80,5 @@ func fun_callMe_external{
     local storage_ptr : Storage* = storage_ptr
     local syscall_ptr : felt* = syscall_ptr
     default_dict_finalize(memory_dict_start, memory_dict, 0)
-    return (var.low, var.high)
+    return (var=var)
 end

--- a/tests/yul/for-loop-with-break.cairo
+++ b/tests/yul/for-loop-with-break.cairo
@@ -183,7 +183,7 @@ end
 @external
 func fun_transferFrom_external{
         pedersen_ptr : HashBuiltin*, range_check_ptr, storage_ptr : Storage*, syscall_ptr : felt*}(
-        var_i : Uint256, var_j : Uint256) -> (var_low, var_high):
+        var_i : Uint256, var_j : Uint256) -> (var : Uint256):
     alloc_locals
     let (local memory_dict) = default_dict_new(0)
     local memory_dict_start : DictAccess* = memory_dict
@@ -196,5 +196,5 @@ func fun_transferFrom_external{
     local storage_ptr : Storage* = storage_ptr
     local syscall_ptr : felt* = syscall_ptr
     default_dict_finalize(memory_dict_start, memory_dict, 0)
-    return (var.low, var.high)
+    return (var=var)
 end

--- a/tests/yul/for-loop-with-continue.cairo
+++ b/tests/yul/for-loop-with-continue.cairo
@@ -152,7 +152,7 @@ end
 @external
 func fun_transferFrom_external{
         pedersen_ptr : HashBuiltin*, range_check_ptr, storage_ptr : Storage*, syscall_ptr : felt*}(
-        var_i : Uint256, var_j : Uint256) -> (var_low, var_high):
+        var_i : Uint256, var_j : Uint256) -> (var : Uint256):
     alloc_locals
     let (local memory_dict) = default_dict_new(0)
     local memory_dict_start : DictAccess* = memory_dict
@@ -165,5 +165,5 @@ func fun_transferFrom_external{
     local storage_ptr : Storage* = storage_ptr
     local syscall_ptr : felt* = syscall_ptr
     default_dict_finalize(memory_dict_start, memory_dict, 0)
-    return (var.low, var.high)
+    return (var=var)
 end

--- a/tests/yul/if-flattening.cairo
+++ b/tests/yul/if-flattening.cairo
@@ -160,7 +160,7 @@ end
 @external
 func fun_transferFrom_external{
         pedersen_ptr : HashBuiltin*, range_check_ptr, storage_ptr : Storage*, syscall_ptr : felt*}(
-        var_src : Uint256, var_wad : Uint256, var_sender : Uint256) -> (var_low, var_high):
+        var_src : Uint256, var_wad : Uint256, var_sender : Uint256) -> (var : Uint256):
     alloc_locals
     let (local memory_dict) = default_dict_new(0)
     local memory_dict_start : DictAccess* = memory_dict
@@ -173,5 +173,5 @@ func fun_transferFrom_external{
     local storage_ptr : Storage* = storage_ptr
     local syscall_ptr : felt* = syscall_ptr
     default_dict_finalize(memory_dict_start, memory_dict, 0)
-    return (var.low, var.high)
+    return (var=var)
 end

--- a/tests/yul/return-var-capturing.cairo
+++ b/tests/yul/return-var-capturing.cairo
@@ -125,7 +125,7 @@ end
 @external
 func fun_rando_external{
         pedersen_ptr : HashBuiltin*, range_check_ptr, storage_ptr : Storage*, syscall_ptr : felt*}(
-        var_a : Uint256, var_b : Uint256) -> (var_low, var_high):
+        var_a : Uint256, var_b : Uint256) -> (var : Uint256):
     alloc_locals
     let (local memory_dict) = default_dict_new(0)
     local memory_dict_start : DictAccess* = memory_dict
@@ -138,5 +138,5 @@ func fun_rando_external{
     local storage_ptr : Storage* = storage_ptr
     local syscall_ptr : felt* = syscall_ptr
     default_dict_finalize(memory_dict_start, memory_dict, 0)
-    return (var.low, var.high)
+    return (var=var)
 end


### PR DESCRIPTION
With the new cairo-lang release (0.4.2), structs are supported as return variables for external functions.
This PR removes the splitting of return variable in external functions.