### PR TITLE
update executables to ones that use pedersen for storage acccess

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,14 @@ TEMPLATES := $(wildcard $(GOLDEN_DIR)/*.template)
 BATS_FILES := $(patsubst $(GOLDEN_DIR)/%.template,$(BATS_DIR)/test-%.bats,$(TEMPLATES))
 TEST_FILES := $(shell find ./tests -type f ! -name '*.temp*') # exclude temporary files
 SRC_FILES := $(shell find ./warp/ -type f)
+KUDU_FILES := $(shell find ./warp/bin -name kudu)
 PY_REQUIREMENTS := requirements.txt
 NPROCS := $(shell getconf _NPROCESSORS_ONLN)
 
 warp: .warp-activation-token
 .PHONY: warp
 
-.warp-activation-token: $(SRC_FILES) ./scripts/kudu setup.py $(PY_REQUIREMENTS)
+.warp-activation-token: $(SRC_FILES) $(KUDU_FILES) ./scripts/kudu setup.py $(PY_REQUIREMENTS)
 	python setup.py install
 	touch .warp-activation-token
 

--- a/tests/yul/ERC20.cairo
+++ b/tests/yul/ERC20.cairo
@@ -3,6 +3,7 @@
 
 from evm.calls import calldataload, calldatasize, caller, returndata_write
 from evm.exec_env import ExecutionEnvironment
+from evm.hashing import uint256_pedersen
 from evm.memory import uint256_mload, uint256_mstore
 from evm.uint256 import is_eq, is_gt, is_lt, is_zero, slt, u256_add, u256_shr
 from starkware.cairo.common.alloc import alloc
@@ -10,10 +11,18 @@ from starkware.cairo.common.cairo_builtins import BitwiseBuiltin, HashBuiltin
 from starkware.cairo.common.default_dict import default_dict_finalize, default_dict_new
 from starkware.cairo.common.dict_access import DictAccess
 from starkware.cairo.common.registers import get_fp_and_pc
-from starkware.cairo.common.uint256 import Uint256, uint256_and, uint256_not, uint256_sub
+from starkware.cairo.common.uint256 import Uint256, uint256_not, uint256_sub
 
-func __warp_constant_0() -> (res : Uint256):
-    return (Uint256(low=0, high=0))
+func sload{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(key : Uint256) -> (
+        value : Uint256):
+    let (res) = evm_storage.read(key.low, key.high)
+    return (res)
+end
+
+func sstore{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
+        key : Uint256, value : Uint256):
+    evm_storage.write(key.low, key.high, value)
+    return ()
 end
 
 @storage_var
@@ -21,7 +30,7 @@ func balances(arg0_low, arg0_high) -> (res : Uint256):
 end
 
 @storage_var
-func totalSupply() -> (res : Uint256):
+func evm_storage(arg0_low, arg0_high) -> (res : Uint256):
 end
 
 @storage_var
@@ -59,14 +68,13 @@ func abi_decode{range_check_ptr}(dataEnd : Uint256) -> ():
     end
 end
 
-func getter_fun_totalSupply{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
-        ) -> (value_14 : Uint256):
+func extract_from_storage_value_dynamict_uint256(slot_value : Uint256) -> (value_14 : Uint256):
     alloc_locals
-    let (res) = totalSupply.read()
-    return (res)
+    local value_14 : Uint256 = slot_value
+    return (value_14)
 end
 
-func abi_encode_uint256_to_uint256_709{memory_dict : DictAccess*, msize, range_check_ptr}(
+func abi_encode_uint256_to_uint256_949{memory_dict : DictAccess*, msize, range_check_ptr}(
         value : Uint256) -> ():
     alloc_locals
     uint256_mstore(offset=Uint256(low=128, high=0), value=value)
@@ -76,11 +84,11 @@ func abi_encode_uint256_to_uint256_709{memory_dict : DictAccess*, msize, range_c
     return ()
 end
 
-func abi_encode_uint256_365{memory_dict : DictAccess*, msize, range_check_ptr}(
+func abi_encode_uint256_428{memory_dict : DictAccess*, msize, range_check_ptr}(
         value0 : Uint256) -> (tail : Uint256):
     alloc_locals
     local tail : Uint256 = Uint256(low=160, high=0)
-    abi_encode_uint256_to_uint256_709(value0)
+    abi_encode_uint256_to_uint256_949(value0)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
@@ -112,11 +120,37 @@ func abi_decode_addresst_addresst_uint256{exec_env : ExecutionEnvironment*, rang
     return (value0_5, value1, value2)
 end
 
-func getter_fun_balances{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
-        arg0 : Uint256) -> (value_20 : Uint256):
+func mapping_index_access_mapping_address_uint256_of_address{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        key_21 : Uint256) -> (dataSlot_22 : Uint256):
     alloc_locals
-    let (res) = balances.read(arg0.low, arg0.high)
-    return (res)
+    uint256_mstore(offset=Uint256(low=0, high=0), value=key_21)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local range_check_ptr = range_check_ptr
+    uint256_mstore(offset=Uint256(low=32, high=0), value=Uint256(low=0, high=0))
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local range_check_ptr = range_check_ptr
+    let (local dataSlot_22 : Uint256) = uint256_pedersen(
+        Uint256(low=0, high=0), Uint256(low=64, high=0))
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    return (dataSlot_22)
+end
+
+func read_from_storage_split_dynamic_uint256{
+        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(slot : Uint256) -> (
+        value_15 : Uint256):
+    alloc_locals
+    let (local __warp_subexpr_0 : Uint256) = sload(slot)
+    local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local syscall_ptr : felt* = syscall_ptr
+    let (local value_15 : Uint256) = extract_from_storage_value_dynamict_uint256(__warp_subexpr_0)
+    return (value_15)
 end
 
 func require_helper{range_check_ptr}(condition : Uint256) -> ():
@@ -131,10 +165,25 @@ func require_helper{range_check_ptr}(condition : Uint256) -> ():
     end
 end
 
-func setter_fun_balances{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
-        arg0_21 : Uint256, value_22 : Uint256) -> ():
+func update_byte_slice_shift(value_25 : Uint256, toInsert : Uint256) -> (result : Uint256):
     alloc_locals
-    balances.write(arg0_21.low, arg0_21.high, value_22)
+    local result : Uint256 = toInsert
+    return (result)
+end
+
+func update_storage_value_offsett_uint256_to_uint256{
+        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
+        slot_26 : Uint256, value_27 : Uint256) -> ():
+    alloc_locals
+    let (local __warp_subexpr_1 : Uint256) = sload(slot_26)
+    local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local syscall_ptr : felt* = syscall_ptr
+    let (local __warp_subexpr_0 : Uint256) = update_byte_slice_shift(__warp_subexpr_1, value_27)
+    sstore(key=slot_26, value=__warp_subexpr_0)
+    local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local syscall_ptr : felt* = syscall_ptr
     return ()
 end
 
@@ -153,48 +202,76 @@ func checked_add_uint256{range_check_ptr}(x : Uint256, y : Uint256) -> (sum : Ui
     return (sum)
 end
 
-func fun_transfer{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
-        var_sender_29 : Uint256, var_recipient_30 : Uint256, var_amount_31 : Uint256) -> ():
+func fun_transfer{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        syscall_ptr : felt*}(
+        var_sender_34 : Uint256, var_recipient_35 : Uint256, var_amount_36 : Uint256) -> ():
     alloc_locals
-    let (local _1_32 : Uint256) = getter_fun_balances(var_sender_29)
+    let (
+        local __warp_subexpr_0 : Uint256) = mapping_index_access_mapping_address_uint256_of_address(
+        var_sender_34)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    let (local _1_37 : Uint256) = read_from_storage_split_dynamic_uint256(__warp_subexpr_0)
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
-    let (local __warp_subexpr_1 : Uint256) = is_lt(_1_32, var_amount_31)
+    let (local __warp_subexpr_2 : Uint256) = is_lt(_1_37, var_amount_36)
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
+    let (local __warp_subexpr_1 : Uint256) = is_zero(__warp_subexpr_2)
     local range_check_ptr = range_check_ptr
-    require_helper(__warp_subexpr_0)
+    require_helper(__warp_subexpr_1)
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_2 : Uint256) = uint256_sub(_1_32, var_amount_31)
+    let (local __warp_subexpr_4 : Uint256) = uint256_sub(_1_37, var_amount_36)
     local range_check_ptr = range_check_ptr
-    setter_fun_balances(var_sender_29, __warp_subexpr_2)
+    let (
+        local __warp_subexpr_3 : Uint256) = mapping_index_access_mapping_address_uint256_of_address(
+        var_sender_34)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    update_storage_value_offsett_uint256_to_uint256(__warp_subexpr_3, __warp_subexpr_4)
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
-    let (local __warp_subexpr_4 : Uint256) = getter_fun_balances(var_recipient_30)
+    let (local _2 : Uint256) = mapping_index_access_mapping_address_uint256_of_address(
+        var_recipient_35)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
-    local syscall_ptr : felt* = syscall_ptr
-    let (local __warp_subexpr_3 : Uint256) = checked_add_uint256(__warp_subexpr_4, var_amount_31)
+    let (local __warp_subexpr_7 : Uint256) = sload(_2)
     local range_check_ptr = range_check_ptr
-    setter_fun_balances(var_recipient_30, __warp_subexpr_3)
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local syscall_ptr : felt* = syscall_ptr
+    let (local __warp_subexpr_6 : Uint256) = extract_from_storage_value_dynamict_uint256(
+        __warp_subexpr_7)
+    let (local __warp_subexpr_5 : Uint256) = checked_add_uint256(__warp_subexpr_6, var_amount_36)
+    local range_check_ptr = range_check_ptr
+    update_storage_value_offsett_uint256_to_uint256(_2, __warp_subexpr_5)
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
     return ()
 end
 
-func fun_transferFrom{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
-        var_sender : Uint256, var_recipient_26 : Uint256, var_amount_27 : Uint256) -> (
-        var_28 : Uint256):
+func fun_transferFrom{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        syscall_ptr : felt*}(
+        var_sender : Uint256, var_recipient_31 : Uint256, var_amount_32 : Uint256) -> (
+        var_33 : Uint256):
     alloc_locals
-    fun_transfer(var_sender, var_recipient_26, var_amount_27)
+    fun_transfer(var_sender, var_recipient_31, var_amount_32)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
-    local var_28 : Uint256 = Uint256(low=1, high=0)
-    return (var_28)
+    local var_33 : Uint256 = Uint256(low=1, high=0)
+    return (var_33)
 end
 
 func abi_encode_bool_to_bool{memory_dict : DictAccess*, msize, range_check_ptr}(
@@ -223,25 +300,21 @@ func abi_encode_bool{memory_dict : DictAccess*, msize, range_check_ptr}(
     return (tail_10)
 end
 
-func abi_encode_uint8_to_uint8{memory_dict : DictAccess*, msize, range_check_ptr}(
-        pos_11 : Uint256) -> ():
+func abi_encode_uint8{memory_dict : DictAccess*, msize, range_check_ptr}(pos_11 : Uint256) -> ():
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = uint256_and(
-        Uint256(low=18, high=0), Uint256(low=255, high=0))
-    local range_check_ptr = range_check_ptr
-    uint256_mstore(offset=pos_11, value=__warp_subexpr_0)
+    uint256_mstore(offset=pos_11, value=Uint256(low=18, high=0))
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
     return ()
 end
 
-func abi_encode_uint8{memory_dict : DictAccess*, msize, range_check_ptr}(
+func abi_encode_uint8_947{memory_dict : DictAccess*, msize, range_check_ptr}(
         headStart_12 : Uint256) -> (tail_13 : Uint256):
     alloc_locals
     let (local tail_13 : Uint256) = u256_add(headStart_12, Uint256(low=32, high=0))
     local range_check_ptr = range_check_ptr
-    abi_encode_uint8_to_uint8(headStart_12)
+    abi_encode_uint8(headStart_12)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
@@ -271,11 +344,11 @@ func abi_encode_uint256{memory_dict : DictAccess*, msize, range_check_ptr}(
 end
 
 func abi_decode_addresst_uint256{exec_env : ExecutionEnvironment*, range_check_ptr}(
-        dataEnd_15 : Uint256) -> (value0_16 : Uint256, value1_17 : Uint256):
+        dataEnd_16 : Uint256) -> (value0_17 : Uint256, value1_18 : Uint256):
     alloc_locals
     let (local __warp_subexpr_2 : Uint256) = uint256_not(Uint256(low=3, high=0))
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_1 : Uint256) = u256_add(dataEnd_15, __warp_subexpr_2)
+    let (local __warp_subexpr_1 : Uint256) = u256_add(dataEnd_16, __warp_subexpr_2)
     local range_check_ptr = range_check_ptr
     let (local __warp_subexpr_0 : Uint256) = slt(__warp_subexpr_1, Uint256(low=64, high=0))
     local range_check_ptr = range_check_ptr
@@ -283,25 +356,33 @@ func abi_decode_addresst_uint256{exec_env : ExecutionEnvironment*, range_check_p
         assert 0 = 1
         jmp rel 0
     end
-    let (local value0_16 : Uint256) = calldataload(Uint256(low=4, high=0))
+    let (local value0_17 : Uint256) = calldataload(Uint256(low=4, high=0))
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
-    let (local value1_17 : Uint256) = calldataload(Uint256(low=36, high=0))
+    let (local value1_18 : Uint256) = calldataload(Uint256(low=36, high=0))
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
-    return (value0_16, value1_17)
+    return (value0_17, value1_18)
 end
 
-func fun_mint{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
-        var_to : Uint256, var_amount : Uint256) -> (var : Uint256):
+func fun_mint{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        syscall_ptr : felt*}(var_to : Uint256, var_amount : Uint256) -> (var : Uint256):
     alloc_locals
-    let (local __warp_subexpr_1 : Uint256) = getter_fun_balances(var_to)
+    let (local _1_28 : Uint256) = mapping_index_access_mapping_address_uint256_of_address(var_to)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
+    let (local __warp_subexpr_2 : Uint256) = sload(_1_28)
+    local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local syscall_ptr : felt* = syscall_ptr
+    let (local __warp_subexpr_1 : Uint256) = extract_from_storage_value_dynamict_uint256(
+        __warp_subexpr_2)
     let (local __warp_subexpr_0 : Uint256) = checked_add_uint256(__warp_subexpr_1, var_amount)
     local range_check_ptr = range_check_ptr
-    setter_fun_balances(var_to, __warp_subexpr_0)
+    update_storage_value_offsett_uint256_to_uint256(_1_28, __warp_subexpr_0)
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
@@ -310,11 +391,11 @@ func fun_mint{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}
 end
 
 func abi_decode_address{exec_env : ExecutionEnvironment*, range_check_ptr}(
-        dataEnd_18 : Uint256) -> (value0_19 : Uint256):
+        dataEnd_19 : Uint256) -> (value0_20 : Uint256):
     alloc_locals
     let (local __warp_subexpr_2 : Uint256) = uint256_not(Uint256(low=3, high=0))
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_1 : Uint256) = u256_add(dataEnd_18, __warp_subexpr_2)
+    let (local __warp_subexpr_1 : Uint256) = u256_add(dataEnd_19, __warp_subexpr_2)
     local range_check_ptr = range_check_ptr
     let (local __warp_subexpr_0 : Uint256) = slt(__warp_subexpr_1, Uint256(low=32, high=0))
     local range_check_ptr = range_check_ptr
@@ -322,62 +403,99 @@ func abi_decode_address{exec_env : ExecutionEnvironment*, range_check_ptr}(
         assert 0 = 1
         jmp rel 0
     end
-    let (local value0_19 : Uint256) = calldataload(Uint256(low=4, high=0))
+    let (local value0_20 : Uint256) = calldataload(Uint256(low=4, high=0))
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
-    return (value0_19)
+    return (value0_20)
 end
 
-func fun_balanceOf{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
-        var_account : Uint256) -> (var_ : Uint256):
+func mapping_index_access_mapping_address_uint256_of_address_438{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        key : Uint256) -> (dataSlot : Uint256):
     alloc_locals
-    let (local var_ : Uint256) = getter_fun_balances(var_account)
+    uint256_mstore(offset=Uint256(low=0, high=0), value=key)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local range_check_ptr = range_check_ptr
+    uint256_mstore(offset=Uint256(low=32, high=0), value=Uint256(low=0, high=0))
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local range_check_ptr = range_check_ptr
+    let (local dataSlot : Uint256) = uint256_pedersen(
+        Uint256(low=0, high=0), Uint256(low=64, high=0))
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    return (dataSlot)
+end
+
+func getter_fun_balances{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
+        key_23 : Uint256) -> (ret_24 : Uint256):
+    alloc_locals
+    let (res) = balances.read(key_23.low, key_23.high)
+    return (res)
+end
+
+func fun_balanceOf{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        syscall_ptr : felt*}(var_account : Uint256) -> (var_ : Uint256):
+    alloc_locals
+    let (
+        local __warp_subexpr_0 : Uint256) = mapping_index_access_mapping_address_uint256_of_address(
+        var_account)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    let (local var_ : Uint256) = read_from_storage_split_dynamic_uint256(__warp_subexpr_0)
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
     return (var_)
 end
 
-func fun_transfer_73{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
-        var_recipient : Uint256, var_amount_24 : Uint256) -> (var_25 : Uint256):
+func fun_transfer_73{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        syscall_ptr : felt*}(var_recipient : Uint256, var_amount_29 : Uint256) -> (
+        var_30 : Uint256):
     alloc_locals
     let (local __warp_subexpr_0 : Uint256) = caller()
     local syscall_ptr : felt* = syscall_ptr
-    fun_transfer(__warp_subexpr_0, var_recipient, var_amount_24)
+    fun_transfer(__warp_subexpr_0, var_recipient, var_amount_29)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
-    local var_25 : Uint256 = Uint256(low=1, high=0)
-    return (var_25)
+    local var_30 : Uint256 = Uint256(low=1, high=0)
+    return (var_30)
 end
 
 func __warp_block_2{
         exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize,
         pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}() -> ():
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = __warp_constant_0()
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    end
-    let (local __warp_subexpr_1 : Uint256) = calldatasize()
+    let (local __warp_subexpr_0 : Uint256) = calldatasize()
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
-    abi_decode(__warp_subexpr_1)
+    abi_decode(__warp_subexpr_0)
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_5 : Uint256) = getter_fun_totalSupply()
+    let (local __warp_subexpr_5 : Uint256) = sload(Uint256(low=1, high=0))
+    local range_check_ptr = range_check_ptr
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
-    let (local __warp_subexpr_4 : Uint256) = uint256_not(Uint256(low=127, high=0))
+    let (local __warp_subexpr_4 : Uint256) = extract_from_storage_value_dynamict_uint256(
+        __warp_subexpr_5)
+    let (local __warp_subexpr_3 : Uint256) = uint256_not(Uint256(low=127, high=0))
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_3 : Uint256) = abi_encode_uint256_365(__warp_subexpr_5)
+    let (local __warp_subexpr_2 : Uint256) = abi_encode_uint256_428(__warp_subexpr_4)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_2 : Uint256) = u256_add(__warp_subexpr_3, __warp_subexpr_4)
+    let (local __warp_subexpr_1 : Uint256) = u256_add(__warp_subexpr_2, __warp_subexpr_3)
     local range_check_ptr = range_check_ptr
-    returndata_write(Uint256(low=128, high=0), __warp_subexpr_2)
+    returndata_write(Uint256(low=128, high=0), __warp_subexpr_1)
     local exec_env : ExecutionEnvironment* = exec_env
     return ()
 end
@@ -386,19 +504,16 @@ func __warp_block_4{
         exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize,
         pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(_1 : Uint256) -> ():
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = __warp_constant_0()
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    end
-    let (local __warp_subexpr_1 : Uint256) = calldatasize()
+    let (local __warp_subexpr_0 : Uint256) = calldatasize()
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
     let (local param : Uint256, local param_1 : Uint256,
-        local param_2 : Uint256) = abi_decode_addresst_addresst_uint256(__warp_subexpr_1)
+        local param_2 : Uint256) = abi_decode_addresst_addresst_uint256(__warp_subexpr_0)
     local exec_env : ExecutionEnvironment* = exec_env
     local range_check_ptr = range_check_ptr
     let (local ret__warp_mangled : Uint256) = fun_transferFrom(param, param_1, param_2)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
@@ -406,13 +521,13 @@ func __warp_block_4{
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_3 : Uint256) = abi_encode_bool(memPos, ret__warp_mangled)
+    let (local __warp_subexpr_2 : Uint256) = abi_encode_bool(memPos, ret__warp_mangled)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_2 : Uint256) = uint256_sub(__warp_subexpr_3, memPos)
+    let (local __warp_subexpr_1 : Uint256) = uint256_sub(__warp_subexpr_2, memPos)
     local range_check_ptr = range_check_ptr
-    returndata_write(memPos, __warp_subexpr_2)
+    returndata_write(memPos, __warp_subexpr_1)
     local exec_env : ExecutionEnvironment* = exec_env
     return ()
 end
@@ -421,27 +536,22 @@ func __warp_block_6{
         exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize, range_check_ptr}(
         _1 : Uint256) -> ():
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = __warp_constant_0()
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    end
-    let (local __warp_subexpr_1 : Uint256) = calldatasize()
+    let (local __warp_subexpr_0 : Uint256) = calldatasize()
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
-    abi_decode(__warp_subexpr_1)
+    abi_decode(__warp_subexpr_0)
     local range_check_ptr = range_check_ptr
     let (local memPos_1 : Uint256) = uint256_mload(_1)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_3 : Uint256) = abi_encode_uint8(memPos_1)
+    let (local __warp_subexpr_2 : Uint256) = abi_encode_uint8_947(memPos_1)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_2 : Uint256) = uint256_sub(__warp_subexpr_3, memPos_1)
+    let (local __warp_subexpr_1 : Uint256) = uint256_sub(__warp_subexpr_2, memPos_1)
     local range_check_ptr = range_check_ptr
-    returndata_write(memPos_1, __warp_subexpr_2)
+    returndata_write(memPos_1, __warp_subexpr_1)
     local exec_env : ExecutionEnvironment* = exec_env
     return ()
 end
@@ -450,20 +560,16 @@ func __warp_block_8{
         exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize,
         pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(_1 : Uint256) -> ():
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = __warp_constant_0()
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    end
-    let (local __warp_subexpr_1 : Uint256) = calldatasize()
+    let (local __warp_subexpr_0 : Uint256) = calldatasize()
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
-    abi_decode(__warp_subexpr_1)
+    abi_decode(__warp_subexpr_0)
     local range_check_ptr = range_check_ptr
-    let (local ret_1 : Uint256) = getter_fun_totalSupply()
+    let (local __warp_subexpr_1 : Uint256) = sload(Uint256(low=1, high=0))
+    local range_check_ptr = range_check_ptr
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
+    let (local ret_1 : Uint256) = extract_from_storage_value_dynamict_uint256(__warp_subexpr_1)
     let (local memPos_2 : Uint256) = uint256_mload(_1)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
@@ -483,19 +589,16 @@ func __warp_block_10{
         exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize,
         pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(_1 : Uint256) -> ():
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = __warp_constant_0()
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    end
-    let (local __warp_subexpr_1 : Uint256) = calldatasize()
+    let (local __warp_subexpr_0 : Uint256) = calldatasize()
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
     let (local param_3 : Uint256, local param_4 : Uint256) = abi_decode_addresst_uint256(
-        __warp_subexpr_1)
+        __warp_subexpr_0)
     local exec_env : ExecutionEnvironment* = exec_env
     local range_check_ptr = range_check_ptr
     let (local ret_2 : Uint256) = fun_mint(param_3, param_4)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
@@ -503,13 +606,13 @@ func __warp_block_10{
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_3 : Uint256) = abi_encode_bool(memPos_3, ret_2)
+    let (local __warp_subexpr_2 : Uint256) = abi_encode_bool(memPos_3, ret_2)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_2 : Uint256) = uint256_sub(__warp_subexpr_3, memPos_3)
+    let (local __warp_subexpr_1 : Uint256) = uint256_sub(__warp_subexpr_2, memPos_3)
     local range_check_ptr = range_check_ptr
-    returndata_write(memPos_3, __warp_subexpr_2)
+    returndata_write(memPos_3, __warp_subexpr_1)
     local exec_env : ExecutionEnvironment* = exec_env
     return ()
 end
@@ -518,18 +621,13 @@ func __warp_block_12{
         exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize,
         pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(_1 : Uint256) -> ():
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = __warp_constant_0()
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    end
-    let (local __warp_subexpr_2 : Uint256) = calldatasize()
+    let (local __warp_subexpr_1 : Uint256) = calldatasize()
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
-    let (local __warp_subexpr_1 : Uint256) = abi_decode_address(__warp_subexpr_2)
+    let (local __warp_subexpr_0 : Uint256) = abi_decode_address(__warp_subexpr_1)
     local exec_env : ExecutionEnvironment* = exec_env
     local range_check_ptr = range_check_ptr
-    let (local ret_3 : Uint256) = getter_fun_balances(__warp_subexpr_1)
+    let (local ret_3 : Uint256) = getter_fun_balances(__warp_subexpr_0)
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
@@ -537,13 +635,13 @@ func __warp_block_12{
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_4 : Uint256) = abi_encode_uint256(memPos_4, ret_3)
+    let (local __warp_subexpr_3 : Uint256) = abi_encode_uint256(memPos_4, ret_3)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_3 : Uint256) = uint256_sub(__warp_subexpr_4, memPos_4)
+    let (local __warp_subexpr_2 : Uint256) = uint256_sub(__warp_subexpr_3, memPos_4)
     local range_check_ptr = range_check_ptr
-    returndata_write(memPos_4, __warp_subexpr_3)
+    returndata_write(memPos_4, __warp_subexpr_2)
     local exec_env : ExecutionEnvironment* = exec_env
     return ()
 end
@@ -552,18 +650,15 @@ func __warp_block_14{
         exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize,
         pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(_1 : Uint256) -> ():
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = __warp_constant_0()
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    end
-    let (local __warp_subexpr_2 : Uint256) = calldatasize()
+    let (local __warp_subexpr_1 : Uint256) = calldatasize()
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
-    let (local __warp_subexpr_1 : Uint256) = abi_decode_address(__warp_subexpr_2)
+    let (local __warp_subexpr_0 : Uint256) = abi_decode_address(__warp_subexpr_1)
     local exec_env : ExecutionEnvironment* = exec_env
     local range_check_ptr = range_check_ptr
-    let (local ret_4 : Uint256) = fun_balanceOf(__warp_subexpr_1)
+    let (local ret_4 : Uint256) = fun_balanceOf(__warp_subexpr_0)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
@@ -571,13 +666,13 @@ func __warp_block_14{
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_4 : Uint256) = abi_encode_uint256(memPos_5, ret_4)
+    let (local __warp_subexpr_3 : Uint256) = abi_encode_uint256(memPos_5, ret_4)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_3 : Uint256) = uint256_sub(__warp_subexpr_4, memPos_5)
+    let (local __warp_subexpr_2 : Uint256) = uint256_sub(__warp_subexpr_3, memPos_5)
     local range_check_ptr = range_check_ptr
-    returndata_write(memPos_5, __warp_subexpr_3)
+    returndata_write(memPos_5, __warp_subexpr_2)
     local exec_env : ExecutionEnvironment* = exec_env
     return ()
 end
@@ -586,19 +681,16 @@ func __warp_block_16{
         exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize,
         pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(_1 : Uint256) -> ():
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = __warp_constant_0()
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    end
-    let (local __warp_subexpr_1 : Uint256) = calldatasize()
+    let (local __warp_subexpr_0 : Uint256) = calldatasize()
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
     let (local param_5 : Uint256, local param_6 : Uint256) = abi_decode_addresst_uint256(
-        __warp_subexpr_1)
+        __warp_subexpr_0)
     local exec_env : ExecutionEnvironment* = exec_env
     local range_check_ptr = range_check_ptr
     let (local ret_5 : Uint256) = fun_transfer_73(param_5, param_6)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
@@ -606,13 +698,13 @@ func __warp_block_16{
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_3 : Uint256) = abi_encode_bool(memPos_6, ret_5)
+    let (local __warp_subexpr_2 : Uint256) = abi_encode_bool(memPos_6, ret_5)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_2 : Uint256) = uint256_sub(__warp_subexpr_3, memPos_6)
+    let (local __warp_subexpr_1 : Uint256) = uint256_sub(__warp_subexpr_2, memPos_6)
     local range_check_ptr = range_check_ptr
-    returndata_write(memPos_6, __warp_subexpr_2)
+    returndata_write(memPos_6, __warp_subexpr_1)
     local exec_env : ExecutionEnvironment* = exec_env
     return ()
 end

--- a/tests/yul/ERC20_storage.cairo
+++ b/tests/yul/ERC20_storage.cairo
@@ -3,6 +3,7 @@
 
 from evm.calls import calldataload, calldatasize, returndata_write
 from evm.exec_env import ExecutionEnvironment
+from evm.hashing import uint256_pedersen
 from evm.memory import uint256_mload, uint256_mstore
 from evm.uint256 import is_eq, is_gt, is_lt, is_zero, slt, u256_add, u256_shr
 from starkware.cairo.common.alloc import alloc
@@ -12,8 +13,16 @@ from starkware.cairo.common.dict_access import DictAccess
 from starkware.cairo.common.registers import get_fp_and_pc
 from starkware.cairo.common.uint256 import Uint256, uint256_and, uint256_not, uint256_sub
 
-func __warp_constant_0() -> (res : Uint256):
-    return (Uint256(low=0, high=0))
+func sload{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(key : Uint256) -> (
+        value : Uint256):
+    let (res) = evm_storage.read(key.low, key.high)
+    return (res)
+end
+
+func sstore{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
+        key : Uint256, value : Uint256):
+    evm_storage.write(key.low, key.high, value)
+    return ()
 end
 
 @storage_var
@@ -21,11 +30,7 @@ func balanceOf(arg0_low, arg0_high) -> (res : Uint256):
 end
 
 @storage_var
-func decimals() -> (res : Uint256):
-end
-
-@storage_var
-func totalSupply() -> (res : Uint256):
+func evm_storage(arg0_low, arg0_high) -> (res : Uint256):
 end
 
 @storage_var
@@ -63,47 +68,47 @@ func abi_decode{range_check_ptr}(dataEnd : Uint256) -> ():
     end
 end
 
-func getter_fun_totalSupply{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
-        ) -> (value : Uint256):
+func extract_from_storage_value_dynamict_uint256(slot_value : Uint256) -> (value : Uint256):
     alloc_locals
-    let (res) = totalSupply.read()
-    return (res)
+    local value : Uint256 = slot_value
+    return (value)
 end
 
-func abi_encode_uint256_to_uint256_687{memory_dict : DictAccess*, msize, range_check_ptr}(
-        value_1 : Uint256) -> ():
+func abi_encode_uint256_to_uint256_1010{memory_dict : DictAccess*, msize, range_check_ptr}(
+        value_2 : Uint256) -> ():
     alloc_locals
-    uint256_mstore(offset=Uint256(low=128, high=0), value=value_1)
+    uint256_mstore(offset=Uint256(low=128, high=0), value=value_2)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
     return ()
 end
 
-func abi_encode_uint256_349{memory_dict : DictAccess*, msize, range_check_ptr}(
+func abi_encode_uint256_440{memory_dict : DictAccess*, msize, range_check_ptr}(
         value0 : Uint256) -> (tail : Uint256):
     alloc_locals
     local tail : Uint256 = Uint256(low=160, high=0)
-    abi_encode_uint256_to_uint256_687(value0)
+    abi_encode_uint256_to_uint256_1010(value0)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
     return (tail)
 end
 
-func getter_fun_decimals{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}() -> (
-        value_5 : Uint256):
+func extract_from_storage_value_dynamict_uint8{range_check_ptr}(slot_value_6 : Uint256) -> (
+        value_7 : Uint256):
     alloc_locals
-    let (res) = decimals.read()
-    return (res)
+    let (local value_7 : Uint256) = uint256_and(slot_value_6, Uint256(low=255, high=0))
+    local range_check_ptr = range_check_ptr
+    return (value_7)
 end
 
 func abi_encode_uint8_to_uint8{memory_dict : DictAccess*, msize, range_check_ptr}(
-        value_6 : Uint256, pos_7 : Uint256) -> ():
+        value_8 : Uint256, pos_9 : Uint256) -> ():
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = uint256_and(value_6, Uint256(low=255, high=0))
+    let (local __warp_subexpr_0 : Uint256) = uint256_and(value_8, Uint256(low=255, high=0))
     local range_check_ptr = range_check_ptr
-    uint256_mstore(offset=pos_7, value=__warp_subexpr_0)
+    uint256_mstore(offset=pos_9, value=__warp_subexpr_0)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
@@ -111,23 +116,23 @@ func abi_encode_uint8_to_uint8{memory_dict : DictAccess*, msize, range_check_ptr
 end
 
 func abi_encode_uint8{memory_dict : DictAccess*, msize, range_check_ptr}(
-        headStart_8 : Uint256, value0_9 : Uint256) -> (tail_10 : Uint256):
+        headStart_10 : Uint256, value0_11 : Uint256) -> (tail_12 : Uint256):
     alloc_locals
-    let (local tail_10 : Uint256) = u256_add(headStart_8, Uint256(low=32, high=0))
+    let (local tail_12 : Uint256) = u256_add(headStart_10, Uint256(low=32, high=0))
     local range_check_ptr = range_check_ptr
-    abi_encode_uint8_to_uint8(value0_9, headStart_8)
+    abi_encode_uint8_to_uint8(value0_11, headStart_10)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    return (tail_10)
+    return (tail_12)
 end
 
 func abi_decode_uint256t_uint256{exec_env : ExecutionEnvironment*, range_check_ptr}(
-        dataEnd_11 : Uint256) -> (value0_12 : Uint256, value1 : Uint256):
+        dataEnd_13 : Uint256) -> (value0_14 : Uint256, value1 : Uint256):
     alloc_locals
     let (local __warp_subexpr_2 : Uint256) = uint256_not(Uint256(low=3, high=0))
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_1 : Uint256) = u256_add(dataEnd_11, __warp_subexpr_2)
+    let (local __warp_subexpr_1 : Uint256) = u256_add(dataEnd_13, __warp_subexpr_2)
     local range_check_ptr = range_check_ptr
     let (local __warp_subexpr_0 : Uint256) = slt(__warp_subexpr_1, Uint256(low=64, high=0))
     local range_check_ptr = range_check_ptr
@@ -135,20 +140,46 @@ func abi_decode_uint256t_uint256{exec_env : ExecutionEnvironment*, range_check_p
         assert 0 = 1
         jmp rel 0
     end
-    let (local value0_12 : Uint256) = calldataload(Uint256(low=4, high=0))
+    let (local value0_14 : Uint256) = calldataload(Uint256(low=4, high=0))
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
     let (local value1 : Uint256) = calldataload(Uint256(low=36, high=0))
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
-    return (value0_12, value1)
+    return (value0_14, value1)
 end
 
-func getter_fun_balanceOf{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
-        arg0 : Uint256) -> (value_23 : Uint256):
+func mapping_index_access_mapping_uint256_uint256_of_uint256{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        key_25 : Uint256) -> (dataSlot_26 : Uint256):
     alloc_locals
-    let (res) = balanceOf.read(arg0.low, arg0.high)
-    return (res)
+    uint256_mstore(offset=Uint256(low=0, high=0), value=key_25)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local range_check_ptr = range_check_ptr
+    uint256_mstore(offset=Uint256(low=32, high=0), value=Uint256(low=2, high=0))
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local range_check_ptr = range_check_ptr
+    let (local dataSlot_26 : Uint256) = uint256_pedersen(
+        Uint256(low=0, high=0), Uint256(low=64, high=0))
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    return (dataSlot_26)
+end
+
+func read_from_storage_split_dynamic_uint256{
+        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(slot : Uint256) -> (
+        value_1 : Uint256):
+    alloc_locals
+    let (local __warp_subexpr_0 : Uint256) = sload(slot)
+    local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local syscall_ptr : felt* = syscall_ptr
+    let (local value_1 : Uint256) = extract_from_storage_value_dynamict_uint256(__warp_subexpr_0)
+    return (value_1)
 end
 
 func require_helper{range_check_ptr}(condition : Uint256) -> ():
@@ -163,30 +194,54 @@ func require_helper{range_check_ptr}(condition : Uint256) -> ():
     end
 end
 
-func checked_sub_uint256{range_check_ptr}(x_27 : Uint256, y_28 : Uint256) -> (diff : Uint256):
+func checked_sub_uint256{range_check_ptr}(x_33 : Uint256, y_34 : Uint256) -> (diff : Uint256):
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = is_lt(x_27, y_28)
+    let (local __warp_subexpr_0 : Uint256) = is_lt(x_33, y_34)
     local range_check_ptr = range_check_ptr
     if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
         assert 0 = 1
         jmp rel 0
     end
-    let (local diff : Uint256) = uint256_sub(x_27, y_28)
+    let (local diff : Uint256) = uint256_sub(x_33, y_34)
     local range_check_ptr = range_check_ptr
     return (diff)
 end
 
-func setter_fun_balanceOf{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
-        arg0_24 : Uint256, value_25 : Uint256) -> ():
+func update_byte_slice_shift(value_29 : Uint256, toInsert : Uint256) -> (result : Uint256):
     alloc_locals
-    balanceOf.write(arg0_24.low, arg0_24.high, value_25)
+    local result : Uint256 = toInsert
+    return (result)
+end
+
+func update_storage_value_offsett_uint256_to_uint256{
+        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
+        slot_30 : Uint256, value_31 : Uint256) -> ():
+    alloc_locals
+    let (local __warp_subexpr_1 : Uint256) = sload(slot_30)
+    local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local syscall_ptr : felt* = syscall_ptr
+    let (local __warp_subexpr_0 : Uint256) = update_byte_slice_shift(__warp_subexpr_1, value_31)
+    sstore(key=slot_30, value=__warp_subexpr_0)
+    local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local syscall_ptr : felt* = syscall_ptr
     return ()
 end
 
-func fun_withdraw{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
-        var_wad : Uint256, var_sender_29 : Uint256) -> ():
+func fun_withdraw{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        syscall_ptr : felt*}(var_wad : Uint256, var_sender_35 : Uint256) -> ():
     alloc_locals
-    let (local __warp_subexpr_2 : Uint256) = getter_fun_balanceOf(var_sender_29)
+    let (
+        local __warp_subexpr_3 : Uint256) = mapping_index_access_mapping_uint256_uint256_of_uint256(
+        var_sender_35)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    let (local __warp_subexpr_2 : Uint256) = read_from_storage_split_dynamic_uint256(
+        __warp_subexpr_3)
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
@@ -196,13 +251,21 @@ func fun_withdraw{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : fe
     local range_check_ptr = range_check_ptr
     require_helper(__warp_subexpr_0)
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_4 : Uint256) = getter_fun_balanceOf(var_sender_29)
+    let (local _1_36 : Uint256) = mapping_index_access_mapping_uint256_uint256_of_uint256(
+        var_sender_35)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
-    local syscall_ptr : felt* = syscall_ptr
-    let (local __warp_subexpr_3 : Uint256) = checked_sub_uint256(__warp_subexpr_4, var_wad)
+    let (local __warp_subexpr_6 : Uint256) = sload(_1_36)
     local range_check_ptr = range_check_ptr
-    setter_fun_balanceOf(var_sender_29, __warp_subexpr_3)
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local syscall_ptr : felt* = syscall_ptr
+    let (local __warp_subexpr_5 : Uint256) = extract_from_storage_value_dynamict_uint256(
+        __warp_subexpr_6)
+    let (local __warp_subexpr_4 : Uint256) = checked_sub_uint256(__warp_subexpr_5, var_wad)
+    local range_check_ptr = range_check_ptr
+    update_storage_value_offsett_uint256_to_uint256(_1_36, __warp_subexpr_4)
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
@@ -210,65 +273,13 @@ func fun_withdraw{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : fe
 end
 
 func abi_decode_uint256{exec_env : ExecutionEnvironment*, range_check_ptr}(
-        dataEnd_13 : Uint256) -> (value0_14 : Uint256):
-    alloc_locals
-    let (local __warp_subexpr_2 : Uint256) = uint256_not(Uint256(low=3, high=0))
-    local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_1 : Uint256) = u256_add(dataEnd_13, __warp_subexpr_2)
-    local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_0 : Uint256) = slt(__warp_subexpr_1, Uint256(low=32, high=0))
-    local range_check_ptr = range_check_ptr
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    end
-    let (local value0_14 : Uint256) = calldataload(Uint256(low=4, high=0))
-    local range_check_ptr = range_check_ptr
-    local exec_env : ExecutionEnvironment* = exec_env
-    return (value0_14)
-end
-
-func fun_get_balance{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
-        var_src_32 : Uint256) -> (var : Uint256):
-    alloc_locals
-    let (local var : Uint256) = getter_fun_balanceOf(var_src_32)
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local range_check_ptr = range_check_ptr
-    local syscall_ptr : felt* = syscall_ptr
-    return (var)
-end
-
-func abi_encode_uint256_to_uint256{memory_dict : DictAccess*, msize, range_check_ptr}(
-        value_2 : Uint256, pos : Uint256) -> ():
-    alloc_locals
-    uint256_mstore(offset=pos, value=value_2)
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
-    local range_check_ptr = range_check_ptr
-    return ()
-end
-
-func abi_encode_uint256{memory_dict : DictAccess*, msize, range_check_ptr}(
-        headStart : Uint256, value0_3 : Uint256) -> (tail_4 : Uint256):
-    alloc_locals
-    let (local tail_4 : Uint256) = u256_add(headStart, Uint256(low=32, high=0))
-    local range_check_ptr = range_check_ptr
-    abi_encode_uint256_to_uint256(value0_3, headStart)
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
-    local range_check_ptr = range_check_ptr
-    return (tail_4)
-end
-
-func abi_decode_uint256t_uint256t_uint256t_uint256{
-        exec_env : ExecutionEnvironment*, range_check_ptr}(dataEnd_15 : Uint256) -> (
-        value0_16 : Uint256, value1_17 : Uint256, value2 : Uint256, value3 : Uint256):
+        dataEnd_15 : Uint256) -> (value0_16 : Uint256):
     alloc_locals
     let (local __warp_subexpr_2 : Uint256) = uint256_not(Uint256(low=3, high=0))
     local range_check_ptr = range_check_ptr
     let (local __warp_subexpr_1 : Uint256) = u256_add(dataEnd_15, __warp_subexpr_2)
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_0 : Uint256) = slt(__warp_subexpr_1, Uint256(low=128, high=0))
+    let (local __warp_subexpr_0 : Uint256) = slt(__warp_subexpr_1, Uint256(low=32, high=0))
     local range_check_ptr = range_check_ptr
     if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
         assert 0 = 1
@@ -277,7 +288,67 @@ func abi_decode_uint256t_uint256t_uint256t_uint256{
     let (local value0_16 : Uint256) = calldataload(Uint256(low=4, high=0))
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
-    let (local value1_17 : Uint256) = calldataload(Uint256(low=36, high=0))
+    return (value0_16)
+end
+
+func fun_get_balance{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        syscall_ptr : felt*}(var_src_40 : Uint256) -> (var : Uint256):
+    alloc_locals
+    let (
+        local __warp_subexpr_0 : Uint256) = mapping_index_access_mapping_uint256_uint256_of_uint256(
+        var_src_40)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    let (local var : Uint256) = read_from_storage_split_dynamic_uint256(__warp_subexpr_0)
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    local syscall_ptr : felt* = syscall_ptr
+    return (var)
+end
+
+func abi_encode_uint256_to_uint256{memory_dict : DictAccess*, msize, range_check_ptr}(
+        value_3 : Uint256, pos : Uint256) -> ():
+    alloc_locals
+    uint256_mstore(offset=pos, value=value_3)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local range_check_ptr = range_check_ptr
+    return ()
+end
+
+func abi_encode_uint256{memory_dict : DictAccess*, msize, range_check_ptr}(
+        headStart : Uint256, value0_4 : Uint256) -> (tail_5 : Uint256):
+    alloc_locals
+    let (local tail_5 : Uint256) = u256_add(headStart, Uint256(low=32, high=0))
+    local range_check_ptr = range_check_ptr
+    abi_encode_uint256_to_uint256(value0_4, headStart)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local range_check_ptr = range_check_ptr
+    return (tail_5)
+end
+
+func abi_decode_uint256t_uint256t_uint256t_uint256{
+        exec_env : ExecutionEnvironment*, range_check_ptr}(dataEnd_17 : Uint256) -> (
+        value0_18 : Uint256, value1_19 : Uint256, value2 : Uint256, value3 : Uint256):
+    alloc_locals
+    let (local __warp_subexpr_2 : Uint256) = uint256_not(Uint256(low=3, high=0))
+    local range_check_ptr = range_check_ptr
+    let (local __warp_subexpr_1 : Uint256) = u256_add(dataEnd_17, __warp_subexpr_2)
+    local range_check_ptr = range_check_ptr
+    let (local __warp_subexpr_0 : Uint256) = slt(__warp_subexpr_1, Uint256(low=128, high=0))
+    local range_check_ptr = range_check_ptr
+    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
+    let (local value0_18 : Uint256) = calldataload(Uint256(low=4, high=0))
+    local range_check_ptr = range_check_ptr
+    local exec_env : ExecutionEnvironment* = exec_env
+    let (local value1_19 : Uint256) = calldataload(Uint256(low=36, high=0))
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
     let (local value2 : Uint256) = calldataload(Uint256(low=68, high=0))
@@ -286,7 +357,7 @@ func abi_decode_uint256t_uint256t_uint256t_uint256{
     let (local value3 : Uint256) = calldataload(Uint256(low=100, high=0))
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
-    return (value0_16, value1_17, value2, value3)
+    return (value0_18, value1_19, value2, value3)
 end
 
 func checked_add_uint256{range_check_ptr}(x : Uint256, y : Uint256) -> (sum : Uint256):
@@ -304,14 +375,23 @@ func checked_add_uint256{range_check_ptr}(x : Uint256, y : Uint256) -> (sum : Ui
     return (sum)
 end
 
-func __warp_block_0{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
-        var_src : Uint256, var_wad_30 : Uint256) -> ():
+func __warp_block_0{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        syscall_ptr : felt*}(var_src : Uint256, var_wad_37 : Uint256) -> ():
     alloc_locals
-    let (local __warp_subexpr_2 : Uint256) = getter_fun_balanceOf(var_src)
+    let (
+        local __warp_subexpr_3 : Uint256) = mapping_index_access_mapping_uint256_uint256_of_uint256(
+        var_src)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    let (local __warp_subexpr_2 : Uint256) = read_from_storage_split_dynamic_uint256(
+        __warp_subexpr_3)
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
-    let (local __warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, var_wad_30)
+    let (local __warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, var_wad_37)
     local range_check_ptr = range_check_ptr
     let (local __warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
     local range_check_ptr = range_check_ptr
@@ -320,11 +400,15 @@ func __warp_block_0{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : 
     return ()
 end
 
-func __warp_if_0{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
-        __warp_subexpr_0 : Uint256, var_src : Uint256, var_wad_30 : Uint256) -> ():
+func __warp_if_0{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        syscall_ptr : felt*}(
+        __warp_subexpr_0 : Uint256, var_src : Uint256, var_wad_37 : Uint256) -> ():
     alloc_locals
     if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        __warp_block_0(var_src, var_wad_30)
+        __warp_block_0(var_src, var_wad_37)
+        local memory_dict : DictAccess* = memory_dict
+        local msize = msize
         local pedersen_ptr : HashBuiltin* = pedersen_ptr
         local range_check_ptr = range_check_ptr
         local syscall_ptr : felt* = syscall_ptr
@@ -334,35 +418,53 @@ func __warp_if_0{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : fel
     end
 end
 
-func fun_transferFrom{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
-        var_src : Uint256, var_dst : Uint256, var_wad_30 : Uint256, var_sender_31 : Uint256) -> (
+func fun_transferFrom{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        syscall_ptr : felt*}(
+        var_src : Uint256, var_dst : Uint256, var_wad_37 : Uint256, var_sender_38 : Uint256) -> (
         var_ : Uint256):
     alloc_locals
-    let (local __warp_subexpr_1 : Uint256) = is_eq(var_src, var_sender_31)
+    let (local __warp_subexpr_1 : Uint256) = is_eq(var_src, var_sender_38)
     local range_check_ptr = range_check_ptr
     let (local __warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
     local range_check_ptr = range_check_ptr
-    __warp_if_0(__warp_subexpr_0, var_src, var_wad_30)
+    __warp_if_0(__warp_subexpr_0, var_src, var_wad_37)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
-    let (local __warp_subexpr_3 : Uint256) = getter_fun_balanceOf(var_src)
+    let (local _1_39 : Uint256) = mapping_index_access_mapping_uint256_uint256_of_uint256(var_src)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    let (local __warp_subexpr_4 : Uint256) = sload(_1_39)
+    local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local syscall_ptr : felt* = syscall_ptr
+    let (local __warp_subexpr_3 : Uint256) = extract_from_storage_value_dynamict_uint256(
+        __warp_subexpr_4)
+    let (local __warp_subexpr_2 : Uint256) = checked_sub_uint256(__warp_subexpr_3, var_wad_37)
+    local range_check_ptr = range_check_ptr
+    update_storage_value_offsett_uint256_to_uint256(_1_39, __warp_subexpr_2)
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
-    let (local __warp_subexpr_2 : Uint256) = checked_sub_uint256(__warp_subexpr_3, var_wad_30)
-    local range_check_ptr = range_check_ptr
-    setter_fun_balanceOf(var_src, __warp_subexpr_2)
+    let (local _2 : Uint256) = mapping_index_access_mapping_uint256_uint256_of_uint256(var_dst)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
-    local syscall_ptr : felt* = syscall_ptr
-    let (local __warp_subexpr_5 : Uint256) = getter_fun_balanceOf(var_dst)
+    let (local __warp_subexpr_7 : Uint256) = sload(_2)
+    local range_check_ptr = range_check_ptr
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
-    let (local __warp_subexpr_4 : Uint256) = checked_add_uint256(__warp_subexpr_5, var_wad_30)
+    let (local __warp_subexpr_6 : Uint256) = extract_from_storage_value_dynamict_uint256(
+        __warp_subexpr_7)
+    let (local __warp_subexpr_5 : Uint256) = checked_add_uint256(__warp_subexpr_6, var_wad_37)
     local range_check_ptr = range_check_ptr
-    setter_fun_balanceOf(var_dst, __warp_subexpr_4)
+    update_storage_value_offsett_uint256_to_uint256(_2, __warp_subexpr_5)
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
@@ -371,13 +473,13 @@ func fun_transferFrom{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr 
 end
 
 func abi_encode_bool_to_bool{memory_dict : DictAccess*, msize, range_check_ptr}(
-        value_18 : Uint256, pos_19 : Uint256) -> ():
+        value_20 : Uint256, pos_21 : Uint256) -> ():
     alloc_locals
-    let (local __warp_subexpr_1 : Uint256) = is_zero(value_18)
+    let (local __warp_subexpr_1 : Uint256) = is_zero(value_20)
     local range_check_ptr = range_check_ptr
     let (local __warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
     local range_check_ptr = range_check_ptr
-    uint256_mstore(offset=pos_19, value=__warp_subexpr_0)
+    uint256_mstore(offset=pos_21, value=__warp_subexpr_0)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
@@ -385,27 +487,64 @@ func abi_encode_bool_to_bool{memory_dict : DictAccess*, msize, range_check_ptr}(
 end
 
 func abi_encode_bool{memory_dict : DictAccess*, msize, range_check_ptr}(
-        headStart_20 : Uint256, value0_21 : Uint256) -> (tail_22 : Uint256):
+        headStart_22 : Uint256, value0_23 : Uint256) -> (tail_24 : Uint256):
     alloc_locals
-    let (local tail_22 : Uint256) = u256_add(headStart_20, Uint256(low=32, high=0))
+    let (local tail_24 : Uint256) = u256_add(headStart_22, Uint256(low=32, high=0))
     local range_check_ptr = range_check_ptr
-    abi_encode_bool_to_bool(value0_21, headStart_20)
+    abi_encode_bool_to_bool(value0_23, headStart_22)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    return (tail_22)
+    return (tail_24)
 end
 
-func fun_deposit{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
-        var_sender : Uint256, var_value : Uint256) -> ():
+func mapping_index_access_mapping_uint256_uint256_of_uint256_448{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        key : Uint256) -> (dataSlot : Uint256):
     alloc_locals
-    let (local __warp_subexpr_1 : Uint256) = getter_fun_balanceOf(var_sender)
+    uint256_mstore(offset=Uint256(low=0, high=0), value=key)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local range_check_ptr = range_check_ptr
+    uint256_mstore(offset=Uint256(low=32, high=0), value=Uint256(low=2, high=0))
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local range_check_ptr = range_check_ptr
+    let (local dataSlot : Uint256) = uint256_pedersen(
+        Uint256(low=0, high=0), Uint256(low=64, high=0))
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    return (dataSlot)
+end
+
+func getter_fun_balanceOf{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
+        key_27 : Uint256) -> (ret_28 : Uint256):
+    alloc_locals
+    let (res) = balanceOf.read(key_27.low, key_27.high)
+    return (res)
+end
+
+func fun_deposit{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        syscall_ptr : felt*}(var_sender : Uint256, var_value : Uint256) -> ():
+    alloc_locals
+    let (local _1_32 : Uint256) = mapping_index_access_mapping_uint256_uint256_of_uint256(
+        var_sender)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
+    let (local __warp_subexpr_2 : Uint256) = sload(_1_32)
+    local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local syscall_ptr : felt* = syscall_ptr
+    let (local __warp_subexpr_1 : Uint256) = extract_from_storage_value_dynamict_uint256(
+        __warp_subexpr_2)
     let (local __warp_subexpr_0 : Uint256) = checked_add_uint256(__warp_subexpr_1, var_value)
     local range_check_ptr = range_check_ptr
-    setter_fun_balanceOf(var_sender, __warp_subexpr_0)
+    update_storage_value_offsett_uint256_to_uint256(_1_32, __warp_subexpr_0)
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
@@ -416,29 +555,26 @@ func __warp_block_3{
         exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize,
         pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}() -> ():
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = __warp_constant_0()
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    end
-    let (local __warp_subexpr_1 : Uint256) = calldatasize()
+    let (local __warp_subexpr_0 : Uint256) = calldatasize()
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
-    abi_decode(__warp_subexpr_1)
+    abi_decode(__warp_subexpr_0)
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_5 : Uint256) = getter_fun_totalSupply()
+    let (local __warp_subexpr_5 : Uint256) = sload(Uint256(low=1, high=0))
+    local range_check_ptr = range_check_ptr
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
-    let (local __warp_subexpr_4 : Uint256) = uint256_not(Uint256(low=127, high=0))
+    let (local __warp_subexpr_4 : Uint256) = extract_from_storage_value_dynamict_uint256(
+        __warp_subexpr_5)
+    let (local __warp_subexpr_3 : Uint256) = uint256_not(Uint256(low=127, high=0))
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_3 : Uint256) = abi_encode_uint256_349(__warp_subexpr_5)
+    let (local __warp_subexpr_2 : Uint256) = abi_encode_uint256_440(__warp_subexpr_4)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_2 : Uint256) = u256_add(__warp_subexpr_3, __warp_subexpr_4)
+    let (local __warp_subexpr_1 : Uint256) = u256_add(__warp_subexpr_2, __warp_subexpr_3)
     local range_check_ptr = range_check_ptr
-    returndata_write(Uint256(low=128, high=0), __warp_subexpr_2)
+    returndata_write(Uint256(low=128, high=0), __warp_subexpr_1)
     local exec_env : ExecutionEnvironment* = exec_env
     return ()
 end
@@ -447,20 +583,18 @@ func __warp_block_5{
         exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize,
         pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(_1 : Uint256) -> ():
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = __warp_constant_0()
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    end
-    let (local __warp_subexpr_1 : Uint256) = calldatasize()
+    let (local __warp_subexpr_0 : Uint256) = calldatasize()
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
-    abi_decode(__warp_subexpr_1)
+    abi_decode(__warp_subexpr_0)
     local range_check_ptr = range_check_ptr
-    let (local ret__warp_mangled : Uint256) = getter_fun_decimals()
+    let (local __warp_subexpr_1 : Uint256) = sload(Uint256(low=0, high=0))
+    local range_check_ptr = range_check_ptr
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
+    let (local ret__warp_mangled : Uint256) = extract_from_storage_value_dynamict_uint8(
+        __warp_subexpr_1)
+    local range_check_ptr = range_check_ptr
     let (local memPos : Uint256) = uint256_mload(_1)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
@@ -488,6 +622,8 @@ func __warp_block_7{
     local exec_env : ExecutionEnvironment* = exec_env
     local range_check_ptr = range_check_ptr
     fun_withdraw(param, param_1)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
@@ -504,18 +640,15 @@ func __warp_block_9{
         exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize,
         pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(_1 : Uint256) -> ():
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = __warp_constant_0()
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    end
-    let (local __warp_subexpr_2 : Uint256) = calldatasize()
+    let (local __warp_subexpr_1 : Uint256) = calldatasize()
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
-    let (local __warp_subexpr_1 : Uint256) = abi_decode_uint256(__warp_subexpr_2)
+    let (local __warp_subexpr_0 : Uint256) = abi_decode_uint256(__warp_subexpr_1)
     local exec_env : ExecutionEnvironment* = exec_env
     local range_check_ptr = range_check_ptr
-    let (local ret_1 : Uint256) = fun_get_balance(__warp_subexpr_1)
+    let (local ret_1 : Uint256) = fun_get_balance(__warp_subexpr_0)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
@@ -523,13 +656,13 @@ func __warp_block_9{
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_4 : Uint256) = abi_encode_uint256(memPos_1, ret_1)
+    let (local __warp_subexpr_3 : Uint256) = abi_encode_uint256(memPos_1, ret_1)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_3 : Uint256) = uint256_sub(__warp_subexpr_4, memPos_1)
+    let (local __warp_subexpr_2 : Uint256) = uint256_sub(__warp_subexpr_3, memPos_1)
     local range_check_ptr = range_check_ptr
-    returndata_write(memPos_1, __warp_subexpr_3)
+    returndata_write(memPos_1, __warp_subexpr_2)
     local exec_env : ExecutionEnvironment* = exec_env
     return ()
 end
@@ -546,6 +679,8 @@ func __warp_block_11{
     local exec_env : ExecutionEnvironment* = exec_env
     local range_check_ptr = range_check_ptr
     let (local ret_2 : Uint256) = fun_transferFrom(param_2, param_3, param_4, param_5)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
@@ -568,18 +703,13 @@ func __warp_block_13{
         exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize,
         pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(_1 : Uint256) -> ():
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = __warp_constant_0()
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    end
-    let (local __warp_subexpr_2 : Uint256) = calldatasize()
+    let (local __warp_subexpr_1 : Uint256) = calldatasize()
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
-    let (local __warp_subexpr_1 : Uint256) = abi_decode_uint256(__warp_subexpr_2)
+    let (local __warp_subexpr_0 : Uint256) = abi_decode_uint256(__warp_subexpr_1)
     local exec_env : ExecutionEnvironment* = exec_env
     local range_check_ptr = range_check_ptr
-    let (local ret_3 : Uint256) = getter_fun_balanceOf(__warp_subexpr_1)
+    let (local ret_3 : Uint256) = getter_fun_balanceOf(__warp_subexpr_0)
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
@@ -587,13 +717,13 @@ func __warp_block_13{
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_4 : Uint256) = abi_encode_uint256(memPos_3, ret_3)
+    let (local __warp_subexpr_3 : Uint256) = abi_encode_uint256(memPos_3, ret_3)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_3 : Uint256) = uint256_sub(__warp_subexpr_4, memPos_3)
+    let (local __warp_subexpr_2 : Uint256) = uint256_sub(__warp_subexpr_3, memPos_3)
     local range_check_ptr = range_check_ptr
-    returndata_write(memPos_3, __warp_subexpr_3)
+    returndata_write(memPos_3, __warp_subexpr_2)
     local exec_env : ExecutionEnvironment* = exec_env
     return ()
 end
@@ -610,6 +740,8 @@ func __warp_block_15{
     local exec_env : ExecutionEnvironment* = exec_env
     local range_check_ptr = range_check_ptr
     fun_deposit(param_6, param_7)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr

--- a/tests/yul/arrays.cairo
+++ b/tests/yul/arrays.cairo
@@ -1,0 +1,460 @@
+%lang starknet
+%builtins pedersen range_check bitwise
+
+from evm.calls import calldataload, calldatasize, returndata_write
+from evm.exec_env import ExecutionEnvironment
+from evm.hashing import uint256_pedersen
+from evm.memory import uint256_mload, uint256_mstore
+from evm.uint256 import is_eq, is_lt, is_zero, slt, u256_add, u256_shl, u256_shr
+from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.cairo_builtins import BitwiseBuiltin, HashBuiltin
+from starkware.cairo.common.default_dict import default_dict_finalize, default_dict_new
+from starkware.cairo.common.dict_access import DictAccess
+from starkware.cairo.common.registers import get_fp_and_pc
+from starkware.cairo.common.uint256 import Uint256, uint256_and, uint256_not, uint256_sub
+
+func sload{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(key : Uint256) -> (
+        value : Uint256):
+    let (res) = evm_storage.read(key.low, key.high)
+    return (res)
+end
+
+func sstore{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
+        key : Uint256, value : Uint256):
+    evm_storage.write(key.low, key.high, value)
+    return ()
+end
+
+@storage_var
+func evm_storage(arg0_low, arg0_high) -> (res : Uint256):
+end
+
+@storage_var
+func this_address() -> (res : felt):
+end
+
+@storage_var
+func address_initialized() -> (res : felt):
+end
+
+func initialize_address{range_check_ptr, syscall_ptr : felt*, pedersen_ptr : HashBuiltin*}(
+        self_address : felt):
+    let (address_init) = address_initialized.read()
+    if address_init == 1:
+        return ()
+    end
+    this_address.write(self_address)
+    address_initialized.write(1)
+    return ()
+end
+
+func abi_decode_uint256t_uint256{exec_env : ExecutionEnvironment*, range_check_ptr}(
+        dataEnd : Uint256) -> (value0 : Uint256, value1 : Uint256):
+    alloc_locals
+    let (local __warp_subexpr_2 : Uint256) = uint256_not(Uint256(low=3, high=0))
+    local range_check_ptr = range_check_ptr
+    let (local __warp_subexpr_1 : Uint256) = u256_add(dataEnd, __warp_subexpr_2)
+    local range_check_ptr = range_check_ptr
+    let (local __warp_subexpr_0 : Uint256) = slt(__warp_subexpr_1, Uint256(low=64, high=0))
+    local range_check_ptr = range_check_ptr
+    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
+    let (local value0 : Uint256) = calldataload(Uint256(low=4, high=0))
+    local range_check_ptr = range_check_ptr
+    local exec_env : ExecutionEnvironment* = exec_env
+    let (local value1 : Uint256) = calldataload(Uint256(low=36, high=0))
+    local range_check_ptr = range_check_ptr
+    local exec_env : ExecutionEnvironment* = exec_env
+    return (value0, value1)
+end
+
+func array_dataslot_array_uint256_dyn_storage{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+        data : Uint256):
+    alloc_locals
+    uint256_mstore(offset=Uint256(low=0, high=0), value=Uint256(low=0, high=0))
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local range_check_ptr = range_check_ptr
+    let (local data : Uint256) = uint256_pedersen(Uint256(low=0, high=0), Uint256(low=32, high=0))
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    return (data)
+end
+
+func storage_array_index_access_uint256_dyn{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        syscall_ptr : felt*}(index : Uint256) -> (slot : Uint256, offset : Uint256):
+    alloc_locals
+    let (local __warp_subexpr_2 : Uint256) = sload(Uint256(low=0, high=0))
+    local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local syscall_ptr : felt* = syscall_ptr
+    let (local __warp_subexpr_1 : Uint256) = is_lt(index, __warp_subexpr_2)
+    local range_check_ptr = range_check_ptr
+    let (local __warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
+    local range_check_ptr = range_check_ptr
+    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
+    let (local __warp_subexpr_3 : Uint256) = array_dataslot_array_uint256_dyn_storage()
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    let (local slot : Uint256) = u256_add(__warp_subexpr_3, index)
+    local range_check_ptr = range_check_ptr
+    local offset : Uint256 = Uint256(low=0, high=0)
+    return (slot, offset)
+end
+
+func update_byte_slice_dynamic32{range_check_ptr}(
+        value_4 : Uint256, shiftBytes : Uint256, toInsert : Uint256) -> (result : Uint256):
+    alloc_locals
+    let (local shiftBits : Uint256) = u256_shl(Uint256(low=3, high=0), shiftBytes)
+    local range_check_ptr = range_check_ptr
+    let (local __warp_subexpr_0 : Uint256) = uint256_not(Uint256(low=0, high=0))
+    local range_check_ptr = range_check_ptr
+    let (local mask : Uint256) = u256_shl(shiftBits, __warp_subexpr_0)
+    local range_check_ptr = range_check_ptr
+    let (local __warp_subexpr_4 : Uint256) = u256_shl(shiftBits, toInsert)
+    local range_check_ptr = range_check_ptr
+    let (local __warp_subexpr_3 : Uint256) = uint256_not(mask)
+    local range_check_ptr = range_check_ptr
+    let (local __warp_subexpr_2 : Uint256) = uint256_and(__warp_subexpr_4, mask)
+    local range_check_ptr = range_check_ptr
+    let (local __warp_subexpr_1 : Uint256) = uint256_and(value_4, __warp_subexpr_3)
+    local range_check_ptr = range_check_ptr
+    let (local result : Uint256) = uint256_sub(__warp_subexpr_1, __warp_subexpr_2)
+    local range_check_ptr = range_check_ptr
+    return (result)
+end
+
+func update_storage_value_uint256_to_uint256{
+        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
+        slot_5 : Uint256, offset_6 : Uint256, value_7 : Uint256) -> ():
+    alloc_locals
+    let (local __warp_subexpr_1 : Uint256) = sload(slot_5)
+    local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local syscall_ptr : felt* = syscall_ptr
+    let (local __warp_subexpr_0 : Uint256) = update_byte_slice_dynamic32(
+        __warp_subexpr_1, offset_6, value_7)
+    local range_check_ptr = range_check_ptr
+    sstore(key=slot_5, value=__warp_subexpr_0)
+    local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local syscall_ptr : felt* = syscall_ptr
+    return ()
+end
+
+func fun_set{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        syscall_ptr : felt*}(var_i : Uint256, var_value : Uint256) -> ():
+    alloc_locals
+    let (local _1 : Uint256, local _2 : Uint256) = storage_array_index_access_uint256_dyn(var_i)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    local syscall_ptr : felt* = syscall_ptr
+    update_storage_value_uint256_to_uint256(_1, _2, var_value)
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    local syscall_ptr : felt* = syscall_ptr
+    return ()
+end
+
+func abi_decode_uint256{exec_env : ExecutionEnvironment*, range_check_ptr}(dataEnd_1 : Uint256) -> (
+        value0_2 : Uint256):
+    alloc_locals
+    let (local __warp_subexpr_2 : Uint256) = uint256_not(Uint256(low=3, high=0))
+    local range_check_ptr = range_check_ptr
+    let (local __warp_subexpr_1 : Uint256) = u256_add(dataEnd_1, __warp_subexpr_2)
+    local range_check_ptr = range_check_ptr
+    let (local __warp_subexpr_0 : Uint256) = slt(__warp_subexpr_1, Uint256(low=32, high=0))
+    local range_check_ptr = range_check_ptr
+    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
+    let (local value0_2 : Uint256) = calldataload(Uint256(low=4, high=0))
+    local range_check_ptr = range_check_ptr
+    local exec_env : ExecutionEnvironment* = exec_env
+    return (value0_2)
+end
+
+func extract_from_storage_value_dynamict_uint256{range_check_ptr}(
+        slot_value : Uint256, offset_8 : Uint256) -> (value_9 : Uint256):
+    alloc_locals
+    let (local __warp_subexpr_0 : Uint256) = u256_shl(Uint256(low=3, high=0), offset_8)
+    local range_check_ptr = range_check_ptr
+    let (local value_9 : Uint256) = u256_shr(__warp_subexpr_0, slot_value)
+    local range_check_ptr = range_check_ptr
+    return (value_9)
+end
+
+func fun_get{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        syscall_ptr : felt*}(var_i_10 : Uint256) -> (var : Uint256):
+    alloc_locals
+    let (local _1_11 : Uint256, local _2_12 : Uint256) = storage_array_index_access_uint256_dyn(
+        var_i_10)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    local syscall_ptr : felt* = syscall_ptr
+    let (local __warp_subexpr_0 : Uint256) = sload(_1_11)
+    local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local syscall_ptr : felt* = syscall_ptr
+    let (local var : Uint256) = extract_from_storage_value_dynamict_uint256(__warp_subexpr_0, _2_12)
+    local range_check_ptr = range_check_ptr
+    return (var)
+end
+
+func abi_encode_uint256_to_uint256{memory_dict : DictAccess*, msize, range_check_ptr}(
+        value : Uint256, pos : Uint256) -> ():
+    alloc_locals
+    uint256_mstore(offset=pos, value=value)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local range_check_ptr = range_check_ptr
+    return ()
+end
+
+func abi_encode_uint256{memory_dict : DictAccess*, msize, range_check_ptr}(
+        headStart : Uint256, value0_3 : Uint256) -> (tail : Uint256):
+    alloc_locals
+    let (local tail : Uint256) = u256_add(headStart, Uint256(low=32, high=0))
+    local range_check_ptr = range_check_ptr
+    abi_encode_uint256_to_uint256(value0_3, headStart)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local range_check_ptr = range_check_ptr
+    return (tail)
+end
+
+func __warp_block_2{
+        exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize,
+        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}() -> ():
+    alloc_locals
+    let (local __warp_subexpr_0 : Uint256) = calldatasize()
+    local range_check_ptr = range_check_ptr
+    local exec_env : ExecutionEnvironment* = exec_env
+    let (local param : Uint256, local param_1 : Uint256) = abi_decode_uint256t_uint256(
+        __warp_subexpr_0)
+    local exec_env : ExecutionEnvironment* = exec_env
+    local range_check_ptr = range_check_ptr
+    fun_set(param, param_1)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    local syscall_ptr : felt* = syscall_ptr
+    let (local __warp_subexpr_1 : Uint256) = uint256_mload(Uint256(low=64, high=0))
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local range_check_ptr = range_check_ptr
+    returndata_write(__warp_subexpr_1, Uint256(low=0, high=0))
+    local exec_env : ExecutionEnvironment* = exec_env
+    return ()
+end
+
+func __warp_block_4{
+        exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize,
+        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}() -> ():
+    alloc_locals
+    let (local __warp_subexpr_1 : Uint256) = calldatasize()
+    local range_check_ptr = range_check_ptr
+    local exec_env : ExecutionEnvironment* = exec_env
+    let (local __warp_subexpr_0 : Uint256) = abi_decode_uint256(__warp_subexpr_1)
+    local exec_env : ExecutionEnvironment* = exec_env
+    local range_check_ptr = range_check_ptr
+    let (local ret__warp_mangled : Uint256) = fun_get(__warp_subexpr_0)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    local syscall_ptr : felt* = syscall_ptr
+    let (local memPos : Uint256) = uint256_mload(Uint256(low=64, high=0))
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local range_check_ptr = range_check_ptr
+    let (local __warp_subexpr_3 : Uint256) = abi_encode_uint256(memPos, ret__warp_mangled)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local range_check_ptr = range_check_ptr
+    let (local __warp_subexpr_2 : Uint256) = uint256_sub(__warp_subexpr_3, memPos)
+    local range_check_ptr = range_check_ptr
+    returndata_write(memPos, __warp_subexpr_2)
+    local exec_env : ExecutionEnvironment* = exec_env
+    return ()
+end
+
+func __warp_if_2{
+        exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize,
+        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
+        __warp_subexpr_0 : Uint256) -> ():
+    alloc_locals
+    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
+        __warp_block_4()
+        local exec_env : ExecutionEnvironment* = exec_env
+        local memory_dict : DictAccess* = memory_dict
+        local msize = msize
+        local pedersen_ptr : HashBuiltin* = pedersen_ptr
+        local range_check_ptr = range_check_ptr
+        local syscall_ptr : felt* = syscall_ptr
+        return ()
+    else:
+        return ()
+    end
+end
+
+func __warp_block_3{
+        exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize,
+        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(match_var : Uint256) -> (
+        ):
+    alloc_locals
+    let (local __warp_subexpr_0 : Uint256) = is_eq(match_var, Uint256(low=2500318106, high=0))
+    local range_check_ptr = range_check_ptr
+    __warp_if_2(__warp_subexpr_0)
+    local exec_env : ExecutionEnvironment* = exec_env
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    local syscall_ptr : felt* = syscall_ptr
+    return ()
+end
+
+func __warp_if_1{
+        exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize,
+        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
+        __warp_subexpr_0 : Uint256, match_var : Uint256) -> ():
+    alloc_locals
+    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
+        __warp_block_2()
+        local exec_env : ExecutionEnvironment* = exec_env
+        local memory_dict : DictAccess* = memory_dict
+        local msize = msize
+        local pedersen_ptr : HashBuiltin* = pedersen_ptr
+        local range_check_ptr = range_check_ptr
+        local syscall_ptr : felt* = syscall_ptr
+        return ()
+    else:
+        __warp_block_3(match_var)
+        local exec_env : ExecutionEnvironment* = exec_env
+        local memory_dict : DictAccess* = memory_dict
+        local msize = msize
+        local pedersen_ptr : HashBuiltin* = pedersen_ptr
+        local range_check_ptr = range_check_ptr
+        local syscall_ptr : felt* = syscall_ptr
+        return ()
+    end
+end
+
+func __warp_block_1{
+        exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize,
+        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(match_var : Uint256) -> (
+        ):
+    alloc_locals
+    let (local __warp_subexpr_0 : Uint256) = is_eq(match_var, Uint256(low=447770341, high=0))
+    local range_check_ptr = range_check_ptr
+    __warp_if_1(__warp_subexpr_0, match_var)
+    local exec_env : ExecutionEnvironment* = exec_env
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    local syscall_ptr : felt* = syscall_ptr
+    return ()
+end
+
+func __warp_block_0{
+        exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize,
+        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}() -> ():
+    alloc_locals
+    let (local __warp_subexpr_0 : Uint256) = calldataload(Uint256(low=0, high=0))
+    local range_check_ptr = range_check_ptr
+    local exec_env : ExecutionEnvironment* = exec_env
+    let (local match_var : Uint256) = u256_shr(Uint256(low=224, high=0), __warp_subexpr_0)
+    local range_check_ptr = range_check_ptr
+    __warp_block_1(match_var)
+    local exec_env : ExecutionEnvironment* = exec_env
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    local syscall_ptr : felt* = syscall_ptr
+    return ()
+end
+
+func __warp_if_0{
+        exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize,
+        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
+        __warp_subexpr_0 : Uint256) -> ():
+    alloc_locals
+    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
+        __warp_block_0()
+        local exec_env : ExecutionEnvironment* = exec_env
+        local memory_dict : DictAccess* = memory_dict
+        local msize = msize
+        local pedersen_ptr : HashBuiltin* = pedersen_ptr
+        local range_check_ptr = range_check_ptr
+        local syscall_ptr : felt* = syscall_ptr
+        return ()
+    else:
+        return ()
+    end
+end
+
+@external
+func fun_ENTRY_POINT{
+        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
+        bitwise_ptr : BitwiseBuiltin*}(
+        calldata_size, calldata_len, calldata : felt*, self_address : felt) -> (
+        success : felt, returndata_size : felt, returndata_len : felt, returndata : felt*):
+    alloc_locals
+    let (local __fp__, _) = get_fp_and_pc()
+    initialize_address{
+        range_check_ptr=range_check_ptr, syscall_ptr=syscall_ptr, pedersen_ptr=pedersen_ptr}(
+        self_address)
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local range_check_ptr = range_check_ptr
+    local syscall_ptr : felt* = syscall_ptr
+    let (returndata_ptr : felt*) = alloc()
+    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
+    let exec_env : ExecutionEnvironment* = &exec_env_
+    let (local memory_dict) = default_dict_new(0)
+    local memory_dict_start : DictAccess* = memory_dict
+    let msize = 0
+    with exec_env, msize, memory_dict:
+        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+        local memory_dict : DictAccess* = memory_dict
+        local msize = msize
+        local range_check_ptr = range_check_ptr
+        let (local __warp_subexpr_2 : Uint256) = calldatasize()
+        local range_check_ptr = range_check_ptr
+        local exec_env : ExecutionEnvironment* = exec_env
+        let (local __warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
+        local range_check_ptr = range_check_ptr
+        let (local __warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
+        local range_check_ptr = range_check_ptr
+        __warp_if_0(__warp_subexpr_0)
+        local exec_env : ExecutionEnvironment* = exec_env
+        local memory_dict : DictAccess* = memory_dict
+        local msize = msize
+        local pedersen_ptr : HashBuiltin* = pedersen_ptr
+        local range_check_ptr = range_check_ptr
+        local syscall_ptr : felt* = syscall_ptr
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return (1, exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
+end

--- a/tests/yul/arrays.sol
+++ b/tests/yul/arrays.sol
@@ -1,0 +1,13 @@
+pragma solidity ^0.8.6;
+
+contract WARP {
+    uint[] balanceOf;
+
+    function set(uint i, uint256 value) public {
+        balanceOf[i] = value;
+    }
+
+    function get(uint i) public returns (uint) {
+        return (balanceOf[i]);
+    }
+}

--- a/tests/yul/c2c.cairo
+++ b/tests/yul/c2c.cairo
@@ -20,10 +20,6 @@ func __warp_constant_10000000000000000000000000000000000000000() -> (res : Uint2
     return (Uint256(low=131811359292784559562136384478721867776, high=29))
 end
 
-func __warp_constant_0() -> (res : Uint256):
-    return (Uint256(low=0, high=0))
-end
-
 @storage_var
 func this_address() -> (res : felt):
 end
@@ -445,7 +441,7 @@ func fun_checkMoneyz{
     return (var_)
 end
 
-func abi_encode_uint256_to_uint256_802{memory_dict : DictAccess*, msize, range_check_ptr}(
+func abi_encode_uint256_to_uint256_793{memory_dict : DictAccess*, msize, range_check_ptr}(
         pos_5 : Uint256) -> ():
     alloc_locals
     uint256_mstore(offset=pos_5, value=Uint256(low=42, high=0))
@@ -466,7 +462,7 @@ func abi_encode_address_rational_by{memory_dict : DictAccess*, msize, range_chec
     local range_check_ptr = range_check_ptr
     let (local __warp_subexpr_0 : Uint256) = u256_add(headStart_16, Uint256(low=32, high=0))
     local range_check_ptr = range_check_ptr
-    abi_encode_uint256_to_uint256_802(__warp_subexpr_0)
+    abi_encode_uint256_to_uint256_793(__warp_subexpr_0)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
@@ -569,16 +565,11 @@ func __warp_block_5{
         exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize, range_check_ptr,
         syscall_ptr : felt*}() -> ():
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = __warp_constant_0()
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    end
-    let (local __warp_subexpr_1 : Uint256) = calldatasize()
+    let (local __warp_subexpr_0 : Uint256) = calldatasize()
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
     let (local param : Uint256, local param_1 : Uint256, local param_2 : Uint256,
-        local param_3 : Uint256) = abi_decode_addresst_addresst_addresst_uint256(__warp_subexpr_1)
+        local param_3 : Uint256) = abi_decode_addresst_addresst_addresst_uint256(__warp_subexpr_0)
     local exec_env : ExecutionEnvironment* = exec_env
     local range_check_ptr = range_check_ptr
     let (local ret__warp_mangled : Uint256) = fun_sendMoneyz(param, param_1, param_2, param_3)
@@ -591,13 +582,13 @@ func __warp_block_5{
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_3 : Uint256) = abi_encode_bool(memPos, ret__warp_mangled)
+    let (local __warp_subexpr_2 : Uint256) = abi_encode_bool(memPos, ret__warp_mangled)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_2 : Uint256) = uint256_sub(__warp_subexpr_3, memPos)
+    let (local __warp_subexpr_1 : Uint256) = uint256_sub(__warp_subexpr_2, memPos)
     local range_check_ptr = range_check_ptr
-    returndata_write(memPos, __warp_subexpr_2)
+    returndata_write(memPos, __warp_subexpr_1)
     local exec_env : ExecutionEnvironment* = exec_env
     return ()
 end
@@ -606,16 +597,11 @@ func __warp_block_7{
         exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize, range_check_ptr,
         syscall_ptr : felt*}() -> ():
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = __warp_constant_0()
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    end
-    let (local __warp_subexpr_1 : Uint256) = calldatasize()
+    let (local __warp_subexpr_0 : Uint256) = calldatasize()
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
     let (local param_4 : Uint256, local param_5 : Uint256) = abi_decode_addresst_address(
-        __warp_subexpr_1)
+        __warp_subexpr_0)
     local exec_env : ExecutionEnvironment* = exec_env
     local range_check_ptr = range_check_ptr
     let (local ret_1 : Uint256) = fun_checkMoneyz(param_4, param_5)
@@ -628,13 +614,13 @@ func __warp_block_7{
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_3 : Uint256) = abi_encode_uint256(memPos_1, ret_1)
+    let (local __warp_subexpr_2 : Uint256) = abi_encode_uint256(memPos_1, ret_1)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_2 : Uint256) = uint256_sub(__warp_subexpr_3, memPos_1)
+    let (local __warp_subexpr_1 : Uint256) = uint256_sub(__warp_subexpr_2, memPos_1)
     local range_check_ptr = range_check_ptr
-    returndata_write(memPos_1, __warp_subexpr_2)
+    returndata_write(memPos_1, __warp_subexpr_1)
     local exec_env : ExecutionEnvironment* = exec_env
     return ()
 end
@@ -643,16 +629,11 @@ func __warp_block_9{
         exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize, range_check_ptr,
         syscall_ptr : felt*}() -> ():
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = __warp_constant_0()
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    end
-    let (local __warp_subexpr_1 : Uint256) = calldatasize()
+    let (local __warp_subexpr_0 : Uint256) = calldatasize()
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
     let (local param_6 : Uint256, local param_7 : Uint256) = abi_decode_addresst_address(
-        __warp_subexpr_1)
+        __warp_subexpr_0)
     local exec_env : ExecutionEnvironment* = exec_env
     local range_check_ptr = range_check_ptr
     let (local ret_2 : Uint256) = fun_gimmeMoney(param_6, param_7)
@@ -665,13 +646,13 @@ func __warp_block_9{
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_3 : Uint256) = abi_encode_bool(memPos_2, ret_2)
+    let (local __warp_subexpr_2 : Uint256) = abi_encode_bool(memPos_2, ret_2)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_2 : Uint256) = uint256_sub(__warp_subexpr_3, memPos_2)
+    let (local __warp_subexpr_1 : Uint256) = uint256_sub(__warp_subexpr_2, memPos_2)
     local range_check_ptr = range_check_ptr
-    returndata_write(memPos_2, __warp_subexpr_2)
+    returndata_write(memPos_2, __warp_subexpr_1)
     local exec_env : ExecutionEnvironment* = exec_env
     return ()
 end

--- a/tests/yul/calldataload.cairo
+++ b/tests/yul/calldataload.cairo
@@ -16,10 +16,6 @@ func returndata_size{exec_env : ExecutionEnvironment*}() -> (res : Uint256):
     return (Uint256(low=exec_env.returndata_size, high=0))
 end
 
-func __warp_constant_0() -> (res : Uint256):
-    return (Uint256(low=0, high=0))
-end
-
 @storage_var
 func this_address() -> (res : felt):
 end
@@ -79,7 +75,7 @@ func abi_encode_uint256{memory_dict : DictAccess*, msize, range_check_ptr}(value
     return ()
 end
 
-func abi_encode_uint256_72{memory_dict : DictAccess*, msize, range_check_ptr}(value0 : Uint256) -> (
+func abi_encode_uint256_70{memory_dict : DictAccess*, msize, range_check_ptr}(value0 : Uint256) -> (
         tail : Uint256):
     alloc_locals
     local tail : Uint256 = Uint256(low=160, high=0)
@@ -94,28 +90,23 @@ func __warp_block_1{
         exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize, range_check_ptr}() -> (
         ):
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = __warp_constant_0()
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    end
-    let (local __warp_subexpr_1 : Uint256) = calldatasize()
+    let (local __warp_subexpr_0 : Uint256) = calldatasize()
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
-    abi_decode(__warp_subexpr_1)
+    abi_decode(__warp_subexpr_0)
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_5 : Uint256) = fun_test()
+    let (local __warp_subexpr_4 : Uint256) = fun_test()
     local exec_env : ExecutionEnvironment* = exec_env
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_4 : Uint256) = uint256_not(Uint256(low=127, high=0))
+    let (local __warp_subexpr_3 : Uint256) = uint256_not(Uint256(low=127, high=0))
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_3 : Uint256) = abi_encode_uint256_72(__warp_subexpr_5)
+    let (local __warp_subexpr_2 : Uint256) = abi_encode_uint256_70(__warp_subexpr_4)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_2 : Uint256) = u256_add(__warp_subexpr_3, __warp_subexpr_4)
+    let (local __warp_subexpr_1 : Uint256) = u256_add(__warp_subexpr_2, __warp_subexpr_3)
     local range_check_ptr = range_check_ptr
-    returndata_write(Uint256(low=128, high=0), __warp_subexpr_2)
+    returndata_write(Uint256(low=128, high=0), __warp_subexpr_1)
     local exec_env : ExecutionEnvironment* = exec_env
     return ()
 end

--- a/tests/yul/calldatasize.cairo
+++ b/tests/yul/calldatasize.cairo
@@ -12,10 +12,6 @@ from starkware.cairo.common.dict_access import DictAccess
 from starkware.cairo.common.registers import get_fp_and_pc
 from starkware.cairo.common.uint256 import Uint256, uint256_not
 
-func __warp_constant_0() -> (res : Uint256):
-    return (Uint256(low=0, high=0))
-end
-
 @storage_var
 func this_address() -> (res : felt):
 end
@@ -76,7 +72,7 @@ func abi_encode_uint256{memory_dict : DictAccess*, msize, range_check_ptr}(value
     return ()
 end
 
-func abi_encode_uint256_72{memory_dict : DictAccess*, msize, range_check_ptr}(value0 : Uint256) -> (
+func abi_encode_uint256_70{memory_dict : DictAccess*, msize, range_check_ptr}(value0 : Uint256) -> (
         tail : Uint256):
     alloc_locals
     local tail : Uint256 = Uint256(low=160, high=0)
@@ -91,28 +87,23 @@ func __warp_block_1{
         exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize, range_check_ptr}() -> (
         ):
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = __warp_constant_0()
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    end
-    let (local __warp_subexpr_1 : Uint256) = calldatasize()
+    let (local __warp_subexpr_0 : Uint256) = calldatasize()
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
-    abi_decode(__warp_subexpr_1)
+    abi_decode(__warp_subexpr_0)
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_5 : Uint256) = fun_test()
+    let (local __warp_subexpr_4 : Uint256) = fun_test()
     local exec_env : ExecutionEnvironment* = exec_env
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_4 : Uint256) = uint256_not(Uint256(low=127, high=0))
+    let (local __warp_subexpr_3 : Uint256) = uint256_not(Uint256(low=127, high=0))
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_3 : Uint256) = abi_encode_uint256_72(__warp_subexpr_5)
+    let (local __warp_subexpr_2 : Uint256) = abi_encode_uint256_70(__warp_subexpr_4)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_2 : Uint256) = u256_add(__warp_subexpr_3, __warp_subexpr_4)
+    let (local __warp_subexpr_1 : Uint256) = u256_add(__warp_subexpr_2, __warp_subexpr_3)
     local range_check_ptr = range_check_ptr
-    returndata_write(Uint256(low=128, high=0), __warp_subexpr_2)
+    returndata_write(Uint256(low=128, high=0), __warp_subexpr_1)
     local exec_env : ExecutionEnvironment* = exec_env
     return ()
 end

--- a/tests/yul/constructors_dyn.cairo
+++ b/tests/yul/constructors_dyn.cairo
@@ -12,20 +12,20 @@ from starkware.cairo.common.dict_access import DictAccess
 from starkware.cairo.common.registers import get_fp_and_pc
 from starkware.cairo.common.uint256 import Uint256, uint256_not, uint256_sub
 
-func __warp_constant_0() -> (res : Uint256):
-    return (Uint256(low=0, high=0))
+func sload{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(key : Uint256) -> (
+        value : Uint256):
+    let (res) = evm_storage.read(key.low, key.high)
+    return (res)
+end
+
+func sstore{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
+        key : Uint256, value : Uint256):
+    evm_storage.write(key.low, key.high, value)
+    return ()
 end
 
 @storage_var
-func owner() -> (res : Uint256):
-end
-
-@storage_var
-func ownerAge() -> (res : Uint256):
-end
-
-@storage_var
-func ownerCellNumber() -> (res : Uint256):
+func evm_storage(arg0_low, arg0_high) -> (res : Uint256):
 end
 
 @storage_var
@@ -89,39 +89,25 @@ func abi_decode_addresst_struct_Person_calldatat_uint256{
     return (value0, value1, value2)
 end
 
-func getter_fun_owner{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}() -> (
-        value_16 : Uint256):
+func cleanup_uint256(value : Uint256) -> (cleaned : Uint256):
     alloc_locals
-    let (res) = owner.read()
-    return (res)
-end
-
-func getter_fun_ownerAge{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}() -> (
-        value_17 : Uint256):
-    alloc_locals
-    let (res) = ownerAge.read()
-    return (res)
-end
-
-func getter_fun_ownerCellNumber{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
-        ) -> (value_5 : Uint256):
-    alloc_locals
-    let (res) = ownerCellNumber.read()
-    return (res)
+    local cleaned : Uint256 = value
+    return (cleaned)
 end
 
 func __warp_block_0{
         exec_env : ExecutionEnvironment*, pedersen_ptr : HashBuiltin*, range_check_ptr,
         syscall_ptr : felt*}(var_person_offset : Uint256) -> (expr : Uint256):
     alloc_locals
-    let (local _1 : Uint256) = getter_fun_ownerAge()
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    let (local __warp_subexpr_0 : Uint256) = sload(Uint256(low=1, high=0))
     local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local syscall_ptr : felt* = syscall_ptr
-    let (local __warp_subexpr_0 : Uint256) = calldataload(var_person_offset)
+    let (local _1 : Uint256) = cleanup_uint256(__warp_subexpr_0)
+    let (local __warp_subexpr_1 : Uint256) = calldataload(var_person_offset)
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
-    let (local expr : Uint256) = is_eq(_1, __warp_subexpr_0)
+    let (local expr : Uint256) = is_eq(_1, __warp_subexpr_1)
     local range_check_ptr = range_check_ptr
     return (expr)
 end
@@ -145,10 +131,11 @@ end
 func __warp_block_1{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
         var_ownerCellNumberCheck : Uint256) -> (expr_1 : Uint256):
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = getter_fun_ownerCellNumber()
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    let (local __warp_subexpr_1 : Uint256) = sload(Uint256(low=2, high=0))
     local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local syscall_ptr : felt* = syscall_ptr
+    let (local __warp_subexpr_0 : Uint256) = cleanup_uint256(__warp_subexpr_1)
     let (local expr_1 : Uint256) = is_eq(__warp_subexpr_0, var_ownerCellNumberCheck)
     local range_check_ptr = range_check_ptr
     return (expr_1)
@@ -174,10 +161,11 @@ func fun_validate_constructor{
         var_ownerCheck : Uint256, var_person_offset : Uint256,
         var_ownerCellNumberCheck : Uint256) -> (var : Uint256):
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = getter_fun_owner()
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    let (local __warp_subexpr_1 : Uint256) = sload(Uint256(low=0, high=0))
     local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local syscall_ptr : felt* = syscall_ptr
+    let (local __warp_subexpr_0 : Uint256) = cleanup_uint256(__warp_subexpr_1)
     let (local expr : Uint256) = is_eq(__warp_subexpr_0, var_ownerCheck)
     local range_check_ptr = range_check_ptr
     let (local expr : Uint256) = __warp_if_0(expr, var_person_offset)
@@ -207,7 +195,7 @@ func abi_encode_bool{memory_dict : DictAccess*, msize, range_check_ptr}(value_2 
     return ()
 end
 
-func abi_encode_bool_388{memory_dict : DictAccess*, msize, range_check_ptr}(value0_3 : Uint256) -> (
+func abi_encode_bool_433{memory_dict : DictAccess*, msize, range_check_ptr}(value0_3 : Uint256) -> (
         tail : Uint256):
     alloc_locals
     local tail : Uint256 = Uint256(low=160, high=0)
@@ -235,9 +223,9 @@ func abi_decode{range_check_ptr}(dataEnd_4 : Uint256) -> ():
 end
 
 func abi_encode_uint256_to_uint256{memory_dict : DictAccess*, msize, range_check_ptr}(
-        value_6 : Uint256, pos : Uint256) -> ():
+        value_5 : Uint256, pos : Uint256) -> ():
     alloc_locals
-    uint256_mstore(offset=pos, value=value_6)
+    uint256_mstore(offset=pos, value=value_5)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
@@ -245,48 +233,43 @@ func abi_encode_uint256_to_uint256{memory_dict : DictAccess*, msize, range_check
 end
 
 func abi_encode_uint256{memory_dict : DictAccess*, msize, range_check_ptr}(
-        headStart : Uint256, value0_7 : Uint256) -> (tail_8 : Uint256):
+        headStart : Uint256, value0_6 : Uint256) -> (tail_7 : Uint256):
     alloc_locals
-    let (local tail_8 : Uint256) = u256_add(headStart, Uint256(low=32, high=0))
+    let (local tail_7 : Uint256) = u256_add(headStart, Uint256(low=32, high=0))
     local range_check_ptr = range_check_ptr
-    abi_encode_uint256_to_uint256(value0_7, headStart)
+    abi_encode_uint256_to_uint256(value0_6, headStart)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    return (tail_8)
+    return (tail_7)
 end
 
 func __warp_block_4{
         exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize,
         pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}() -> ():
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = __warp_constant_0()
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    end
-    let (local __warp_subexpr_1 : Uint256) = calldatasize()
+    let (local __warp_subexpr_0 : Uint256) = calldatasize()
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
     let (local param : Uint256, local param_1 : Uint256,
         local param_2 : Uint256) = abi_decode_addresst_struct_Person_calldatat_uint256(
-        __warp_subexpr_1)
+        __warp_subexpr_0)
     local exec_env : ExecutionEnvironment* = exec_env
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_5 : Uint256) = fun_validate_constructor(param, param_1, param_2)
+    let (local __warp_subexpr_4 : Uint256) = fun_validate_constructor(param, param_1, param_2)
     local exec_env : ExecutionEnvironment* = exec_env
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
-    let (local __warp_subexpr_4 : Uint256) = uint256_not(Uint256(low=127, high=0))
+    let (local __warp_subexpr_3 : Uint256) = uint256_not(Uint256(low=127, high=0))
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_3 : Uint256) = abi_encode_bool_388(__warp_subexpr_5)
+    let (local __warp_subexpr_2 : Uint256) = abi_encode_bool_433(__warp_subexpr_4)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_2 : Uint256) = u256_add(__warp_subexpr_3, __warp_subexpr_4)
+    let (local __warp_subexpr_1 : Uint256) = u256_add(__warp_subexpr_2, __warp_subexpr_3)
     local range_check_ptr = range_check_ptr
-    returndata_write(Uint256(low=128, high=0), __warp_subexpr_2)
+    returndata_write(Uint256(low=128, high=0), __warp_subexpr_1)
     local exec_env : ExecutionEnvironment* = exec_env
     return ()
 end
@@ -295,20 +278,16 @@ func __warp_block_6{
         exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize,
         pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}() -> ():
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = __warp_constant_0()
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    end
-    let (local __warp_subexpr_1 : Uint256) = calldatasize()
+    let (local __warp_subexpr_0 : Uint256) = calldatasize()
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
-    abi_decode(__warp_subexpr_1)
+    abi_decode(__warp_subexpr_0)
     local range_check_ptr = range_check_ptr
-    let (local ret__warp_mangled : Uint256) = getter_fun_ownerCellNumber()
+    let (local __warp_subexpr_1 : Uint256) = sload(Uint256(low=2, high=0))
+    local range_check_ptr = range_check_ptr
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
+    let (local ret__warp_mangled : Uint256) = cleanup_uint256(__warp_subexpr_1)
     let (local memPos : Uint256) = uint256_mload(Uint256(low=64, high=0))
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
@@ -328,20 +307,16 @@ func __warp_block_8{
         exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize,
         pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}() -> ():
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = __warp_constant_0()
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    end
-    let (local __warp_subexpr_1 : Uint256) = calldatasize()
+    let (local __warp_subexpr_0 : Uint256) = calldatasize()
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
-    abi_decode(__warp_subexpr_1)
+    abi_decode(__warp_subexpr_0)
     local range_check_ptr = range_check_ptr
-    let (local ret_1 : Uint256) = getter_fun_owner()
+    let (local __warp_subexpr_1 : Uint256) = sload(Uint256(low=0, high=0))
+    local range_check_ptr = range_check_ptr
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
+    let (local ret_1 : Uint256) = cleanup_uint256(__warp_subexpr_1)
     let (local memPos_1 : Uint256) = uint256_mload(Uint256(low=64, high=0))
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
@@ -361,20 +336,16 @@ func __warp_block_10{
         exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize,
         pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}() -> ():
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = __warp_constant_0()
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    end
-    let (local __warp_subexpr_1 : Uint256) = calldatasize()
+    let (local __warp_subexpr_0 : Uint256) = calldatasize()
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
-    abi_decode(__warp_subexpr_1)
+    abi_decode(__warp_subexpr_0)
     local range_check_ptr = range_check_ptr
-    let (local ret_2 : Uint256) = getter_fun_ownerAge()
+    let (local __warp_subexpr_1 : Uint256) = sload(Uint256(low=1, high=0))
+    local range_check_ptr = range_check_ptr
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
+    let (local ret_2 : Uint256) = cleanup_uint256(__warp_subexpr_1)
     let (local memPos_2 : Uint256) = uint256_mload(Uint256(low=64, high=0))
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
@@ -637,12 +608,6 @@ func fun_ENTRY_POINT{
     return (1, exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
 end
 
-func cleanup_uint256(value : Uint256) -> (cleaned : Uint256):
-    alloc_locals
-    local cleaned : Uint256 = value
-    return (cleaned)
-end
-
 func finalize_allocation{memory_dict : DictAccess*, msize, range_check_ptr}(memPtr : Uint256) -> ():
     alloc_locals
     let (local newFreePtr : Uint256) = u256_add(memPtr, Uint256(low=64, high=0))
@@ -669,26 +634,26 @@ func finalize_allocation{memory_dict : DictAccess*, msize, range_check_ptr}(memP
     return ()
 end
 
-func allocate_memory{memory_dict : DictAccess*, msize, range_check_ptr}() -> (memPtr_9 : Uint256):
+func allocate_memory{memory_dict : DictAccess*, msize, range_check_ptr}() -> (memPtr_8 : Uint256):
     alloc_locals
-    let (local memPtr_9 : Uint256) = uint256_mload(Uint256(low=64, high=0))
+    let (local memPtr_8 : Uint256) = uint256_mload(Uint256(low=64, high=0))
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    finalize_allocation(memPtr_9)
+    finalize_allocation(memPtr_8)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    return (memPtr_9)
+    return (memPtr_8)
 end
 
 func abi_decode_struct_Person{
         exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize, range_check_ptr}(
-        end_10 : Uint256) -> (value_11 : Uint256):
+        end_9 : Uint256) -> (value_10 : Uint256):
     alloc_locals
     let (local __warp_subexpr_2 : Uint256) = uint256_not(Uint256(low=35, high=0))
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_1 : Uint256) = u256_add(end_10, __warp_subexpr_2)
+    let (local __warp_subexpr_1 : Uint256) = u256_add(end_9, __warp_subexpr_2)
     local range_check_ptr = range_check_ptr
     let (local __warp_subexpr_0 : Uint256) = slt(__warp_subexpr_1, Uint256(low=64, high=0))
     local range_check_ptr = range_check_ptr
@@ -696,36 +661,36 @@ func abi_decode_struct_Person{
         assert 0 = 1
         jmp rel 0
     end
-    let (local value_11 : Uint256) = allocate_memory()
+    let (local value_10 : Uint256) = allocate_memory()
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
     let (local __warp_subexpr_3 : Uint256) = calldataload(Uint256(low=36, high=0))
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
-    uint256_mstore(offset=value_11, value=__warp_subexpr_3)
+    uint256_mstore(offset=value_10, value=__warp_subexpr_3)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
     let (local __warp_subexpr_5 : Uint256) = calldataload(Uint256(low=68, high=0))
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
-    let (local __warp_subexpr_4 : Uint256) = u256_add(value_11, Uint256(low=32, high=0))
+    let (local __warp_subexpr_4 : Uint256) = u256_add(value_10, Uint256(low=32, high=0))
     local range_check_ptr = range_check_ptr
     uint256_mstore(offset=__warp_subexpr_4, value=__warp_subexpr_5)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    return (value_11)
+    return (value_10)
 end
 
 func abi_decode_addresst_struct_Persont_uint256{
         exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize, range_check_ptr}(
-        dataEnd_12 : Uint256) -> (value0_13 : Uint256, value1_14 : Uint256, value2_15 : Uint256):
+        dataEnd_11 : Uint256) -> (value0_12 : Uint256, value1_13 : Uint256, value2_14 : Uint256):
     alloc_locals
     let (local __warp_subexpr_2 : Uint256) = uint256_not(Uint256(low=3, high=0))
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_1 : Uint256) = u256_add(dataEnd_12, __warp_subexpr_2)
+    let (local __warp_subexpr_1 : Uint256) = u256_add(dataEnd_11, __warp_subexpr_2)
     local range_check_ptr = range_check_ptr
     let (local __warp_subexpr_0 : Uint256) = slt(__warp_subexpr_1, Uint256(low=128, high=0))
     local range_check_ptr = range_check_ptr
@@ -733,38 +698,71 @@ func abi_decode_addresst_struct_Persont_uint256{
         assert 0 = 1
         jmp rel 0
     end
-    let (local value0_13 : Uint256) = calldataload(Uint256(low=4, high=0))
+    let (local value0_12 : Uint256) = calldataload(Uint256(low=4, high=0))
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
-    let (local value1_14 : Uint256) = abi_decode_struct_Person(dataEnd_12)
+    let (local value1_13 : Uint256) = abi_decode_struct_Person(dataEnd_11)
     local exec_env : ExecutionEnvironment* = exec_env
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local value2_15 : Uint256) = calldataload(Uint256(low=100, high=0))
+    let (local value2_14 : Uint256) = calldataload(Uint256(low=100, high=0))
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
-    return (value0_13, value1_14, value2_15)
+    return (value0_12, value1_13, value2_14)
 end
 
-func setter_fun_owner{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
-        value_18 : Uint256) -> ():
+func update_byte_slice_shift(value_15 : Uint256, toInsert : Uint256) -> (result : Uint256):
     alloc_locals
-    owner.write(value_18)
+    local result : Uint256 = toInsert
+    return (result)
+end
+
+func update_storage_value_offsett_address_to_address_442{
+        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(value_16 : Uint256) -> (
+        ):
+    alloc_locals
+    let (local __warp_subexpr_1 : Uint256) = sload(Uint256(low=0, high=0))
+    local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local syscall_ptr : felt* = syscall_ptr
+    let (local __warp_subexpr_0 : Uint256) = update_byte_slice_shift(__warp_subexpr_1, value_16)
+    sstore(key=Uint256(low=0, high=0), value=__warp_subexpr_0)
+    local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local syscall_ptr : felt* = syscall_ptr
     return ()
 end
 
-func setter_fun_ownerAge{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
-        value_19 : Uint256) -> ():
+func update_storage_value_offsett_address_to_address{
+        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(value_17 : Uint256) -> (
+        ):
     alloc_locals
-    ownerAge.write(value_19)
+    let (local __warp_subexpr_1 : Uint256) = sload(Uint256(low=1, high=0))
+    local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local syscall_ptr : felt* = syscall_ptr
+    let (local __warp_subexpr_0 : Uint256) = update_byte_slice_shift(__warp_subexpr_1, value_17)
+    sstore(key=Uint256(low=1, high=0), value=__warp_subexpr_0)
+    local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local syscall_ptr : felt* = syscall_ptr
     return ()
 end
 
-func setter_fun_ownerCellNumber{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
-        value_20 : Uint256) -> ():
+func update_storage_value_offsett_address_to_address_444{
+        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(value_18 : Uint256) -> (
+        ):
     alloc_locals
-    ownerCellNumber.write(value_20)
+    let (local __warp_subexpr_1 : Uint256) = sload(Uint256(low=2, high=0))
+    local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local syscall_ptr : felt* = syscall_ptr
+    let (local __warp_subexpr_0 : Uint256) = update_byte_slice_shift(__warp_subexpr_1, value_18)
+    sstore(key=Uint256(low=2, high=0), value=__warp_subexpr_0)
+    local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local syscall_ptr : felt* = syscall_ptr
     return ()
 end
 
@@ -773,7 +771,7 @@ func fun_warp_ctorHelper_DynArgs{
         syscall_ptr : felt*}(
         var_owner : Uint256, var_person_mpos : Uint256, var_ownerCellNumber : Uint256) -> ():
     alloc_locals
-    setter_fun_owner(var_owner)
+    update_storage_value_offsett_address_to_address_442(var_owner)
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
@@ -782,11 +780,11 @@ func fun_warp_ctorHelper_DynArgs{
     local msize = msize
     local range_check_ptr = range_check_ptr
     let (local __warp_subexpr_0 : Uint256) = cleanup_uint256(__warp_subexpr_1)
-    setter_fun_ownerAge(__warp_subexpr_0)
+    update_storage_value_offsett_address_to_address(__warp_subexpr_0)
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
-    setter_fun_ownerCellNumber(var_ownerCellNumber)
+    update_storage_value_offsett_address_to_address_444(var_ownerCellNumber)
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
@@ -813,16 +811,11 @@ func constructor{
         local memory_dict : DictAccess* = memory_dict
         local msize = msize
         local range_check_ptr = range_check_ptr
-        let (local __warp_subexpr_0 : Uint256) = __warp_constant_0()
-        if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-            assert 0 = 1
-            jmp rel 0
-        end
-        let (local __warp_subexpr_1 : Uint256) = calldatasize()
+        let (local __warp_subexpr_0 : Uint256) = calldatasize()
         local range_check_ptr = range_check_ptr
         local exec_env : ExecutionEnvironment* = exec_env
         let (local param_3 : Uint256, local param_4 : Uint256,
-            local param_5 : Uint256) = abi_decode_addresst_struct_Persont_uint256(__warp_subexpr_1)
+            local param_5 : Uint256) = abi_decode_addresst_struct_Persont_uint256(__warp_subexpr_0)
         local exec_env : ExecutionEnvironment* = exec_env
         local memory_dict : DictAccess* = memory_dict
         local msize = msize
@@ -833,11 +826,11 @@ func constructor{
         local pedersen_ptr : HashBuiltin* = pedersen_ptr
         local range_check_ptr = range_check_ptr
         local syscall_ptr : felt* = syscall_ptr
-        let (local __warp_subexpr_2 : Uint256) = uint256_mload(Uint256(low=64, high=0))
+        let (local __warp_subexpr_1 : Uint256) = uint256_mload(Uint256(low=64, high=0))
         local memory_dict : DictAccess* = memory_dict
         local msize = msize
         local range_check_ptr = range_check_ptr
-        returndata_write(__warp_subexpr_2, Uint256(low=0, high=0))
+        returndata_write(__warp_subexpr_1, Uint256(low=0, high=0))
         local exec_env : ExecutionEnvironment* = exec_env
         return ()
     end

--- a/tests/yul/constructors_nonDyn.cairo
+++ b/tests/yul/constructors_nonDyn.cairo
@@ -12,20 +12,20 @@ from starkware.cairo.common.dict_access import DictAccess
 from starkware.cairo.common.registers import get_fp_and_pc
 from starkware.cairo.common.uint256 import Uint256, uint256_not, uint256_sub
 
-func __warp_constant_0() -> (res : Uint256):
-    return (Uint256(low=0, high=0))
+func sload{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(key : Uint256) -> (
+        value : Uint256):
+    let (res) = evm_storage.read(key.low, key.high)
+    return (res)
+end
+
+func sstore{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
+        key : Uint256, value : Uint256):
+    evm_storage.write(key.low, key.high, value)
+    return ()
 end
 
 @storage_var
-func owner() -> (res : Uint256):
-end
-
-@storage_var
-func ownerAge() -> (res : Uint256):
-end
-
-@storage_var
-func ownerCellNumber() -> (res : Uint256):
+func evm_storage(arg0_low, arg0_high) -> (res : Uint256):
 end
 
 @storage_var
@@ -63,45 +63,37 @@ func abi_decode{range_check_ptr}(dataEnd : Uint256) -> ():
     end
 end
 
-func getter_fun_ownerCellNumber{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
-        ) -> (value : Uint256):
+func cleanup_from_storage_uint256(value : Uint256) -> (cleaned : Uint256):
     alloc_locals
-    let (res) = ownerCellNumber.read()
-    return (res)
+    local cleaned : Uint256 = value
+    return (cleaned)
 end
 
-func abi_encode_uint256_to_uint256_550{memory_dict : DictAccess*, msize, range_check_ptr}(
-        value_2 : Uint256) -> ():
+func abi_encode_uint256_to_uint256_652{memory_dict : DictAccess*, msize, range_check_ptr}(
+        value_1 : Uint256) -> ():
     alloc_locals
-    uint256_mstore(offset=Uint256(low=128, high=0), value=value_2)
+    uint256_mstore(offset=Uint256(low=128, high=0), value=value_1)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
     return ()
 end
 
-func abi_encode_uint256_281{memory_dict : DictAccess*, msize, range_check_ptr}(
+func abi_encode_uint256_327{memory_dict : DictAccess*, msize, range_check_ptr}(
         value0 : Uint256) -> (tail : Uint256):
     alloc_locals
     local tail : Uint256 = Uint256(low=160, high=0)
-    abi_encode_uint256_to_uint256_550(value0)
+    abi_encode_uint256_to_uint256_652(value0)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
     return (tail)
 end
 
-func getter_fun_owner{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}() -> (
-        value_6 : Uint256):
-    alloc_locals
-    let (res) = owner.read()
-    return (res)
-end
-
 func abi_encode_uint256_to_uint256{memory_dict : DictAccess*, msize, range_check_ptr}(
-        value_3 : Uint256, pos : Uint256) -> ():
+        value_2 : Uint256, pos : Uint256) -> ():
     alloc_locals
-    uint256_mstore(offset=pos, value=value_3)
+    uint256_mstore(offset=pos, value=value_2)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
@@ -109,30 +101,23 @@ func abi_encode_uint256_to_uint256{memory_dict : DictAccess*, msize, range_check
 end
 
 func abi_encode_uint256{memory_dict : DictAccess*, msize, range_check_ptr}(
-        headStart : Uint256, value0_4 : Uint256) -> (tail_5 : Uint256):
+        headStart : Uint256, value0_3 : Uint256) -> (tail_4 : Uint256):
     alloc_locals
-    let (local tail_5 : Uint256) = u256_add(headStart, Uint256(low=32, high=0))
+    let (local tail_4 : Uint256) = u256_add(headStart, Uint256(low=32, high=0))
     local range_check_ptr = range_check_ptr
-    abi_encode_uint256_to_uint256(value0_4, headStart)
+    abi_encode_uint256_to_uint256(value0_3, headStart)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    return (tail_5)
-end
-
-func getter_fun_ownerAge{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}() -> (
-        value_7 : Uint256):
-    alloc_locals
-    let (res) = ownerAge.read()
-    return (res)
+    return (tail_4)
 end
 
 func abi_decode_addresst_uint256t_uint256{exec_env : ExecutionEnvironment*, range_check_ptr}(
-        dataEnd_8 : Uint256) -> (value0_9 : Uint256, value1 : Uint256, value2 : Uint256):
+        dataEnd_5 : Uint256) -> (value0_6 : Uint256, value1 : Uint256, value2 : Uint256):
     alloc_locals
     let (local __warp_subexpr_2 : Uint256) = uint256_not(Uint256(low=3, high=0))
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_1 : Uint256) = u256_add(dataEnd_8, __warp_subexpr_2)
+    let (local __warp_subexpr_1 : Uint256) = u256_add(dataEnd_5, __warp_subexpr_2)
     local range_check_ptr = range_check_ptr
     let (local __warp_subexpr_0 : Uint256) = slt(__warp_subexpr_1, Uint256(low=96, high=0))
     local range_check_ptr = range_check_ptr
@@ -140,7 +125,7 @@ func abi_decode_addresst_uint256t_uint256{exec_env : ExecutionEnvironment*, rang
         assert 0 = 1
         jmp rel 0
     end
-    let (local value0_9 : Uint256) = calldataload(Uint256(low=4, high=0))
+    let (local value0_6 : Uint256) = calldataload(Uint256(low=4, high=0))
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
     let (local value1 : Uint256) = calldataload(Uint256(low=36, high=0))
@@ -149,23 +134,18 @@ func abi_decode_addresst_uint256t_uint256{exec_env : ExecutionEnvironment*, rang
     let (local value2 : Uint256) = calldataload(Uint256(low=68, high=0))
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
-    return (value0_9, value1, value2)
-end
-
-func cleanup_uint256(value_1 : Uint256) -> (cleaned : Uint256):
-    alloc_locals
-    local cleaned : Uint256 = value_1
-    return (cleaned)
+    return (value0_6, value1, value2)
 end
 
 func __warp_block_0{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
         var_ownerAgeCheck : Uint256) -> (expr : Uint256):
     alloc_locals
-    let (local __warp_subexpr_1 : Uint256) = getter_fun_ownerAge()
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    let (local __warp_subexpr_2 : Uint256) = sload(Uint256(low=1, high=0))
     local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local syscall_ptr : felt* = syscall_ptr
-    let (local __warp_subexpr_0 : Uint256) = cleanup_uint256(__warp_subexpr_1)
+    let (local __warp_subexpr_1 : Uint256) = cleanup_from_storage_uint256(__warp_subexpr_2)
+    let (local __warp_subexpr_0 : Uint256) = cleanup_from_storage_uint256(__warp_subexpr_1)
     let (local expr : Uint256) = is_eq(var_ownerAgeCheck, __warp_subexpr_0)
     local range_check_ptr = range_check_ptr
     return (expr)
@@ -188,11 +168,12 @@ end
 func __warp_block_1{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
         var_ownerCellNumberCheck : Uint256) -> (expr_1 : Uint256):
     alloc_locals
-    let (local __warp_subexpr_1 : Uint256) = getter_fun_ownerCellNumber()
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    let (local __warp_subexpr_2 : Uint256) = sload(Uint256(low=2, high=0))
     local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local syscall_ptr : felt* = syscall_ptr
-    let (local __warp_subexpr_0 : Uint256) = cleanup_uint256(__warp_subexpr_1)
+    let (local __warp_subexpr_1 : Uint256) = cleanup_from_storage_uint256(__warp_subexpr_2)
+    let (local __warp_subexpr_0 : Uint256) = cleanup_from_storage_uint256(__warp_subexpr_1)
     let (local expr_1 : Uint256) = is_eq(var_ownerCellNumberCheck, __warp_subexpr_0)
     local range_check_ptr = range_check_ptr
     return (expr_1)
@@ -216,11 +197,12 @@ func fun_validate_constructor{pedersen_ptr : HashBuiltin*, range_check_ptr, sysc
         var_ownerCheck : Uint256, var_ownerAgeCheck : Uint256,
         var_ownerCellNumberCheck : Uint256) -> (var : Uint256):
     alloc_locals
-    let (local __warp_subexpr_1 : Uint256) = getter_fun_owner()
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    let (local __warp_subexpr_2 : Uint256) = sload(Uint256(low=0, high=0))
     local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local syscall_ptr : felt* = syscall_ptr
-    let (local __warp_subexpr_0 : Uint256) = cleanup_uint256(__warp_subexpr_1)
+    let (local __warp_subexpr_1 : Uint256) = cleanup_from_storage_uint256(__warp_subexpr_2)
+    let (local __warp_subexpr_0 : Uint256) = cleanup_from_storage_uint256(__warp_subexpr_1)
     let (local expr : Uint256) = is_eq(var_ownerCheck, __warp_subexpr_0)
     local range_check_ptr = range_check_ptr
     let (local expr : Uint256) = __warp_if_0(expr, var_ownerAgeCheck)
@@ -237,13 +219,13 @@ func fun_validate_constructor{pedersen_ptr : HashBuiltin*, range_check_ptr, sysc
 end
 
 func abi_encode_bool_to_bool{memory_dict : DictAccess*, msize, range_check_ptr}(
-        value_10 : Uint256, pos_11 : Uint256) -> ():
+        value_7 : Uint256, pos_8 : Uint256) -> ():
     alloc_locals
-    let (local __warp_subexpr_1 : Uint256) = is_zero(value_10)
+    let (local __warp_subexpr_1 : Uint256) = is_zero(value_7)
     local range_check_ptr = range_check_ptr
     let (local __warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
     local range_check_ptr = range_check_ptr
-    uint256_mstore(offset=pos_11, value=__warp_subexpr_0)
+    uint256_mstore(offset=pos_8, value=__warp_subexpr_0)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
@@ -251,44 +233,40 @@ func abi_encode_bool_to_bool{memory_dict : DictAccess*, msize, range_check_ptr}(
 end
 
 func abi_encode_bool{memory_dict : DictAccess*, msize, range_check_ptr}(
-        headStart_12 : Uint256, value0_13 : Uint256) -> (tail_14 : Uint256):
+        headStart_9 : Uint256, value0_10 : Uint256) -> (tail_11 : Uint256):
     alloc_locals
-    let (local tail_14 : Uint256) = u256_add(headStart_12, Uint256(low=32, high=0))
+    let (local tail_11 : Uint256) = u256_add(headStart_9, Uint256(low=32, high=0))
     local range_check_ptr = range_check_ptr
-    abi_encode_bool_to_bool(value0_13, headStart_12)
+    abi_encode_bool_to_bool(value0_10, headStart_9)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    return (tail_14)
+    return (tail_11)
 end
 
 func __warp_block_4{
         exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize,
         pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}() -> ():
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = __warp_constant_0()
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    end
-    let (local __warp_subexpr_1 : Uint256) = calldatasize()
+    let (local __warp_subexpr_0 : Uint256) = calldatasize()
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
-    abi_decode(__warp_subexpr_1)
+    abi_decode(__warp_subexpr_0)
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_5 : Uint256) = getter_fun_ownerCellNumber()
+    let (local __warp_subexpr_5 : Uint256) = sload(Uint256(low=2, high=0))
+    local range_check_ptr = range_check_ptr
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
-    let (local __warp_subexpr_4 : Uint256) = uint256_not(Uint256(low=127, high=0))
+    let (local __warp_subexpr_4 : Uint256) = cleanup_from_storage_uint256(__warp_subexpr_5)
+    let (local __warp_subexpr_3 : Uint256) = uint256_not(Uint256(low=127, high=0))
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_3 : Uint256) = abi_encode_uint256_281(__warp_subexpr_5)
+    let (local __warp_subexpr_2 : Uint256) = abi_encode_uint256_327(__warp_subexpr_4)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_2 : Uint256) = u256_add(__warp_subexpr_3, __warp_subexpr_4)
+    let (local __warp_subexpr_1 : Uint256) = u256_add(__warp_subexpr_2, __warp_subexpr_3)
     local range_check_ptr = range_check_ptr
-    returndata_write(Uint256(low=128, high=0), __warp_subexpr_2)
+    returndata_write(Uint256(low=128, high=0), __warp_subexpr_1)
     local exec_env : ExecutionEnvironment* = exec_env
     return ()
 end
@@ -297,20 +275,16 @@ func __warp_block_6{
         exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize,
         pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}() -> ():
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = __warp_constant_0()
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    end
-    let (local __warp_subexpr_1 : Uint256) = calldatasize()
+    let (local __warp_subexpr_0 : Uint256) = calldatasize()
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
-    abi_decode(__warp_subexpr_1)
+    abi_decode(__warp_subexpr_0)
     local range_check_ptr = range_check_ptr
-    let (local ret__warp_mangled : Uint256) = getter_fun_owner()
+    let (local __warp_subexpr_1 : Uint256) = sload(Uint256(low=0, high=0))
+    local range_check_ptr = range_check_ptr
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
+    let (local ret__warp_mangled : Uint256) = cleanup_from_storage_uint256(__warp_subexpr_1)
     let (local memPos : Uint256) = uint256_mload(Uint256(low=64, high=0))
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
@@ -330,20 +304,16 @@ func __warp_block_8{
         exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize,
         pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}() -> ():
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = __warp_constant_0()
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    end
-    let (local __warp_subexpr_1 : Uint256) = calldatasize()
+    let (local __warp_subexpr_0 : Uint256) = calldatasize()
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
-    abi_decode(__warp_subexpr_1)
+    abi_decode(__warp_subexpr_0)
     local range_check_ptr = range_check_ptr
-    let (local ret_1 : Uint256) = getter_fun_ownerAge()
+    let (local __warp_subexpr_1 : Uint256) = sload(Uint256(low=1, high=0))
+    local range_check_ptr = range_check_ptr
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
+    let (local ret_1 : Uint256) = cleanup_from_storage_uint256(__warp_subexpr_1)
     let (local memPos_1 : Uint256) = uint256_mload(Uint256(low=64, high=0))
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
@@ -363,16 +333,11 @@ func __warp_block_10{
         exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize,
         pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}() -> ():
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = __warp_constant_0()
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    end
-    let (local __warp_subexpr_1 : Uint256) = calldatasize()
+    let (local __warp_subexpr_0 : Uint256) = calldatasize()
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
     let (local param : Uint256, local param_1 : Uint256,
-        local param_2 : Uint256) = abi_decode_addresst_uint256t_uint256(__warp_subexpr_1)
+        local param_2 : Uint256) = abi_decode_addresst_uint256t_uint256(__warp_subexpr_0)
     local exec_env : ExecutionEnvironment* = exec_env
     local range_check_ptr = range_check_ptr
     let (local ret_2 : Uint256) = fun_validate_constructor(param, param_1, param_2)
@@ -383,13 +348,13 @@ func __warp_block_10{
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_3 : Uint256) = abi_encode_bool(memPos_2, ret_2)
+    let (local __warp_subexpr_2 : Uint256) = abi_encode_bool(memPos_2, ret_2)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_2 : Uint256) = uint256_sub(__warp_subexpr_3, memPos_2)
+    let (local __warp_subexpr_1 : Uint256) = uint256_sub(__warp_subexpr_2, memPos_2)
     local range_check_ptr = range_check_ptr
-    returndata_write(memPos_2, __warp_subexpr_2)
+    returndata_write(memPos_2, __warp_subexpr_1)
     local exec_env : ExecutionEnvironment* = exec_env
     return ()
 end
@@ -641,24 +606,57 @@ func fun_ENTRY_POINT{
     return (1, exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
 end
 
-func setter_fun_owner{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
-        value_15 : Uint256) -> ():
+func update_byte_slice_shift(value_12 : Uint256, toInsert : Uint256) -> (result : Uint256):
     alloc_locals
-    owner.write(value_15)
+    local result : Uint256 = toInsert
+    return (result)
+end
+
+func update_storage_value_offsett_address_to_address_334{
+        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(value_13 : Uint256) -> (
+        ):
+    alloc_locals
+    let (local __warp_subexpr_1 : Uint256) = sload(Uint256(low=0, high=0))
+    local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local syscall_ptr : felt* = syscall_ptr
+    let (local __warp_subexpr_0 : Uint256) = update_byte_slice_shift(__warp_subexpr_1, value_13)
+    sstore(key=Uint256(low=0, high=0), value=__warp_subexpr_0)
+    local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local syscall_ptr : felt* = syscall_ptr
     return ()
 end
 
-func setter_fun_ownerAge{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
-        value_16 : Uint256) -> ():
+func update_storage_value_offsett_address_to_address{
+        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(value_14 : Uint256) -> (
+        ):
     alloc_locals
-    ownerAge.write(value_16)
+    let (local __warp_subexpr_1 : Uint256) = sload(Uint256(low=1, high=0))
+    local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local syscall_ptr : felt* = syscall_ptr
+    let (local __warp_subexpr_0 : Uint256) = update_byte_slice_shift(__warp_subexpr_1, value_14)
+    sstore(key=Uint256(low=1, high=0), value=__warp_subexpr_0)
+    local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local syscall_ptr : felt* = syscall_ptr
     return ()
 end
 
-func setter_fun_ownerCellNumber{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
-        value_17 : Uint256) -> ():
+func update_storage_value_offsett_address_to_address_336{
+        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(value_15 : Uint256) -> (
+        ):
     alloc_locals
-    ownerCellNumber.write(value_17)
+    let (local __warp_subexpr_1 : Uint256) = sload(Uint256(low=2, high=0))
+    local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local syscall_ptr : felt* = syscall_ptr
+    let (local __warp_subexpr_0 : Uint256) = update_byte_slice_shift(__warp_subexpr_1, value_15)
+    sstore(key=Uint256(low=2, high=0), value=__warp_subexpr_0)
+    local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local syscall_ptr : felt* = syscall_ptr
     return ()
 end
 
@@ -672,15 +670,15 @@ func constructor{
     local memory_dict_start : DictAccess* = memory_dict
     let msize = 0
     with pedersen_ptr, range_check_ptr, bitwise_ptr, memory_dict, msize:
-        setter_fun_owner(var_owner)
+        update_storage_value_offsett_address_to_address_334(var_owner)
         local pedersen_ptr : HashBuiltin* = pedersen_ptr
         local range_check_ptr = range_check_ptr
         local syscall_ptr : felt* = syscall_ptr
-        setter_fun_ownerAge(var_ownerAge)
+        update_storage_value_offsett_address_to_address(var_ownerAge)
         local pedersen_ptr : HashBuiltin* = pedersen_ptr
         local range_check_ptr = range_check_ptr
         local syscall_ptr : felt* = syscall_ptr
-        setter_fun_ownerCellNumber(var_ownerCellNumber)
+        update_storage_value_offsett_address_to_address_336(var_ownerCellNumber)
         local pedersen_ptr : HashBuiltin* = pedersen_ptr
         local range_check_ptr = range_check_ptr
         local syscall_ptr : felt* = syscall_ptr

--- a/tests/yul/if-flattening.cairo
+++ b/tests/yul/if-flattening.cairo
@@ -3,6 +3,7 @@
 
 from evm.calls import calldataload, calldatasize, returndata_write
 from evm.exec_env import ExecutionEnvironment
+from evm.hashing import uint256_pedersen
 from evm.memory import uint256_mload, uint256_mstore
 from evm.uint256 import is_eq, is_lt, is_zero, slt, u256_add, u256_shr
 from starkware.cairo.common.alloc import alloc
@@ -12,12 +13,24 @@ from starkware.cairo.common.dict_access import DictAccess
 from starkware.cairo.common.registers import get_fp_and_pc
 from starkware.cairo.common.uint256 import Uint256, uint256_not, uint256_sub
 
-func __warp_constant_0() -> (res : Uint256):
-    return (Uint256(low=0, high=0))
+func sload{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(key : Uint256) -> (
+        value : Uint256):
+    let (res) = evm_storage.read(key.low, key.high)
+    return (res)
+end
+
+func sstore{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
+        key : Uint256, value : Uint256):
+    evm_storage.write(key.low, key.high, value)
+    return ()
 end
 
 @storage_var
 func allowance(arg0_low, arg0_high) -> (res : Uint256):
+end
+
+@storage_var
+func evm_storage(arg0_low, arg0_high) -> (res : Uint256):
 end
 
 @storage_var
@@ -58,28 +71,68 @@ func abi_decode_uint256{exec_env : ExecutionEnvironment*, range_check_ptr}(dataE
     return (value0)
 end
 
-func getter_fun_allowance{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
-        arg0 : Uint256) -> (value : Uint256):
+func mapping_index_access_mapping_uint256_uint256_of_uint256_252{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        key : Uint256) -> (dataSlot : Uint256):
     alloc_locals
-    let (res) = allowance.read(arg0.low, arg0.high)
+    uint256_mstore(offset=Uint256(low=0, high=0), value=key)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local range_check_ptr = range_check_ptr
+    uint256_mstore(offset=Uint256(low=32, high=0), value=Uint256(low=0, high=0))
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local range_check_ptr = range_check_ptr
+    let (local dataSlot : Uint256) = uint256_pedersen(
+        Uint256(low=0, high=0), Uint256(low=64, high=0))
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    return (dataSlot)
+end
+
+func extract_from_storage_value_dynamict_uint256(slot_value : Uint256) -> (value : Uint256):
+    alloc_locals
+    local value : Uint256 = slot_value
+    return (value)
+end
+
+func read_from_storage_split_dynamic_uint256{
+        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(slot : Uint256) -> (
+        value_3 : Uint256):
+    alloc_locals
+    let (local __warp_subexpr_0 : Uint256) = sload(slot)
+    local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local syscall_ptr : felt* = syscall_ptr
+    let (local value_3 : Uint256) = extract_from_storage_value_dynamict_uint256(__warp_subexpr_0)
+    return (value_3)
+end
+
+func getter_fun_allowance{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
+        key_4 : Uint256) -> (ret_5 : Uint256):
+    alloc_locals
+    let (res) = allowance.read(key_4.low, key_4.high)
     return (res)
 end
 
-func abi_encode_uint256_to_uint256_367{memory_dict : DictAccess*, msize, range_check_ptr}(
-        value_1 : Uint256) -> ():
+func abi_encode_uint256_to_uint256{memory_dict : DictAccess*, msize, range_check_ptr}(
+        value_6 : Uint256, pos : Uint256) -> ():
     alloc_locals
-    uint256_mstore(offset=Uint256(low=128, high=0), value=value_1)
+    uint256_mstore(offset=pos, value=value_6)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
     return ()
 end
 
-func abi_encode_uint256_199{memory_dict : DictAccess*, msize, range_check_ptr}(
-        value0_3 : Uint256) -> (tail : Uint256):
+func abi_encode_uint256{memory_dict : DictAccess*, msize, range_check_ptr}(
+        headStart : Uint256, value0_7 : Uint256) -> (tail : Uint256):
     alloc_locals
-    local tail : Uint256 = Uint256(low=160, high=0)
-    abi_encode_uint256_to_uint256_367(value0_3)
+    let (local tail : Uint256) = u256_add(headStart, Uint256(low=32, high=0))
+    local range_check_ptr = range_check_ptr
+    abi_encode_uint256_to_uint256(value0_7, headStart)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
@@ -87,11 +140,11 @@ func abi_encode_uint256_199{memory_dict : DictAccess*, msize, range_check_ptr}(
 end
 
 func abi_decode_uint256t_uint256t_uint256{exec_env : ExecutionEnvironment*, range_check_ptr}(
-        dataEnd_6 : Uint256) -> (value0_7 : Uint256, value1 : Uint256, value2 : Uint256):
+        dataEnd_8 : Uint256) -> (value0_9 : Uint256, value1 : Uint256, value2 : Uint256):
     alloc_locals
     let (local __warp_subexpr_2 : Uint256) = uint256_not(Uint256(low=3, high=0))
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_1 : Uint256) = u256_add(dataEnd_6, __warp_subexpr_2)
+    let (local __warp_subexpr_1 : Uint256) = u256_add(dataEnd_8, __warp_subexpr_2)
     local range_check_ptr = range_check_ptr
     let (local __warp_subexpr_0 : Uint256) = slt(__warp_subexpr_1, Uint256(low=96, high=0))
     local range_check_ptr = range_check_ptr
@@ -99,7 +152,7 @@ func abi_decode_uint256t_uint256t_uint256{exec_env : ExecutionEnvironment*, rang
         assert 0 = 1
         jmp rel 0
     end
-    let (local value0_7 : Uint256) = calldataload(Uint256(low=4, high=0))
+    let (local value0_9 : Uint256) = calldataload(Uint256(low=4, high=0))
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
     let (local value1 : Uint256) = calldataload(Uint256(low=36, high=0))
@@ -108,7 +161,28 @@ func abi_decode_uint256t_uint256t_uint256{exec_env : ExecutionEnvironment*, rang
     let (local value2 : Uint256) = calldataload(Uint256(low=68, high=0))
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
-    return (value0_7, value1, value2)
+    return (value0_9, value1, value2)
+end
+
+func mapping_index_access_mapping_uint256_uint256_of_uint256{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        key_1 : Uint256) -> (dataSlot_2 : Uint256):
+    alloc_locals
+    uint256_mstore(offset=Uint256(low=0, high=0), value=key_1)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local range_check_ptr = range_check_ptr
+    uint256_mstore(offset=Uint256(low=32, high=0), value=Uint256(low=0, high=0))
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local range_check_ptr = range_check_ptr
+    let (local dataSlot_2 : Uint256) = uint256_pedersen(
+        Uint256(low=0, high=0), Uint256(low=64, high=0))
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
+    local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    return (dataSlot_2)
 end
 
 func checked_sub_uint256{range_check_ptr}(x : Uint256, y : Uint256) -> (diff : Uint256):
@@ -124,23 +198,46 @@ func checked_sub_uint256{range_check_ptr}(x : Uint256, y : Uint256) -> (diff : U
     return (diff)
 end
 
-func setter_fun_allowance{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
-        arg0_8 : Uint256, value_9 : Uint256) -> ():
+func update_byte_slice_shift(value_10 : Uint256, toInsert : Uint256) -> (result : Uint256):
     alloc_locals
-    allowance.write(arg0_8.low, arg0_8.high, value_9)
+    local result : Uint256 = toInsert
+    return (result)
+end
+
+func update_storage_value_offsett_uint256_to_uint256{
+        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
+        slot_11 : Uint256, value_12 : Uint256) -> ():
+    alloc_locals
+    let (local __warp_subexpr_1 : Uint256) = sload(slot_11)
+    local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local syscall_ptr : felt* = syscall_ptr
+    let (local __warp_subexpr_0 : Uint256) = update_byte_slice_shift(__warp_subexpr_1, value_12)
+    sstore(key=slot_11, value=__warp_subexpr_0)
+    local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local syscall_ptr : felt* = syscall_ptr
     return ()
 end
 
-func __warp_block_2{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
-        var_src : Uint256, var_wad : Uint256) -> (var_res : Uint256):
+func __warp_block_2{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        syscall_ptr : felt*}(var_src : Uint256, var_wad : Uint256) -> (var_res : Uint256):
     alloc_locals
-    let (local __warp_subexpr_1 : Uint256) = getter_fun_allowance(var_src)
+    let (local _1 : Uint256) = mapping_index_access_mapping_uint256_uint256_of_uint256(var_src)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
+    let (local __warp_subexpr_2 : Uint256) = sload(_1)
+    local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local syscall_ptr : felt* = syscall_ptr
+    let (local __warp_subexpr_1 : Uint256) = extract_from_storage_value_dynamict_uint256(
+        __warp_subexpr_2)
     let (local __warp_subexpr_0 : Uint256) = checked_sub_uint256(__warp_subexpr_1, var_wad)
     local range_check_ptr = range_check_ptr
-    setter_fun_allowance(var_src, __warp_subexpr_0)
+    update_storage_value_offsett_uint256_to_uint256(_1, __warp_subexpr_0)
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
@@ -148,14 +245,18 @@ func __warp_block_2{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : 
     return (var_res)
 end
 
-func __warp_if_0{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
-        __warp_subexpr_0 : Uint256, var_src : Uint256, var_wad : Uint256) -> (var_res : Uint256):
+func __warp_if_0{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        syscall_ptr : felt*}(__warp_subexpr_0 : Uint256, var_src : Uint256, var_wad : Uint256) -> (
+        var_res : Uint256):
     alloc_locals
     if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
         local var_res : Uint256 = Uint256(low=2, high=0)
         return (var_res)
     else:
         let (local var_res : Uint256) = __warp_block_2(var_src, var_wad)
+        local memory_dict : DictAccess* = memory_dict
+        local msize = msize
         local pedersen_ptr : HashBuiltin* = pedersen_ptr
         local range_check_ptr = range_check_ptr
         local syscall_ptr : felt* = syscall_ptr
@@ -163,37 +264,49 @@ func __warp_if_0{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : fel
     end
 end
 
-func __warp_block_1{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
-        match_var : Uint256, var_src : Uint256, var_wad : Uint256) -> (var_res : Uint256):
+func __warp_block_1{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        syscall_ptr : felt*}(match_var : Uint256, var_src : Uint256, var_wad : Uint256) -> (
+        var_res : Uint256):
     alloc_locals
     let (local __warp_subexpr_0 : Uint256) = is_eq(match_var, Uint256(low=0, high=0))
     local range_check_ptr = range_check_ptr
     let (local var_res : Uint256) = __warp_if_0(__warp_subexpr_0, var_src, var_wad)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
     return (var_res)
 end
 
-func __warp_block_0{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
-        var_sender : Uint256, var_src : Uint256, var_wad : Uint256) -> (var_res : Uint256):
+func __warp_block_0{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        syscall_ptr : felt*}(var_sender : Uint256, var_src : Uint256, var_wad : Uint256) -> (
+        var_res : Uint256):
     alloc_locals
     let (local __warp_subexpr_0 : Uint256) = is_eq(var_src, var_sender)
     local range_check_ptr = range_check_ptr
     let (local match_var : Uint256) = is_zero(__warp_subexpr_0)
     local range_check_ptr = range_check_ptr
     let (local var_res : Uint256) = __warp_block_1(match_var, var_src, var_wad)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
     return (var_res)
 end
 
-func fun_transferFrom{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
-        var_src : Uint256, var_wad : Uint256, var_sender : Uint256) -> (var : Uint256):
+func fun_transferFrom{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        syscall_ptr : felt*}(var_src : Uint256, var_wad : Uint256, var_sender : Uint256) -> (
+        var : Uint256):
     alloc_locals
     local var_res : Uint256 = Uint256(low=0, high=0)
     let (local var_res : Uint256) = __warp_block_0(var_sender, var_src, var_wad)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
@@ -201,56 +314,31 @@ func fun_transferFrom{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr 
     return (var)
 end
 
-func abi_encode_uint256_to_uint256{memory_dict : DictAccess*, msize, range_check_ptr}(
-        value_2 : Uint256, pos : Uint256) -> ():
-    alloc_locals
-    uint256_mstore(offset=pos, value=value_2)
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
-    local range_check_ptr = range_check_ptr
-    return ()
-end
-
-func abi_encode_uint256{memory_dict : DictAccess*, msize, range_check_ptr}(
-        headStart : Uint256, value0_4 : Uint256) -> (tail_5 : Uint256):
-    alloc_locals
-    let (local tail_5 : Uint256) = u256_add(headStart, Uint256(low=32, high=0))
-    local range_check_ptr = range_check_ptr
-    abi_encode_uint256_to_uint256(value0_4, headStart)
-    local memory_dict : DictAccess* = memory_dict
-    local msize = msize
-    local range_check_ptr = range_check_ptr
-    return (tail_5)
-end
-
 func __warp_block_5{
         exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize,
         pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}() -> ():
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = __warp_constant_0()
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    end
-    let (local __warp_subexpr_6 : Uint256) = calldatasize()
+    let (local __warp_subexpr_1 : Uint256) = calldatasize()
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
-    let (local __warp_subexpr_5 : Uint256) = abi_decode_uint256(__warp_subexpr_6)
+    let (local __warp_subexpr_0 : Uint256) = abi_decode_uint256(__warp_subexpr_1)
     local exec_env : ExecutionEnvironment* = exec_env
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_4 : Uint256) = getter_fun_allowance(__warp_subexpr_5)
+    let (local ret__warp_mangled : Uint256) = getter_fun_allowance(__warp_subexpr_0)
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
-    let (local __warp_subexpr_3 : Uint256) = uint256_not(Uint256(low=127, high=0))
-    local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_2 : Uint256) = abi_encode_uint256_199(__warp_subexpr_4)
+    let (local memPos : Uint256) = uint256_mload(Uint256(low=64, high=0))
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_1 : Uint256) = u256_add(__warp_subexpr_2, __warp_subexpr_3)
+    let (local __warp_subexpr_3 : Uint256) = abi_encode_uint256(memPos, ret__warp_mangled)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
     local range_check_ptr = range_check_ptr
-    returndata_write(Uint256(low=128, high=0), __warp_subexpr_1)
+    let (local __warp_subexpr_2 : Uint256) = uint256_sub(__warp_subexpr_3, memPos)
+    local range_check_ptr = range_check_ptr
+    returndata_write(memPos, __warp_subexpr_2)
     local exec_env : ExecutionEnvironment* = exec_env
     return ()
 end
@@ -266,21 +354,23 @@ func __warp_block_7{
         local param_2 : Uint256) = abi_decode_uint256t_uint256t_uint256(__warp_subexpr_0)
     local exec_env : ExecutionEnvironment* = exec_env
     local range_check_ptr = range_check_ptr
-    let (local ret__warp_mangled : Uint256) = fun_transferFrom(param, param_1, param_2)
+    let (local ret_1 : Uint256) = fun_transferFrom(param, param_1, param_2)
+    local memory_dict : DictAccess* = memory_dict
+    local msize = msize
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
-    let (local memPos : Uint256) = uint256_mload(Uint256(low=64, high=0))
+    let (local memPos_1 : Uint256) = uint256_mload(Uint256(low=64, high=0))
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_2 : Uint256) = abi_encode_uint256(memPos, ret__warp_mangled)
+    let (local __warp_subexpr_2 : Uint256) = abi_encode_uint256(memPos_1, ret_1)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_1 : Uint256) = uint256_sub(__warp_subexpr_2, memPos)
+    let (local __warp_subexpr_1 : Uint256) = uint256_sub(__warp_subexpr_2, memPos_1)
     local range_check_ptr = range_check_ptr
-    returndata_write(memPos, __warp_subexpr_1)
+    returndata_write(memPos_1, __warp_subexpr_1)
     local exec_env : ExecutionEnvironment* = exec_env
     return ()
 end

--- a/tests/yul/pure-function.cairo
+++ b/tests/yul/pure-function.cairo
@@ -13,10 +13,6 @@ from starkware.cairo.common.registers import get_fp_and_pc
 from starkware.cairo.common.uint256 import (
     Uint256, uint256_and, uint256_not, uint256_sub, uint256_xor)
 
-func __warp_constant_0() -> (res : Uint256):
-    return (Uint256(low=0, high=0))
-end
-
 @storage_var
 func this_address() -> (res : felt):
 end
@@ -141,29 +137,24 @@ func __warp_block_3{
         exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize, range_check_ptr}() -> (
         ):
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = __warp_constant_0()
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    end
-    let (local __warp_subexpr_1 : Uint256) = calldatasize()
+    let (local __warp_subexpr_0 : Uint256) = calldatasize()
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
     let (local param : Uint256, local param_1 : Uint256, local param_2 : Uint256,
-        local param_3 : Uint256) = abi_decode_uint256t_uint256t_uint256t_uint256(__warp_subexpr_1)
+        local param_3 : Uint256) = abi_decode_uint256t_uint256t_uint256t_uint256(__warp_subexpr_0)
     local exec_env : ExecutionEnvironment* = exec_env
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_5 : Uint256) = fun_pureFunction(param, param_1, param_2, param_3)
+    let (local __warp_subexpr_4 : Uint256) = fun_pureFunction(param, param_1, param_2, param_3)
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_4 : Uint256) = uint256_not(Uint256(low=127, high=0))
+    let (local __warp_subexpr_3 : Uint256) = uint256_not(Uint256(low=127, high=0))
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_3 : Uint256) = abi_encode_uint256(__warp_subexpr_5)
+    let (local __warp_subexpr_2 : Uint256) = abi_encode_uint256(__warp_subexpr_4)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_2 : Uint256) = u256_add(__warp_subexpr_3, __warp_subexpr_4)
+    let (local __warp_subexpr_1 : Uint256) = u256_add(__warp_subexpr_2, __warp_subexpr_3)
     local range_check_ptr = range_check_ptr
-    returndata_write(Uint256(low=128, high=0), __warp_subexpr_2)
+    returndata_write(Uint256(low=128, high=0), __warp_subexpr_1)
     local exec_env : ExecutionEnvironment* = exec_env
     return ()
 end

--- a/tests/yul/returndatasize.cairo
+++ b/tests/yul/returndatasize.cairo
@@ -16,10 +16,6 @@ func returndata_size{exec_env : ExecutionEnvironment*}() -> (res : Uint256):
     return (Uint256(low=exec_env.returndata_size, high=0))
 end
 
-func __warp_constant_0() -> (res : Uint256):
-    return (Uint256(low=0, high=0))
-end
-
 @storage_var
 func this_address() -> (res : felt):
 end
@@ -76,7 +72,7 @@ func abi_encode_uint256{memory_dict : DictAccess*, msize, range_check_ptr}(value
     return ()
 end
 
-func abi_encode_uint256_68{memory_dict : DictAccess*, msize, range_check_ptr}(value0 : Uint256) -> (
+func abi_encode_uint256_66{memory_dict : DictAccess*, msize, range_check_ptr}(value0 : Uint256) -> (
         tail : Uint256):
     alloc_locals
     local tail : Uint256 = Uint256(low=160, high=0)
@@ -91,27 +87,22 @@ func __warp_block_1{
         exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize, range_check_ptr}() -> (
         ):
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = __warp_constant_0()
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    end
-    let (local __warp_subexpr_1 : Uint256) = calldatasize()
+    let (local __warp_subexpr_0 : Uint256) = calldatasize()
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
-    abi_decode(__warp_subexpr_1)
+    abi_decode(__warp_subexpr_0)
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_5 : Uint256) = fun_viewReturndatasize()
+    let (local __warp_subexpr_4 : Uint256) = fun_viewReturndatasize()
     local exec_env : ExecutionEnvironment* = exec_env
-    let (local __warp_subexpr_4 : Uint256) = uint256_not(Uint256(low=127, high=0))
+    let (local __warp_subexpr_3 : Uint256) = uint256_not(Uint256(low=127, high=0))
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_3 : Uint256) = abi_encode_uint256_68(__warp_subexpr_5)
+    let (local __warp_subexpr_2 : Uint256) = abi_encode_uint256_66(__warp_subexpr_4)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_2 : Uint256) = u256_add(__warp_subexpr_3, __warp_subexpr_4)
+    let (local __warp_subexpr_1 : Uint256) = u256_add(__warp_subexpr_2, __warp_subexpr_3)
     local range_check_ptr = range_check_ptr
-    returndata_write(Uint256(low=128, high=0), __warp_subexpr_2)
+    returndata_write(Uint256(low=128, high=0), __warp_subexpr_1)
     local exec_env : ExecutionEnvironment* = exec_env
     return ()
 end

--- a/tests/yul/short_string.cairo
+++ b/tests/yul/short_string.cairo
@@ -12,10 +12,6 @@ from starkware.cairo.common.dict_access import DictAccess
 from starkware.cairo.common.registers import get_fp_and_pc
 from starkware.cairo.common.uint256 import Uint256, uint256_and, uint256_not, uint256_sub
 
-func __warp_constant_0() -> (res : Uint256):
-    return (Uint256(low=0, high=0))
-end
-
 @storage_var
 func this_address() -> (res : felt):
 end
@@ -271,7 +267,7 @@ func abi_encode_string{memory_dict : DictAccess*, msize, range_check_ptr}(
     return (tail)
 end
 
-func allocate_memory_array_string_564{memory_dict : DictAccess*, msize, range_check_ptr}() -> (
+func allocate_memory_array_string_558{memory_dict : DictAccess*, msize, range_check_ptr}() -> (
         memPtr_6 : Uint256):
     alloc_locals
     let (local memPtr_6 : Uint256) = allocate_memory()
@@ -304,7 +300,7 @@ func allocate_and_zero_memory_array_string{
         exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize, range_check_ptr}() -> (
         memPtr_9 : Uint256):
     alloc_locals
-    let (local memPtr_9 : Uint256) = allocate_memory_array_string_564()
+    let (local memPtr_9 : Uint256) = allocate_memory_array_string_558()
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
@@ -318,7 +314,7 @@ func allocate_and_zero_memory_array_string{
     return (memPtr_9)
 end
 
-func memory_array_index_access_bytes_299{memory_dict : DictAccess*, msize, range_check_ptr}(
+func memory_array_index_access_bytes{memory_dict : DictAccess*, msize, range_check_ptr}(
         baseRef : Uint256) -> (addr : Uint256):
     alloc_locals
     let (local __warp_subexpr_1 : Uint256) = uint256_mload(baseRef)
@@ -336,7 +332,7 @@ func memory_array_index_access_bytes_299{memory_dict : DictAccess*, msize, range
     return (addr)
 end
 
-func memory_array_index_access_bytes{memory_dict : DictAccess*, msize, range_check_ptr}(
+func memory_array_index_access_bytes_296{memory_dict : DictAccess*, msize, range_check_ptr}(
         baseRef_10 : Uint256) -> (addr_11 : Uint256):
     alloc_locals
     let (local __warp_subexpr_2 : Uint256) = uint256_mload(baseRef_10)
@@ -356,7 +352,7 @@ func memory_array_index_access_bytes{memory_dict : DictAccess*, msize, range_che
     return (addr_11)
 end
 
-func memory_array_index_access_bytes_301{memory_dict : DictAccess*, msize, range_check_ptr}(
+func memory_array_index_access_bytes_297{memory_dict : DictAccess*, msize, range_check_ptr}(
         baseRef_12 : Uint256) -> (addr_13 : Uint256):
     alloc_locals
     let (local __warp_subexpr_2 : Uint256) = uint256_mload(baseRef_12)
@@ -385,7 +381,7 @@ func fun_bytesFun{
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_0 : Uint256) = memory_array_index_access_bytes_299(expr_mpos)
+    let (local __warp_subexpr_0 : Uint256) = memory_array_index_access_bytes(expr_mpos)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
@@ -393,7 +389,7 @@ func fun_bytesFun{
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_1 : Uint256) = memory_array_index_access_bytes(expr_mpos)
+    let (local __warp_subexpr_1 : Uint256) = memory_array_index_access_bytes_296(expr_mpos)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
@@ -401,7 +397,7 @@ func fun_bytesFun{
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_2 : Uint256) = memory_array_index_access_bytes_301(expr_mpos)
+    let (local __warp_subexpr_2 : Uint256) = memory_array_index_access_bytes_297(expr_mpos)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
@@ -417,15 +413,10 @@ func __warp_block_3{
         exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize, range_check_ptr}() -> (
         ):
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = __warp_constant_0()
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    end
-    let (local __warp_subexpr_1 : Uint256) = calldatasize()
+    let (local __warp_subexpr_0 : Uint256) = calldatasize()
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
-    abi_decode(__warp_subexpr_1)
+    abi_decode(__warp_subexpr_0)
     local range_check_ptr = range_check_ptr
     let (
         local ret__warp_mangled : Uint256) = copy_literal_to_memory_e1629b9dda060bb30c7908346f6af189c16773fa148d3366701fbaa35d54f3c8(
@@ -437,13 +428,13 @@ func __warp_block_3{
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_3 : Uint256) = abi_encode_string(memPos, ret__warp_mangled)
+    let (local __warp_subexpr_2 : Uint256) = abi_encode_string(memPos, ret__warp_mangled)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_2 : Uint256) = uint256_sub(__warp_subexpr_3, memPos)
+    let (local __warp_subexpr_1 : Uint256) = uint256_sub(__warp_subexpr_2, memPos)
     local range_check_ptr = range_check_ptr
-    returndata_write(memPos, __warp_subexpr_2)
+    returndata_write(memPos, __warp_subexpr_1)
     local exec_env : ExecutionEnvironment* = exec_env
     return ()
 end
@@ -452,15 +443,10 @@ func __warp_block_5{
         exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize, range_check_ptr}() -> (
         ):
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = __warp_constant_0()
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    end
-    let (local __warp_subexpr_1 : Uint256) = calldatasize()
+    let (local __warp_subexpr_0 : Uint256) = calldatasize()
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
-    abi_decode(__warp_subexpr_1)
+    abi_decode(__warp_subexpr_0)
     local range_check_ptr = range_check_ptr
     let (local ret_1 : Uint256) = fun_bytesFun()
     local exec_env : ExecutionEnvironment* = exec_env
@@ -471,13 +457,13 @@ func __warp_block_5{
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_3 : Uint256) = abi_encode_string(memPos_1, ret_1)
+    let (local __warp_subexpr_2 : Uint256) = abi_encode_string(memPos_1, ret_1)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_2 : Uint256) = uint256_sub(__warp_subexpr_3, memPos_1)
+    let (local __warp_subexpr_1 : Uint256) = uint256_sub(__warp_subexpr_2, memPos_1)
     local range_check_ptr = range_check_ptr
-    returndata_write(memPos_1, __warp_subexpr_2)
+    returndata_write(memPos_1, __warp_subexpr_1)
     local exec_env : ExecutionEnvironment* = exec_env
     return ()
 end

--- a/tests/yul/simple-storage-var.cairo
+++ b/tests/yul/simple-storage-var.cairo
@@ -12,12 +12,20 @@ from starkware.cairo.common.dict_access import DictAccess
 from starkware.cairo.common.registers import get_fp_and_pc
 from starkware.cairo.common.uint256 import Uint256, uint256_not, uint256_sub
 
-func __warp_constant_0() -> (res : Uint256):
-    return (Uint256(low=0, high=0))
+func sload{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(key : Uint256) -> (
+        value : Uint256):
+    let (res) = evm_storage.read(key.low, key.high)
+    return (res)
+end
+
+func sstore{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
+        key : Uint256, value : Uint256):
+    evm_storage.write(key.low, key.high, value)
+    return ()
 end
 
 @storage_var
-func counter() -> (res : Uint256):
+func evm_storage(arg0_low, arg0_high) -> (res : Uint256):
 end
 
 @storage_var
@@ -55,14 +63,13 @@ func abi_decode{range_check_ptr}(dataEnd : Uint256) -> ():
     end
 end
 
-func getter_fun_counter{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}() -> (
-        value : Uint256):
+func extract_from_storage_value_dynamict_uint256(slot_value : Uint256) -> (value : Uint256):
     alloc_locals
-    let (res) = counter.read()
-    return (res)
+    local value : Uint256 = slot_value
+    return (value)
 end
 
-func abi_encode_uint256_to_uint256_222{memory_dict : DictAccess*, msize, range_check_ptr}(
+func abi_encode_uint256_to_uint256_292{memory_dict : DictAccess*, msize, range_check_ptr}(
         value_1 : Uint256) -> ():
     alloc_locals
     uint256_mstore(offset=Uint256(low=128, high=0), value=value_1)
@@ -72,11 +79,11 @@ func abi_encode_uint256_to_uint256_222{memory_dict : DictAccess*, msize, range_c
     return ()
 end
 
-func abi_encode_uint256_118{memory_dict : DictAccess*, msize, range_check_ptr}(
+func abi_encode_uint256_156{memory_dict : DictAccess*, msize, range_check_ptr}(
         value0 : Uint256) -> (tail : Uint256):
     alloc_locals
     local tail : Uint256 = Uint256(low=160, high=0)
-    abi_encode_uint256_to_uint256_222(value0)
+    abi_encode_uint256_to_uint256_292(value0)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
@@ -98,30 +105,47 @@ func checked_add_uint256{range_check_ptr}(x : Uint256) -> (sum : Uint256):
     return (sum)
 end
 
-func setter_fun_counter{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
-        value_5 : Uint256) -> ():
+func update_byte_slice_shift(value_5 : Uint256, toInsert : Uint256) -> (result : Uint256):
     alloc_locals
-    counter.write(value_5)
+    local result : Uint256 = toInsert
+    return (result)
+end
+
+func update_storage_value_offsett_uint256_to_uint256{
+        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(value_6 : Uint256) -> ():
+    alloc_locals
+    let (local __warp_subexpr_1 : Uint256) = sload(Uint256(low=0, high=0))
+    local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local syscall_ptr : felt* = syscall_ptr
+    let (local __warp_subexpr_0 : Uint256) = update_byte_slice_shift(__warp_subexpr_1, value_6)
+    sstore(key=Uint256(low=0, high=0), value=__warp_subexpr_0)
+    local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    local syscall_ptr : felt* = syscall_ptr
     return ()
 end
 
 func fun_increment{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}() -> (
         var : Uint256):
     alloc_locals
-    let (local __warp_subexpr_1 : Uint256) = getter_fun_counter()
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    let (local __warp_subexpr_2 : Uint256) = sload(Uint256(low=0, high=0))
     local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local syscall_ptr : felt* = syscall_ptr
+    let (local __warp_subexpr_1 : Uint256) = extract_from_storage_value_dynamict_uint256(
+        __warp_subexpr_2)
     let (local __warp_subexpr_0 : Uint256) = checked_add_uint256(__warp_subexpr_1)
     local range_check_ptr = range_check_ptr
-    setter_fun_counter(__warp_subexpr_0)
+    update_storage_value_offsett_uint256_to_uint256(__warp_subexpr_0)
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
-    let (local var : Uint256) = getter_fun_counter()
-    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    let (local __warp_subexpr_3 : Uint256) = sload(Uint256(low=0, high=0))
     local range_check_ptr = range_check_ptr
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local syscall_ptr : felt* = syscall_ptr
+    let (local var : Uint256) = extract_from_storage_value_dynamict_uint256(__warp_subexpr_3)
     return (var)
 end
 
@@ -151,29 +175,26 @@ func __warp_block_2{
         exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize,
         pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}() -> ():
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = __warp_constant_0()
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    end
-    let (local __warp_subexpr_1 : Uint256) = calldatasize()
+    let (local __warp_subexpr_0 : Uint256) = calldatasize()
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
-    abi_decode(__warp_subexpr_1)
+    abi_decode(__warp_subexpr_0)
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_5 : Uint256) = getter_fun_counter()
+    let (local __warp_subexpr_5 : Uint256) = sload(Uint256(low=0, high=0))
+    local range_check_ptr = range_check_ptr
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
-    local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
-    let (local __warp_subexpr_4 : Uint256) = uint256_not(Uint256(low=127, high=0))
+    let (local __warp_subexpr_4 : Uint256) = extract_from_storage_value_dynamict_uint256(
+        __warp_subexpr_5)
+    let (local __warp_subexpr_3 : Uint256) = uint256_not(Uint256(low=127, high=0))
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_3 : Uint256) = abi_encode_uint256_118(__warp_subexpr_5)
+    let (local __warp_subexpr_2 : Uint256) = abi_encode_uint256_156(__warp_subexpr_4)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_2 : Uint256) = u256_add(__warp_subexpr_3, __warp_subexpr_4)
+    let (local __warp_subexpr_1 : Uint256) = u256_add(__warp_subexpr_2, __warp_subexpr_3)
     local range_check_ptr = range_check_ptr
-    returndata_write(Uint256(low=128, high=0), __warp_subexpr_2)
+    returndata_write(Uint256(low=128, high=0), __warp_subexpr_1)
     local exec_env : ExecutionEnvironment* = exec_env
     return ()
 end
@@ -182,15 +203,10 @@ func __warp_block_4{
         exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize,
         pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}() -> ():
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = __warp_constant_0()
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    end
-    let (local __warp_subexpr_1 : Uint256) = calldatasize()
+    let (local __warp_subexpr_0 : Uint256) = calldatasize()
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
-    abi_decode(__warp_subexpr_1)
+    abi_decode(__warp_subexpr_0)
     local range_check_ptr = range_check_ptr
     let (local ret__warp_mangled : Uint256) = fun_increment()
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
@@ -200,13 +216,13 @@ func __warp_block_4{
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_3 : Uint256) = abi_encode_uint256(memPos, ret__warp_mangled)
+    let (local __warp_subexpr_2 : Uint256) = abi_encode_uint256(memPos, ret__warp_mangled)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_2 : Uint256) = uint256_sub(__warp_subexpr_3, memPos)
+    let (local __warp_subexpr_1 : Uint256) = uint256_sub(__warp_subexpr_2, memPos)
     local range_check_ptr = range_check_ptr
-    returndata_write(memPos, __warp_subexpr_2)
+    returndata_write(memPos, __warp_subexpr_1)
     local exec_env : ExecutionEnvironment* = exec_env
     return ()
 end

--- a/tests/yul/sstore-sload.cairo
+++ b/tests/yul/sstore-sload.cairo
@@ -24,10 +24,6 @@ func sload{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(ke
     return (res)
 end
 
-func __warp_constant_0() -> (res : Uint256):
-    return (Uint256(low=0, high=0))
-end
-
 @storage_var
 func evm_storage(arg0_low, arg0_high) -> (res : Uint256):
 end
@@ -90,7 +86,7 @@ func abi_encode_uint256{memory_dict : DictAccess*, msize, range_check_ptr}(value
     return ()
 end
 
-func abi_encode_uint256_70{memory_dict : DictAccess*, msize, range_check_ptr}(value0 : Uint256) -> (
+func abi_encode_uint256_68{memory_dict : DictAccess*, msize, range_check_ptr}(value0 : Uint256) -> (
         tail : Uint256):
     alloc_locals
     local tail : Uint256 = Uint256(low=160, high=0)
@@ -105,29 +101,24 @@ func __warp_block_1{
         exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize,
         pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}() -> ():
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = __warp_constant_0()
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    end
-    let (local __warp_subexpr_1 : Uint256) = calldatasize()
+    let (local __warp_subexpr_0 : Uint256) = calldatasize()
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
-    abi_decode(__warp_subexpr_1)
+    abi_decode(__warp_subexpr_0)
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_5 : Uint256) = fun_test()
+    let (local __warp_subexpr_4 : Uint256) = fun_test()
     local pedersen_ptr : HashBuiltin* = pedersen_ptr
     local range_check_ptr = range_check_ptr
     local syscall_ptr : felt* = syscall_ptr
-    let (local __warp_subexpr_4 : Uint256) = uint256_not(Uint256(low=127, high=0))
+    let (local __warp_subexpr_3 : Uint256) = uint256_not(Uint256(low=127, high=0))
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_3 : Uint256) = abi_encode_uint256_70(__warp_subexpr_5)
+    let (local __warp_subexpr_2 : Uint256) = abi_encode_uint256_68(__warp_subexpr_4)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_2 : Uint256) = u256_add(__warp_subexpr_3, __warp_subexpr_4)
+    let (local __warp_subexpr_1 : Uint256) = u256_add(__warp_subexpr_2, __warp_subexpr_3)
     local range_check_ptr = range_check_ptr
-    returndata_write(Uint256(low=128, high=0), __warp_subexpr_2)
+    returndata_write(Uint256(low=128, high=0), __warp_subexpr_1)
     local exec_env : ExecutionEnvironment* = exec_env
     return ()
 end

--- a/tests/yul/view-function.cairo
+++ b/tests/yul/view-function.cairo
@@ -13,10 +13,6 @@ from starkware.cairo.common.registers import get_fp_and_pc
 from starkware.cairo.common.uint256 import (
     Uint256, uint256_and, uint256_not, uint256_sub, uint256_xor)
 
-func __warp_constant_0() -> (res : Uint256):
-    return (Uint256(low=0, high=0))
-end
-
 @storage_var
 func this_address() -> (res : felt):
 end
@@ -141,29 +137,24 @@ func __warp_block_3{
         exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize, range_check_ptr}() -> (
         ):
     alloc_locals
-    let (local __warp_subexpr_0 : Uint256) = __warp_constant_0()
-    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    end
-    let (local __warp_subexpr_1 : Uint256) = calldatasize()
+    let (local __warp_subexpr_0 : Uint256) = calldatasize()
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
     let (local param : Uint256, local param_1 : Uint256, local param_2 : Uint256,
-        local param_3 : Uint256) = abi_decode_uint256t_uint256t_uint256t_uint256(__warp_subexpr_1)
+        local param_3 : Uint256) = abi_decode_uint256t_uint256t_uint256t_uint256(__warp_subexpr_0)
     local exec_env : ExecutionEnvironment* = exec_env
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_5 : Uint256) = fun_viewFunction(param, param_1, param_2, param_3)
+    let (local __warp_subexpr_4 : Uint256) = fun_viewFunction(param, param_1, param_2, param_3)
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_4 : Uint256) = uint256_not(Uint256(low=127, high=0))
+    let (local __warp_subexpr_3 : Uint256) = uint256_not(Uint256(low=127, high=0))
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_3 : Uint256) = abi_encode_uint256(__warp_subexpr_5)
+    let (local __warp_subexpr_2 : Uint256) = abi_encode_uint256(__warp_subexpr_4)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
     local range_check_ptr = range_check_ptr
-    let (local __warp_subexpr_2 : Uint256) = u256_add(__warp_subexpr_3, __warp_subexpr_4)
+    let (local __warp_subexpr_1 : Uint256) = u256_add(__warp_subexpr_2, __warp_subexpr_3)
     local range_check_ptr = range_check_ptr
-    returndata_write(Uint256(low=128, high=0), __warp_subexpr_2)
+    returndata_write(Uint256(low=128, high=0), __warp_subexpr_1)
     local exec_env : ExecutionEnvironment* = exec_env
     return ()
 end

--- a/warp/cairo-src/evm/array.cairo
+++ b/warp/cairo-src/evm/array.cairo
@@ -13,11 +13,14 @@ func array_create_from_memory{memory_dict : DictAccess*, range_check_ptr}(offset
     # contents from offset to offset + length
     alloc_locals
     let (local array) = alloc()
-    copy_from_memory(offset=offset, length=length, array=array)
+    array_copy_from_memory(offset=offset, length=length, array=array)
     return (array)
 end
 
-func copy_from_memory{memory_dict : DictAccess*, range_check_ptr}(offset, length, array : felt*):
+func array_copy_from_memory{memory_dict : DictAccess*, range_check_ptr}(
+        offset, length, array : felt*):
+    # Copies memory contents from 'offset' to 'offset + length' to
+    # 'array'. See 'array_create_from_memory'.
     alloc_locals
     if length == 0:
         return ()

--- a/warp/cairo-src/evm/hashing.cairo
+++ b/warp/cairo-src/evm/hashing.cairo
@@ -1,9 +1,12 @@
+from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.cairo.common.dict_access import DictAccess
+from starkware.cairo.common.hash_chain import hash_chain
 from starkware.cairo.common.keccak import unsafe_keccak
 
-from evm.array import array_create_from_memory
+from evm.array import array_copy_from_memory, array_create_from_memory
 from evm.uint256 import Uint256
-from evm.utils import update_msize
+from evm.utils import ceil_div, felt_to_uint256, update_msize
 
 func sha{range_check_ptr, memory_dict : DictAccess*, msize}(offset, length) -> (res : Uint256):
     alloc_locals
@@ -16,4 +19,24 @@ end
 func uint256_sha{range_check_ptr, memory_dict : DictAccess*, msize}(
         offset : Uint256, length : Uint256) -> (res : Uint256):
     return sha(offset.low, length.low)
+end
+
+func pedersen{range_check_ptr, pedersen_ptr : HashBuiltin*, memory_dict : DictAccess*, msize}(
+        offset, length) -> (res):
+    alloc_locals
+    let (msize) = update_msize(msize, offset, length)
+    let (array) = alloc()
+    let (array_len) = ceil_div(length, 16)
+    array[0] = array_len
+    array_copy_from_memory(offset, length, array + 1)
+    let (res) = hash_chain{hash_ptr=pedersen_ptr}(array)
+    return (res)
+end
+
+func uint256_pedersen{
+        range_check_ptr, pedersen_ptr : HashBuiltin*, memory_dict : DictAccess*, msize}(
+        offset : Uint256, length : Uint256) -> (res : Uint256):
+    let (felt_res) = pedersen(offset.low, length.low)
+    let (res) = felt_to_uint256(felt_res)
+    return (res)
 end

--- a/warp/cairo-src/evm/output.cairo
+++ b/warp/cairo-src/evm/output.cairo
@@ -1,7 +1,6 @@
 from starkware.cairo.common.dict import DictAccess
 
 from evm.array import array_create_from_memory
-from evm.utils import ceil_div
 
 struct Output:
     # The structure represents EVM output data. It contains of

--- a/warp/yul/BuiltinHandler.py
+++ b/warp/yul/BuiltinHandler.py
@@ -329,13 +329,22 @@ class SLoad(DynamicHandler):
         return None
 
 
-# ============ Keccak ============
+# ============ Hashing ============
 class SHA3(StaticHandler):
     def __init__(self):
         super().__init__(
             function_name="uint256_sha",
             module="evm.hashing",
             used_implicits=("memory_dict", "msize", "range_check_ptr"),
+        )
+
+
+class Pedersen(StaticHandler):
+    def __init__(self):
+        super().__init__(
+            function_name="uint256_pedersen",
+            module="evm.hashing",
+            used_implicits=("memory_dict", "msize", "range_check_ptr", "pedersen_ptr"),
         )
 
 
@@ -489,6 +498,7 @@ def get_default_builtins(
         "mulmod": MulMod(),
         "not": Not(),
         "or": Sub(),
+        "pedersen": Pedersen(),
         "return": Return(),
         "returndatacopy": ReturnDataCopy(),
         "returndatasize": ReturnDataSize(cairo_functions),


### PR DESCRIPTION
Problem: before we tried to map solidity storage variables to cairo
     storage variables. The approach was somewhat limited. Solidity
     storage mappings and arrays can be curried. Cairo ones – can't.
      We had to heavily modify solidity compiler and still didn't
     support all the possible storage variables, e.g. structs.

Solution: with Shahar's suggestion we decided on the following. We
     just substitute keccak hash for storage access with a pedersen
     hash, native to cairo. It results in very slight modifications to
     solidity, as we only had to add another builtin instruction. It
     does lead to the bigger size of the generated code.