### PR TITLE
Change binary name gen-yul-json-ast -> kudu

### DIFF
--- a/warp/yul/main.py
+++ b/warp/yul/main.py
@@ -18,7 +18,7 @@ from yul.ToCairoVisitor import ToCairoVisitor
 from yul.parse import parse_node
 from yul.utils import get_public_functions
 
-AST_GENERATOR = "gen-yul-json-ast"
+AST_GENERATOR = "kudu"
 
 
 def generate_cairo(sol_src_path, main_contract):


### PR DESCRIPTION
gen-yul-json-ast now lives at: https://github.com/NethermindEth/kudu
This PR should be merged after https://github.com/NethermindEth/kudu/pull/21 is merged