### PR TITLE
Replace $ with _ in identifiers

### DIFF
--- a/warp/yul/MangleNamesVisitor.py
+++ b/warp/yul/MangleNamesVisitor.py
@@ -6,6 +6,7 @@ CAIRO_KEYWORDS = {"ret", "felt", "call", "jmp", "func", "end"}
 
 
 def mangle(identifier: str) -> str:
+    identifier = identifier.replace("$", "_")
     if identifier in CAIRO_KEYWORDS:
         return identifier + "__warp_mangled"
     else:


### PR DESCRIPTION
Yul identifiers do not allow `$`, so we replace it with `_`