### PR TITLE
add separate CI configurations for develop and main

### DIFF
--- a/.github/workflows/develop-ci.yml
+++ b/.github/workflows/develop-ci.yml
@@ -1,0 +1,47 @@
+name: develop-ci
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches-ignore: [ main ]
+
+jobs:
+  test-complete:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v2.2.2
+        with:
+          python-version: 3.7 # Cairo was tested with this version
+
+      - name: Install dependencies
+        run: >
+          sudo add-apt-repository ppa:ethereum/ethereum
+
+          sudo add-apt-repository 'deb http://mirrors.kernel.org/ubuntu hirsute main universe'
+
+          sudo apt-get -y install gcc-11 g++-11 solc
+          libboost-filesystem-dev libboost-system-dev
+          libboost-program-options-dev libboost-regex-dev
+
+      - name: Check formatting
+        run: |
+          pip install colorama black==21.6b0 isort
+          black . --check --verbose --diff --color
+          isort . --check --verbose --diff --color
+
+      - name: Install Warp
+        run: make
+
+      - name: Setup BATS testing framework
+        uses: mig4/setup-bats@v1.2.0
+
+      - name: Test golden tests
+        run: make test_bats
+
+      - name: Test yul tests
+        run: make test_yul

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -1,9 +1,10 @@
-name: build
+name: main-ci
 
 on:
   push:
     branches: [ main ]
   pull_request:
+    branches: [ main ]
 
 jobs:
   test-linux-tranpsilation:


### PR DESCRIPTION
Building solc on github self-hosted macos runners is a problem.

We make PRs to main only for "releases". CI for main tests for all the
    possible platforms: macos 10.15, macos 11, ubuntu etc. All the
    executables needed for CI (solc, kudu) are built by team members
    that own macs.

We make PRs to develop as we regularly do them in the normal process
     of development. CI only runs for ubuntu. Executables for macos
     are not updated.