### PR TITLE
disable extracting "reverting" ifs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+typing-extensions<4,>=3.7.4.1
 wheel
 eth-hash==0.2.0
 ecdsa
@@ -10,4 +11,3 @@ cairo-lang==0.5.2
 aiohttp<4,>=3.7.4
 eth-utils<1.10
 click
-lark

--- a/tests/ast/ifs-to-flatten-scope.ast.result
+++ b/tests/ast/ifs-to-flatten-scope.ast.result
@@ -21,12 +21,19 @@ Block:
 							Identifier:sender
 							Identifier:recipient
 					Block:
-						Assignment:
-							Variables:
-							Value:
+						If:
+							FunctionCall:
+								Identifier:not
 								FunctionCall:
-									Identifier:__warp_cond_revert
+									Identifier:greater
 									Identifier:amount
+									Literal:0
+							Block:
+								ExpressionStatement:
+									FunctionCall:
+										Identifier:revert
+										Literal:0
+										Literal:0
 						Assignment:
 							Variables:
 								Identifier:res
@@ -39,27 +46,6 @@ Block:
 							Variables:
 								Identifier:res
 							Value:
-								Literal:0
-	FunctionDefinition:
-		Name: __warp_cond_revert
-		Parameters:
-			TypedName:
-				amount:Uint256
-		Return Variables:
-		Body:
-			Block:
-				If:
-					FunctionCall:
-						Identifier:not
-						FunctionCall:
-							Identifier:greater
-							Identifier:amount
-							Literal:0
-					Block:
-						ExpressionStatement:
-							FunctionCall:
-								Identifier:revert
-								Literal:0
 								Literal:0
 	FunctionDefinition:
 		Name: __warp_if_0

--- a/tests/ast/revert-condition.ast.result
+++ b/tests/ast/revert-condition.ast.result
@@ -20,12 +20,14 @@ Block:
 							Identifier:lt
 							Identifier:x
 							Identifier:y
-				Assignment:
-					Variables:
-					Value:
-						FunctionCall:
-							Identifier:__warp_cond_revert
-							Identifier:_1_5
+				If:
+					Identifier:_1_5
+					Block:
+						ExpressionStatement:
+							FunctionCall:
+								Identifier:revert
+								Literal:0
+								Literal:0
 				Assignment:
 					Variables:
 						Identifier:diff
@@ -50,12 +52,14 @@ Block:
 						FunctionCall:
 							Identifier:iszero
 							Identifier:condition
-				Assignment:
-					Variables:
-					Value:
-						FunctionCall:
-							Identifier:__warp_cond_revert
-							Identifier:_1_17
+				If:
+					Identifier:_1_17
+					Block:
+						ExpressionStatement:
+							FunctionCall:
+								Identifier:revert
+								Literal:0
+								Literal:0
 	FunctionDefinition:
 		Name: fun_transfer
 		Parameters:
@@ -132,19 +136,3 @@ Block:
 						Identifier:var
 					Value:
 						Literal:1
-	FunctionDefinition:
-		Name: __warp_cond_revert
-		Parameters:
-			TypedName:
-				_1_5:Uint256
-		Return Variables:
-		Body:
-			Block:
-				If:
-					Identifier:_1_5
-					Block:
-						ExpressionStatement:
-							FunctionCall:
-								Identifier:revert
-								Literal:0
-								Literal:0

--- a/tests/yul/ERC20.cairo
+++ b/tests/yul/ERC20.cairo
@@ -43,16 +43,6 @@ func initialize_address{range_check_ptr, syscall_ptr : felt*, pedersen_ptr : Has
     return ()
 end
 
-func __warp_cond_revert(_3_7 : Uint256) -> ():
-    alloc_locals
-    if _3_7.low + _3_7.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
 func abi_decode{range_check_ptr}(headStart : Uint256, dataEnd : Uint256) -> ():
     alloc_locals
     local _1_5 : Uint256 = Uint256(low=0, high=0)
@@ -60,8 +50,12 @@ func abi_decode{range_check_ptr}(headStart : Uint256, dataEnd : Uint256) -> ():
     local range_check_ptr = range_check_ptr
     let (local _3_7 : Uint256) = slt(_2_6, _1_5)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_3_7)
-    return ()
+    if _3_7.low + _3_7.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    else:
+        return ()
+    end
 end
 
 func getter_fun_totalSupply{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
@@ -103,7 +97,10 @@ func abi_decode_addresst_addresst_uint256{exec_env : ExecutionEnvironment*, rang
     local range_check_ptr = range_check_ptr
     let (local _3_15 : Uint256) = slt(_2_14, _1_13)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_3_15)
+    if _3_15.low + _3_15.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     let (local value0_12 : Uint256) = calldataload(headStart_10)
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
@@ -133,8 +130,12 @@ func require_helper{range_check_ptr}(condition : Uint256) -> ():
     alloc_locals
     let (local _1_79 : Uint256) = is_zero(condition)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_1_79)
-    return ()
+    if _1_79.low + _1_79.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    else:
+        return ()
+    end
 end
 
 func setter_fun_balances{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
@@ -150,7 +151,10 @@ func checked_add_uint256{range_check_ptr}(x : Uint256, y : Uint256) -> (sum : Ui
     local range_check_ptr = range_check_ptr
     let (local _2_64 : Uint256) = is_gt(x, _1_63)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_2_64)
+    if _2_64.low + _2_64.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     let (local sum : Uint256) = u256_add(x, y)
     local range_check_ptr = range_check_ptr
     return (sum)
@@ -261,7 +265,10 @@ func abi_decode_addresst_uint256{exec_env : ExecutionEnvironment*, range_check_p
     local range_check_ptr = range_check_ptr
     let (local _3_44 : Uint256) = slt(_2_43, _1_42)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_3_44)
+    if _3_44.low + _3_44.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     let (local value0_40 : Uint256) = calldataload(headStart_38)
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
@@ -299,7 +306,10 @@ func abi_decode_address{exec_env : ExecutionEnvironment*, range_check_ptr}(
     local range_check_ptr = range_check_ptr
     let (local _3_52 : Uint256) = slt(_2_51, _1_50)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_3_52)
+    if _3_52.low + _3_52.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     let (local value0_49 : Uint256) = calldataload(headStart_47)
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
@@ -335,7 +345,10 @@ func __warp_block_3{
         _2 : Uint256, _3 : Uint256, _4 : Uint256) -> ():
     alloc_locals
     let (local _11 : Uint256) = __warp_constant_0()
-    __warp_cond_revert(_11)
+    if _11.low + _11.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local _12 : Uint256 = _4
     abi_decode(_3, _4)
     local range_check_ptr = range_check_ptr
@@ -364,7 +377,10 @@ func __warp_block_5{
         _1 : Uint256, _3 : Uint256, _4 : Uint256) -> ():
     alloc_locals
     let (local _19 : Uint256) = __warp_constant_0()
-    __warp_cond_revert(_19)
+    if _19.low + _19.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local _20 : Uint256 = _4
     let (local param : Uint256, local param_1 : Uint256,
         local param_2 : Uint256) = abi_decode_addresst_addresst_uint256(_3, _4)
@@ -394,7 +410,10 @@ func __warp_block_7{
         _1 : Uint256, _3 : Uint256, _4 : Uint256) -> ():
     alloc_locals
     let (local _23 : Uint256) = __warp_constant_0()
-    __warp_cond_revert(_23)
+    if _23.low + _23.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local _24 : Uint256 = _4
     abi_decode(_3, _4)
     local range_check_ptr = range_check_ptr
@@ -420,7 +439,10 @@ func __warp_block_9{
         _1 : Uint256, _3 : Uint256, _4 : Uint256) -> ():
     alloc_locals
     let (local _28 : Uint256) = __warp_constant_0()
-    __warp_cond_revert(_28)
+    if _28.low + _28.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local _29 : Uint256 = _4
     abi_decode(_3, _4)
     local range_check_ptr = range_check_ptr
@@ -449,7 +471,10 @@ func __warp_block_11{
         _1 : Uint256, _3 : Uint256, _4 : Uint256) -> ():
     alloc_locals
     let (local _32 : Uint256) = __warp_constant_0()
-    __warp_cond_revert(_32)
+    if _32.low + _32.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local _33 : Uint256 = _4
     let (local param_3 : Uint256, local param_4 : Uint256) = abi_decode_addresst_uint256(_3, _4)
     local exec_env : ExecutionEnvironment* = exec_env
@@ -479,7 +504,10 @@ func __warp_block_13{
         _1 : Uint256, _3 : Uint256, _4 : Uint256) -> ():
     alloc_locals
     let (local _36 : Uint256) = __warp_constant_0()
-    __warp_cond_revert(_36)
+    if _36.low + _36.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local _37 : Uint256 = _4
     let (local _38 : Uint256) = abi_decode_address(_3, _4)
     local exec_env : ExecutionEnvironment* = exec_env
@@ -509,7 +537,10 @@ func __warp_block_15{
         _1 : Uint256, _3 : Uint256, _4 : Uint256) -> ():
     alloc_locals
     let (local _41 : Uint256) = __warp_constant_0()
-    __warp_cond_revert(_41)
+    if _41.low + _41.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local _42 : Uint256 = _4
     let (local _43 : Uint256) = abi_decode_address(_3, _4)
     local exec_env : ExecutionEnvironment* = exec_env
@@ -539,7 +570,10 @@ func __warp_block_17{
         _1 : Uint256, _3 : Uint256, _4 : Uint256) -> ():
     alloc_locals
     let (local _46 : Uint256) = __warp_constant_0()
-    __warp_cond_revert(_46)
+    if _46.low + _46.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local _47 : Uint256 = _4
     let (local param_5 : Uint256, local param_6 : Uint256) = abi_decode_addresst_uint256(_3, _4)
     local exec_env : ExecutionEnvironment* = exec_env
@@ -1008,4 +1042,3 @@ func fun_ENTRY_POINT{
     default_dict_finalize(memory_dict_start, memory_dict, 0)
     return (1, exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
 end
-

--- a/tests/yul/ERC20_storage.cairo
+++ b/tests/yul/ERC20_storage.cairo
@@ -47,16 +47,6 @@ func initialize_address{range_check_ptr, syscall_ptr : felt*, pedersen_ptr : Has
     return ()
 end
 
-func __warp_cond_revert(_3_7 : Uint256) -> ():
-    alloc_locals
-    if _3_7.low + _3_7.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
 func abi_decode{range_check_ptr}(headStart : Uint256, dataEnd : Uint256) -> ():
     alloc_locals
     local _1_5 : Uint256 = Uint256(low=0, high=0)
@@ -64,8 +54,12 @@ func abi_decode{range_check_ptr}(headStart : Uint256, dataEnd : Uint256) -> ():
     local range_check_ptr = range_check_ptr
     let (local _3_7 : Uint256) = slt(_2_6, _1_5)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_3_7)
-    return ()
+    if _3_7.low + _3_7.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    else:
+        return ()
+    end
 end
 
 func getter_fun_totalSupply{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
@@ -139,7 +133,10 @@ func abi_decode_uint256t_uint256{exec_env : ExecutionEnvironment*, range_check_p
     local range_check_ptr = range_check_ptr
     let (local _3_27 : Uint256) = slt(_2_26, _1_25)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_3_27)
+    if _3_27.low + _3_27.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     let (local value0_24 : Uint256) = calldataload(headStart_22)
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
@@ -163,15 +160,22 @@ func require_helper{range_check_ptr}(condition : Uint256) -> ():
     alloc_locals
     let (local _1_77 : Uint256) = is_zero(condition)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_1_77)
-    return ()
+    if _1_77.low + _1_77.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    else:
+        return ()
+    end
 end
 
 func checked_sub_uint256{range_check_ptr}(x_80 : Uint256, y_81 : Uint256) -> (diff : Uint256):
     alloc_locals
     let (local _1_82 : Uint256) = is_lt(x_80, y_81)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_1_82)
+    if _1_82.low + _1_82.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     let (local diff : Uint256) = uint256_sub(x_80, y_81)
     local range_check_ptr = range_check_ptr
     return (diff)
@@ -218,7 +222,10 @@ func abi_decode_uint256{exec_env : ExecutionEnvironment*, range_check_ptr}(
     local range_check_ptr = range_check_ptr
     let (local _3_35 : Uint256) = slt(_2_34, _1_33)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_3_35)
+    if _3_35.low + _3_35.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     let (local value0_32 : Uint256) = calldataload(headStart_30)
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
@@ -245,7 +252,10 @@ func abi_decode_uint256t_uint256t_uint256t_uint256{
     local range_check_ptr = range_check_ptr
     let (local _3_42 : Uint256) = slt(_2_41, _1_40)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_3_42)
+    if _3_42.low + _3_42.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     let (local value0_38 : Uint256) = calldataload(headStart_36)
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
@@ -276,7 +286,10 @@ func checked_add_uint256{range_check_ptr}(x : Uint256, y : Uint256) -> (sum : Ui
     local range_check_ptr = range_check_ptr
     let (local _2_68 : Uint256) = is_gt(x, _1_67)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_2_68)
+    if _2_68.low + _2_68.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     let (local sum : Uint256) = u256_add(x, y)
     local range_check_ptr = range_check_ptr
     return (sum)
@@ -397,7 +410,10 @@ func __warp_block_4{
         _2 : Uint256, _3 : Uint256, _4 : Uint256) -> ():
     alloc_locals
     let (local _11 : Uint256) = __warp_constant_0()
-    __warp_cond_revert(_11)
+    if _11.low + _11.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local _12 : Uint256 = _4
     abi_decode(_3, _4)
     local range_check_ptr = range_check_ptr
@@ -426,7 +442,10 @@ func __warp_block_6{
         _1 : Uint256, _3 : Uint256, _4 : Uint256) -> ():
     alloc_locals
     let (local _19 : Uint256) = __warp_constant_0()
-    __warp_cond_revert(_19)
+    if _19.low + _19.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local _20 : Uint256 = _4
     abi_decode(_3, _4)
     local range_check_ptr = range_check_ptr
@@ -478,7 +497,10 @@ func __warp_block_10{
         _1 : Uint256, _3 : Uint256, _4 : Uint256) -> ():
     alloc_locals
     let (local _26 : Uint256) = __warp_constant_0()
-    __warp_cond_revert(_26)
+    if _26.low + _26.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local _27 : Uint256 = _4
     let (local _28 : Uint256) = abi_decode_uint256(_3, _4)
     local exec_env : ExecutionEnvironment* = exec_env
@@ -537,7 +559,10 @@ func __warp_block_14{
         _1 : Uint256, _3 : Uint256, _4 : Uint256) -> ():
     alloc_locals
     let (local _34 : Uint256) = __warp_constant_0()
-    __warp_cond_revert(_34)
+    if _34.low + _34.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local _35 : Uint256 = _4
     let (local _36 : Uint256) = abi_decode_uint256(_3, _4)
     local exec_env : ExecutionEnvironment* = exec_env
@@ -988,4 +1013,3 @@ func fun_ENTRY_POINT{
     default_dict_finalize(memory_dict_start, memory_dict, 0)
     return (1, exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
 end
-

--- a/tests/yul/c2c.cairo
+++ b/tests/yul/c2c.cairo
@@ -43,16 +43,6 @@ func initialize_address{range_check_ptr, syscall_ptr : felt*, pedersen_ptr : Has
     return ()
 end
 
-func __warp_cond_revert(_3_7 : Uint256) -> ():
-    alloc_locals
-    if _3_7.low + _3_7.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
 func abi_decode_addresst_addresst_addresst_uint256{
         exec_env : ExecutionEnvironment*, range_check_ptr}(
         headStart : Uint256, dataEnd : Uint256) -> (
@@ -63,7 +53,10 @@ func abi_decode_addresst_addresst_addresst_uint256{
     local range_check_ptr = range_check_ptr
     let (local _3_7 : Uint256) = slt(_2_6, _1_5)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_3_7)
+    if _3_7.low + _3_7.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     let (local value0 : Uint256) = calldataload(headStart)
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
@@ -159,7 +152,10 @@ func finalize_allocation{memory_dict : DictAccess*, msize, range_check_ptr}(
     local range_check_ptr = range_check_ptr
     let (local _8_49 : Uint256) = uint256_sub(_7_48, _5_46)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_8_49)
+    if _8_49.low + _8_49.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local _9_50 : Uint256 = Uint256(low=64, high=0)
     uint256_mstore(offset=_9_50, value=newFreePtr)
     local memory_dict : DictAccess* = memory_dict
@@ -178,8 +174,12 @@ func validator_revert_bool{range_check_ptr}(value_51 : Uint256) -> ():
     local range_check_ptr = range_check_ptr
     let (local _4_55 : Uint256) = is_zero(_3_54)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_4_55)
-    return ()
+    if _4_55.low + _4_55.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    else:
+        return ()
+    end
 end
 
 func abi_decode_t_bool_fromMemory{memory_dict : DictAccess*, msize, range_check_ptr}(
@@ -202,7 +202,10 @@ func abi_decode_bool_fromMemory{memory_dict : DictAccess*, msize, range_check_pt
     local range_check_ptr = range_check_ptr
     let (local _3_64 : Uint256) = slt(_2_63, _1_62)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_3_64)
+    if _3_64.low + _3_64.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     let (local value0_61 : Uint256) = abi_decode_t_bool_fromMemory(headStart_59)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
@@ -286,7 +289,10 @@ func fun_sendMoneyz{
     local range_check_ptr = range_check_ptr
     let (local _12_146 : Uint256) = is_zero(_11_145)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_12_146)
+    if _12_146.low + _12_146.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local expr_147 : Uint256 = _9_143
     let (local expr_147 : Uint256) = __warp_if_0(_11_145, _2_136, expr_147)
     local exec_env : ExecutionEnvironment* = exec_env
@@ -332,7 +338,10 @@ func abi_decode_addresst_address{exec_env : ExecutionEnvironment*, range_check_p
     local range_check_ptr = range_check_ptr
     let (local _3_25 : Uint256) = slt(_2_24, _1_23)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_3_25)
+    if _3_25.low + _3_25.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     let (local value0_21 : Uint256) = calldataload(headStart_19)
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
@@ -366,7 +375,10 @@ func abi_decode_uint256_fromMemory{memory_dict : DictAccess*, msize, range_check
     local range_check_ptr = range_check_ptr
     let (local _3_102 : Uint256) = slt(_2_101, _1_100)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_3_102)
+    if _3_102.low + _3_102.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     let (local value0_99 : Uint256) = uint256_mload(headStart_97)
     local memory_dict : DictAccess* = memory_dict
     local msize = msize
@@ -446,7 +458,10 @@ func fun_checkMoneyz{
     local range_check_ptr = range_check_ptr
     let (local _11_118 : Uint256) = is_zero(_10_117)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_11_118)
+    if _11_118.low + _11_118.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local expr_119 : Uint256 = Uint256(low=0, high=0)
     let (local expr_119 : Uint256) = __warp_if_1(_10_117, _2_109, expr_119)
     local exec_env : ExecutionEnvironment* = exec_env
@@ -573,7 +588,10 @@ func fun_gimmeMoney{
     local range_check_ptr = range_check_ptr
     let (local _13_93 : Uint256) = is_zero(_12_92)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_13_93)
+    if _13_93.low + _13_93.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local expr : Uint256 = _10_90
     let (local expr : Uint256) = __warp_if_2(_12_92, _2_82, expr)
     local exec_env : ExecutionEnvironment* = exec_env
@@ -589,7 +607,10 @@ func __warp_block_6{
         syscall_ptr : felt*}(_2 : Uint256, _3 : Uint256, _4 : Uint256) -> ():
     alloc_locals
     let (local _11 : Uint256) = __warp_constant_0()
-    __warp_cond_revert(_11)
+    if _11.low + _11.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local _12 : Uint256 = _4
     local _13 : Uint256 = _3
     let (local param : Uint256, local param_1 : Uint256, local param_2 : Uint256,
@@ -623,7 +644,10 @@ func __warp_block_8{
         syscall_ptr : felt*}(_2 : Uint256, _3 : Uint256, _4 : Uint256) -> ():
     alloc_locals
     let (local _17 : Uint256) = __warp_constant_0()
-    __warp_cond_revert(_17)
+    if _17.low + _17.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local _18 : Uint256 = _4
     local _19 : Uint256 = _3
     let (local param_4 : Uint256, local param_5 : Uint256) = abi_decode_addresst_address(_3, _4)
@@ -656,7 +680,10 @@ func __warp_block_10{
         syscall_ptr : felt*}(_2 : Uint256, _3 : Uint256, _4 : Uint256) -> ():
     alloc_locals
     let (local _23 : Uint256) = __warp_constant_0()
-    __warp_cond_revert(_23)
+    if _23.low + _23.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local _24 : Uint256 = _4
     local _25 : Uint256 = _3
     let (local param_6 : Uint256, local param_7 : Uint256) = abi_decode_addresst_address(_3, _4)
@@ -893,4 +920,3 @@ func fun_ENTRY_POINT{
     default_dict_finalize(memory_dict_start, memory_dict, 0)
     return (1, exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
 end
-

--- a/tests/yul/calldatacopy.cairo
+++ b/tests/yul/calldatacopy.cairo
@@ -31,16 +31,6 @@ func initialize_address{range_check_ptr, syscall_ptr : felt*, pedersen_ptr : Has
     return ()
 end
 
-func __warp_cond_revert(_3_5 : Uint256) -> ():
-    alloc_locals
-    if _3_5.low + _3_5.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
 func abi_decode{range_check_ptr}(headStart : Uint256, dataEnd : Uint256) -> ():
     alloc_locals
     local _1_3 : Uint256 = Uint256(low=0, high=0)
@@ -48,8 +38,12 @@ func abi_decode{range_check_ptr}(headStart : Uint256, dataEnd : Uint256) -> ():
     local range_check_ptr = range_check_ptr
     let (local _3_5 : Uint256) = slt(_2_4, _1_3)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_3_5)
-    return ()
+    if _3_5.low + _3_5.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    else:
+        return ()
+    end
 end
 
 func fun_callMe{
@@ -226,4 +220,3 @@ func fun_ENTRY_POINT{
     default_dict_finalize(memory_dict_start, memory_dict, 0)
     return (1, exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
 end
-

--- a/tests/yul/calldataload.cairo
+++ b/tests/yul/calldataload.cairo
@@ -39,16 +39,6 @@ func initialize_address{range_check_ptr, syscall_ptr : felt*, pedersen_ptr : Has
     return ()
 end
 
-func __warp_cond_revert(_3_7 : Uint256) -> ():
-    alloc_locals
-    if _3_7.low + _3_7.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
 func abi_decode{range_check_ptr}(headStart : Uint256, dataEnd : Uint256) -> ():
     alloc_locals
     local _1_5 : Uint256 = Uint256(low=0, high=0)
@@ -56,8 +46,12 @@ func abi_decode{range_check_ptr}(headStart : Uint256, dataEnd : Uint256) -> ():
     local range_check_ptr = range_check_ptr
     let (local _3_7 : Uint256) = slt(_2_6, _1_5)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_3_7)
-    return ()
+    if _3_7.low + _3_7.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    else:
+        return ()
+    end
 end
 
 func fun_test{exec_env : ExecutionEnvironment*, range_check_ptr}() -> (var_res : Uint256):
@@ -68,8 +62,12 @@ func fun_test{exec_env : ExecutionEnvironment*, range_check_ptr}() -> (var_res :
     let (local _2_13 : Uint256) = calldataload(_1_12)
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
-    __warp_cond_revert(_2_13)
-    return (var_res)
+    if _2_13.low + _2_13.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    else:
+        return (var_res)
+    end
 end
 
 func abi_encode_uint256_to_uint256{memory_dict : DictAccess*, msize, range_check_ptr}(
@@ -100,7 +98,10 @@ func __warp_block_1{
         _1 : Uint256, _3 : Uint256, _4 : Uint256) -> ():
     alloc_locals
     let (local _13 : Uint256) = __warp_constant_0()
-    __warp_cond_revert(_13)
+    if _13.low + _13.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local _14 : Uint256 = _4
     local _15 : Uint256 = _3
     abi_decode(_3, _4)
@@ -221,4 +222,3 @@ func fun_ENTRY_POINT{
     default_dict_finalize(memory_dict_start, memory_dict, 0)
     return (1, exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
 end
-

--- a/tests/yul/calldatasize.cairo
+++ b/tests/yul/calldatasize.cairo
@@ -35,16 +35,6 @@ func initialize_address{range_check_ptr, syscall_ptr : felt*, pedersen_ptr : Has
     return ()
 end
 
-func __warp_cond_revert(_3_7 : Uint256) -> ():
-    alloc_locals
-    if _3_7.low + _3_7.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
 func abi_decode{range_check_ptr}(headStart : Uint256, dataEnd : Uint256) -> ():
     alloc_locals
     local _1_5 : Uint256 = Uint256(low=0, high=0)
@@ -52,8 +42,12 @@ func abi_decode{range_check_ptr}(headStart : Uint256, dataEnd : Uint256) -> ():
     local range_check_ptr = range_check_ptr
     let (local _3_7 : Uint256) = slt(_2_6, _1_5)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_3_7)
-    return ()
+    if _3_7.low + _3_7.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    else:
+        return ()
+    end
 end
 
 func fun_test{exec_env : ExecutionEnvironment*, range_check_ptr}() -> (var_res : Uint256):
@@ -65,8 +59,12 @@ func fun_test{exec_env : ExecutionEnvironment*, range_check_ptr}() -> (var_res :
     let (local _2_13 : Uint256) = calldataload(_1_12)
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
-    __warp_cond_revert(_2_13)
-    return (var_res)
+    if _2_13.low + _2_13.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    else:
+        return (var_res)
+    end
 end
 
 func abi_encode_uint256_to_uint256{memory_dict : DictAccess*, msize, range_check_ptr}(
@@ -97,7 +95,10 @@ func __warp_block_1{
         _1 : Uint256, _3 : Uint256, _4 : Uint256) -> ():
     alloc_locals
     let (local _13 : Uint256) = __warp_constant_0()
-    __warp_cond_revert(_13)
+    if _13.low + _13.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local _14 : Uint256 = _4
     local _15 : Uint256 = _3
     abi_decode(_3, _4)
@@ -218,4 +219,3 @@ func fun_ENTRY_POINT{
     default_dict_finalize(memory_dict_start, memory_dict, 0)
     return (1, exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
 end
-

--- a/tests/yul/constructors_dyn.cairo
+++ b/tests/yul/constructors_dyn.cairo
@@ -47,16 +47,6 @@ func initialize_address{range_check_ptr, syscall_ptr : felt*, pedersen_ptr : Has
     return ()
 end
 
-func __warp_cond_revert(_3_10 : Uint256) -> ():
-    alloc_locals
-    if _3_10.low + _3_10.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
 func abi_decode_struct_Person_calldata{range_check_ptr}(
         offset : Uint256, end__warp_mangled : Uint256) -> (value_7 : Uint256):
     alloc_locals
@@ -65,7 +55,10 @@ func abi_decode_struct_Person_calldata{range_check_ptr}(
     local range_check_ptr = range_check_ptr
     let (local _3_10 : Uint256) = slt(_2_9, _1_8)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_3_10)
+    if _3_10.low + _3_10.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local value_7 : Uint256 = offset
     return (value_7)
 end
@@ -80,7 +73,10 @@ func abi_decode_addresst_struct_Person_calldatat_uint256{
     local range_check_ptr = range_check_ptr
     let (local _3_13 : Uint256) = slt(_2_12, _1_11)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_3_13)
+    if _3_13.low + _3_13.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     let (local value0 : Uint256) = calldataload(headStart)
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
@@ -237,8 +233,12 @@ func abi_decode{range_check_ptr}(headStart_24 : Uint256, dataEnd_25 : Uint256) -
     local range_check_ptr = range_check_ptr
     let (local _3_28 : Uint256) = slt(_2_27, _1_26)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_3_28)
-    return ()
+    if _3_28.low + _3_28.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    else:
+        return ()
+    end
 end
 
 func abi_encode_uint256_to_uint256{memory_dict : DictAccess*, msize, range_check_ptr}(
@@ -293,7 +293,10 @@ func __warp_block_5{
         _1 : Uint256, _3 : Uint256, _4 : Uint256) -> ():
     alloc_locals
     let (local _11 : Uint256) = __warp_constant_0()
-    __warp_cond_revert(_11)
+    if _11.low + _11.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local _12 : Uint256 = _4
     let (local param : Uint256, local param_1 : Uint256,
         local param_2 : Uint256) = abi_decode_addresst_struct_Person_calldatat_uint256(_3, _4)
@@ -325,7 +328,10 @@ func __warp_block_7{
         _2 : Uint256, _3 : Uint256, _4 : Uint256) -> ():
     alloc_locals
     let (local _19 : Uint256) = __warp_constant_0()
-    __warp_cond_revert(_19)
+    if _19.low + _19.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local _20 : Uint256 = _4
     abi_decode(_3, _4)
     local range_check_ptr = range_check_ptr
@@ -355,7 +361,10 @@ func __warp_block_9{
         _2 : Uint256, _3 : Uint256, _4 : Uint256) -> ():
     alloc_locals
     let (local _29 : Uint256) = __warp_constant_0()
-    __warp_cond_revert(_29)
+    if _29.low + _29.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local _30 : Uint256 = _4
     abi_decode(_3, _4)
     local range_check_ptr = range_check_ptr
@@ -385,7 +394,10 @@ func __warp_block_11{
         _2 : Uint256, _3 : Uint256, _4 : Uint256) -> ():
     alloc_locals
     let (local _34 : Uint256) = __warp_constant_0()
-    __warp_cond_revert(_34)
+    if _34.low + _34.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local _35 : Uint256 = _4
     abi_decode(_3, _4)
     local range_check_ptr = range_check_ptr
@@ -710,7 +722,10 @@ func finalize_allocation{memory_dict : DictAccess*, msize, range_check_ptr}(
     local range_check_ptr = range_check_ptr
     let (local _8_52 : Uint256) = uint256_sub(_7_51, _5_49)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_8_52)
+    if _8_52.low + _8_52.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local _9_53 : Uint256 = Uint256(low=64, high=0)
     uint256_mstore(offset=_9_53, value=newFreePtr)
     local memory_dict : DictAccess* = memory_dict
@@ -743,7 +758,10 @@ func abi_decode_struct_Person{
     local range_check_ptr = range_check_ptr
     let (local _3_62 : Uint256) = slt(_2_61, _1_60)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_3_62)
+    if _3_62.low + _3_62.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local _4_63 : Uint256 = _1_60
     let (local value_59 : Uint256) = allocate_memory(_1_60)
     local memory_dict : DictAccess* = memory_dict
@@ -782,7 +800,10 @@ func abi_decode_addresst_struct_Persont_uint256{
     local range_check_ptr = range_check_ptr
     let (local _3_77 : Uint256) = slt(_2_76, _1_75)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_3_77)
+    if _3_77.low + _3_77.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     let (local value0_72 : Uint256) = calldataload(headStart_70)
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
@@ -883,7 +904,10 @@ func constructor{
         let (local _10_120 : Uint256) = u256_shr(_9_119, _8_118)
         local range_check_ptr = range_check_ptr
         let (local _24 : Uint256) = __warp_constant_0()
-        __warp_cond_revert(_24)
+        if _24.low + _24.high != 0:
+            assert 0 = 1
+            jmp rel 0
+        end
         local _25 : Uint256 = _4_116
         let (local param_3 : Uint256, local param_4 : Uint256,
             local param_5 : Uint256) = abi_decode_addresst_struct_Persont_uint256(_3_115, _4_116)
@@ -908,4 +932,3 @@ func constructor{
         return ()
     end
 end
-

--- a/tests/yul/constructors_nonDyn.cairo
+++ b/tests/yul/constructors_nonDyn.cairo
@@ -47,16 +47,6 @@ func initialize_address{range_check_ptr, syscall_ptr : felt*, pedersen_ptr : Has
     return ()
 end
 
-func __warp_cond_revert(_3_7 : Uint256) -> ():
-    alloc_locals
-    if _3_7.low + _3_7.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
 func abi_decode{range_check_ptr}(headStart : Uint256, dataEnd : Uint256) -> ():
     alloc_locals
     local _1_5 : Uint256 = Uint256(low=0, high=0)
@@ -64,8 +54,12 @@ func abi_decode{range_check_ptr}(headStart : Uint256, dataEnd : Uint256) -> ():
     local range_check_ptr = range_check_ptr
     let (local _3_7 : Uint256) = slt(_2_6, _1_5)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_3_7)
-    return ()
+    if _3_7.low + _3_7.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    else:
+        return ()
+    end
 end
 
 func getter_fun_ownerCellNumber{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
@@ -144,7 +138,10 @@ func abi_decode_addresst_uint256t_uint256{exec_env : ExecutionEnvironment*, rang
     local range_check_ptr = range_check_ptr
     let (local _3_30 : Uint256) = slt(_2_29, _1_28)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_3_30)
+    if _3_30.low + _3_30.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     let (local value0_27 : Uint256) = calldataload(headStart_25)
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
@@ -286,7 +283,10 @@ func __warp_block_5{
         _1 : Uint256, _3 : Uint256, _4 : Uint256) -> ():
     alloc_locals
     let (local _11 : Uint256) = __warp_constant_0()
-    __warp_cond_revert(_11)
+    if _11.low + _11.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local _12 : Uint256 = _4
     abi_decode(_3, _4)
     local range_check_ptr = range_check_ptr
@@ -315,7 +315,10 @@ func __warp_block_7{
         _2 : Uint256, _3 : Uint256, _4 : Uint256) -> ():
     alloc_locals
     let (local _19 : Uint256) = __warp_constant_0()
-    __warp_cond_revert(_19)
+    if _19.low + _19.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local _20 : Uint256 = _4
     abi_decode(_3, _4)
     local range_check_ptr = range_check_ptr
@@ -345,7 +348,10 @@ func __warp_block_9{
         _2 : Uint256, _3 : Uint256, _4 : Uint256) -> ():
     alloc_locals
     let (local _24 : Uint256) = __warp_constant_0()
-    __warp_cond_revert(_24)
+    if _24.low + _24.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local _25 : Uint256 = _4
     abi_decode(_3, _4)
     local range_check_ptr = range_check_ptr
@@ -375,7 +381,10 @@ func __warp_block_11{
         _2 : Uint256, _3 : Uint256, _4 : Uint256) -> ():
     alloc_locals
     let (local _29 : Uint256) = __warp_constant_0()
-    __warp_cond_revert(_29)
+    if _29.low + _29.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local _30 : Uint256 = _4
     let (local param : Uint256, local param_1 : Uint256,
         local param_2 : Uint256) = abi_decode_addresst_uint256t_uint256(_3, _4)
@@ -719,4 +728,3 @@ func constructor{
         return ()
     end
 end
-

--- a/tests/yul/for-loop-with-break.cairo
+++ b/tests/yul/for-loop-with-break.cairo
@@ -31,16 +31,6 @@ func initialize_address{range_check_ptr, syscall_ptr : felt*, pedersen_ptr : Has
     return ()
 end
 
-func __warp_cond_revert(_3_5 : Uint256) -> ():
-    alloc_locals
-    if _3_5.low + _3_5.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
 func abi_decode_uint256t_uint256{exec_env : ExecutionEnvironment*, range_check_ptr}(
         headStart : Uint256, dataEnd : Uint256) -> (value0 : Uint256, value1 : Uint256):
     alloc_locals
@@ -49,7 +39,10 @@ func abi_decode_uint256t_uint256{exec_env : ExecutionEnvironment*, range_check_p
     local range_check_ptr = range_check_ptr
     let (local _3_5 : Uint256) = slt(_2_4, _1_3)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_3_5)
+    if _3_5.low + _3_5.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     let (local value0 : Uint256) = calldataload(headStart)
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
@@ -66,7 +59,10 @@ func checked_sub_uint256{range_check_ptr}(x_23 : Uint256, y_24 : Uint256) -> (di
     alloc_locals
     let (local _1_25 : Uint256) = is_lt(x_23, y_24)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_1_25)
+    if _1_25.low + _1_25.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     let (local diff : Uint256) = uint256_sub(x_23, y_24)
     local range_check_ptr = range_check_ptr
     return (diff)
@@ -78,7 +74,10 @@ func checked_add_uint256{range_check_ptr}(x : Uint256, y : Uint256) -> (sum : Ui
     local range_check_ptr = range_check_ptr
     let (local _2_22 : Uint256) = is_gt(x, _1_21)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_2_22)
+    if _2_22.low + _2_22.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     let (local sum : Uint256) = u256_add(x, y)
     local range_check_ptr = range_check_ptr
     return (sum)
@@ -285,4 +284,3 @@ func fun_ENTRY_POINT{
     default_dict_finalize(memory_dict_start, memory_dict, 0)
     return (1, exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
 end
-

--- a/tests/yul/for-loop-with-continue.cairo
+++ b/tests/yul/for-loop-with-continue.cairo
@@ -31,16 +31,6 @@ func initialize_address{range_check_ptr, syscall_ptr : felt*, pedersen_ptr : Has
     return ()
 end
 
-func __warp_cond_revert(_3_5 : Uint256) -> ():
-    alloc_locals
-    if _3_5.low + _3_5.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
 func abi_decode_uint256t_uint256{exec_env : ExecutionEnvironment*, range_check_ptr}(
         headStart : Uint256, dataEnd : Uint256) -> (value0 : Uint256, value1 : Uint256):
     alloc_locals
@@ -49,7 +39,10 @@ func abi_decode_uint256t_uint256{exec_env : ExecutionEnvironment*, range_check_p
     local range_check_ptr = range_check_ptr
     let (local _3_5 : Uint256) = slt(_2_4, _1_3)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_3_5)
+    if _3_5.low + _3_5.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     let (local value0 : Uint256) = calldataload(headStart)
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
@@ -66,7 +59,10 @@ func checked_sub_uint256{range_check_ptr}(x_23 : Uint256, y_24 : Uint256) -> (di
     alloc_locals
     let (local _1_25 : Uint256) = is_lt(x_23, y_24)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_1_25)
+    if _1_25.low + _1_25.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     let (local diff : Uint256) = uint256_sub(x_23, y_24)
     local range_check_ptr = range_check_ptr
     return (diff)
@@ -78,7 +74,10 @@ func checked_add_uint256{range_check_ptr}(x : Uint256, y : Uint256) -> (sum : Ui
     local range_check_ptr = range_check_ptr
     let (local _2_22 : Uint256) = is_gt(x, _1_21)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_2_22)
+    if _2_22.low + _2_22.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     let (local sum : Uint256) = u256_add(x, y)
     local range_check_ptr = range_check_ptr
     return (sum)
@@ -277,4 +276,3 @@ func fun_ENTRY_POINT{
     default_dict_finalize(memory_dict_start, memory_dict, 0)
     return (1, exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
 end
-

--- a/tests/yul/for-loop-with-nested-return.cairo
+++ b/tests/yul/for-loop-with-nested-return.cairo
@@ -31,16 +31,6 @@ func initialize_address{range_check_ptr, syscall_ptr : felt*, pedersen_ptr : Has
     return ()
 end
 
-func __warp_cond_revert(_3_5 : Uint256) -> ():
-    alloc_locals
-    if _3_5.low + _3_5.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
 func abi_decode_uint256t_uint256{exec_env : ExecutionEnvironment*, range_check_ptr}(
         headStart : Uint256, dataEnd : Uint256) -> (value0 : Uint256, value1 : Uint256):
     alloc_locals
@@ -49,7 +39,10 @@ func abi_decode_uint256t_uint256{exec_env : ExecutionEnvironment*, range_check_p
     local range_check_ptr = range_check_ptr
     let (local _3_5 : Uint256) = slt(_2_4, _1_3)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_3_5)
+    if _3_5.low + _3_5.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     let (local value0 : Uint256) = calldataload(headStart)
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
@@ -66,7 +59,10 @@ func checked_sub_uint256{range_check_ptr}(x_23 : Uint256, y_24 : Uint256) -> (di
     alloc_locals
     let (local _1_25 : Uint256) = is_lt(x_23, y_24)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_1_25)
+    if _1_25.low + _1_25.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     let (local diff : Uint256) = uint256_sub(x_23, y_24)
     local range_check_ptr = range_check_ptr
     return (diff)
@@ -78,7 +74,10 @@ func checked_add_uint256{range_check_ptr}(x : Uint256, y : Uint256) -> (sum : Ui
     local range_check_ptr = range_check_ptr
     let (local _2_22 : Uint256) = is_gt(x, _1_21)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_2_22)
+    if _2_22.low + _2_22.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     let (local sum : Uint256) = u256_add(x, y)
     local range_check_ptr = range_check_ptr
     return (sum)
@@ -310,4 +309,3 @@ func fun_ENTRY_POINT{
     default_dict_finalize(memory_dict_start, memory_dict, 0)
     return (1, exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
 end
-

--- a/tests/yul/function-with-nested-return.cairo
+++ b/tests/yul/function-with-nested-return.cairo
@@ -31,16 +31,6 @@ func initialize_address{range_check_ptr, syscall_ptr : felt*, pedersen_ptr : Has
     return ()
 end
 
-func __warp_cond_revert(_3_5 : Uint256) -> ():
-    alloc_locals
-    if _3_5.low + _3_5.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
 func abi_decode_uint256t_uint256{exec_env : ExecutionEnvironment*, range_check_ptr}(
         headStart : Uint256, dataEnd : Uint256) -> (value0 : Uint256, value1 : Uint256):
     alloc_locals
@@ -49,7 +39,10 @@ func abi_decode_uint256t_uint256{exec_env : ExecutionEnvironment*, range_check_p
     local range_check_ptr = range_check_ptr
     let (local _3_5 : Uint256) = slt(_2_4, _1_3)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_3_5)
+    if _3_5.low + _3_5.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     let (local value0 : Uint256) = calldataload(headStart)
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
@@ -226,4 +219,3 @@ func fun_ENTRY_POINT{
     default_dict_finalize(memory_dict_start, memory_dict, 0)
     return (1, exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
 end
-

--- a/tests/yul/if-flattening.cairo
+++ b/tests/yul/if-flattening.cairo
@@ -39,16 +39,6 @@ func initialize_address{range_check_ptr, syscall_ptr : felt*, pedersen_ptr : Has
     return ()
 end
 
-func __warp_cond_revert(_3_7 : Uint256) -> ():
-    alloc_locals
-    if _3_7.low + _3_7.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
 func abi_decode_uint256{exec_env : ExecutionEnvironment*, range_check_ptr}(
         headStart : Uint256, dataEnd : Uint256) -> (value0 : Uint256):
     alloc_locals
@@ -57,7 +47,10 @@ func abi_decode_uint256{exec_env : ExecutionEnvironment*, range_check_ptr}(
     local range_check_ptr = range_check_ptr
     let (local _3_7 : Uint256) = slt(_2_6, _1_5)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_3_7)
+    if _3_7.low + _3_7.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     let (local value0 : Uint256) = calldataload(headStart)
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
@@ -103,7 +96,10 @@ func abi_decode_uint256t_uint256t_uint256{exec_env : ExecutionEnvironment*, rang
     local range_check_ptr = range_check_ptr
     let (local _3_18 : Uint256) = slt(_2_17, _1_16)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_3_18)
+    if _3_18.low + _3_18.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     let (local value0_15 : Uint256) = calldataload(headStart_13)
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
@@ -126,7 +122,10 @@ func checked_sub_uint256{range_check_ptr}(x : Uint256, y : Uint256) -> (diff : U
     alloc_locals
     let (local _1_31 : Uint256) = is_lt(x, y)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_1_31)
+    if _1_31.low + _1_31.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     let (local diff : Uint256) = uint256_sub(x, y)
     local range_check_ptr = range_check_ptr
     return (diff)
@@ -216,7 +215,10 @@ func __warp_block_6{
         _1 : Uint256, _3 : Uint256, _4 : Uint256) -> ():
     alloc_locals
     let (local _11 : Uint256) = __warp_constant_0()
-    __warp_cond_revert(_11)
+    if _11.low + _11.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     let (local _12 : Uint256) = uint256_not(Uint256(low=127, high=0))
     local range_check_ptr = range_check_ptr
     local _13 : Uint256 = _4
@@ -455,4 +457,3 @@ func fun_ENTRY_POINT{
     default_dict_finalize(memory_dict_start, memory_dict, 0)
     return (1, exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
 end
-

--- a/tests/yul/payable-function.cairo
+++ b/tests/yul/payable-function.cairo
@@ -32,16 +32,6 @@ func initialize_address{range_check_ptr, syscall_ptr : felt*, pedersen_ptr : Has
     return ()
 end
 
-func __warp_cond_revert(_3_5 : Uint256) -> ():
-    alloc_locals
-    if _3_5.low + _3_5.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
 func abi_decode_uint256t_uint256t_uint256t_uint256{
         exec_env : ExecutionEnvironment*, range_check_ptr}(
         headStart : Uint256, dataEnd : Uint256) -> (
@@ -52,7 +42,10 @@ func abi_decode_uint256t_uint256t_uint256t_uint256{
     local range_check_ptr = range_check_ptr
     let (local _3_5 : Uint256) = slt(_2_4, _1_3)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_3_5)
+    if _3_5.low + _3_5.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     let (local value0 : Uint256) = calldataload(headStart)
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
@@ -277,4 +270,3 @@ func fun_ENTRY_POINT{
     default_dict_finalize(memory_dict_start, memory_dict, 0)
     return (1, exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
 end
-

--- a/tests/yul/pure-function.cairo
+++ b/tests/yul/pure-function.cairo
@@ -36,16 +36,6 @@ func initialize_address{range_check_ptr, syscall_ptr : felt*, pedersen_ptr : Has
     return ()
 end
 
-func __warp_cond_revert(_3_7 : Uint256) -> ():
-    alloc_locals
-    if _3_7.low + _3_7.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
 func abi_decode_uint256t_uint256t_uint256t_uint256{
         exec_env : ExecutionEnvironment*, range_check_ptr}(
         headStart : Uint256, dataEnd : Uint256) -> (
@@ -56,7 +46,10 @@ func abi_decode_uint256t_uint256t_uint256t_uint256{
     local range_check_ptr = range_check_ptr
     let (local _3_7 : Uint256) = slt(_2_6, _1_5)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_3_7)
+    if _3_7.low + _3_7.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     let (local value0 : Uint256) = calldataload(headStart)
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
@@ -161,7 +154,10 @@ func __warp_block_3{
         _1 : Uint256, _3 : Uint256, _4 : Uint256) -> ():
     alloc_locals
     let (local _13 : Uint256) = __warp_constant_0()
-    __warp_cond_revert(_13)
+    if _13.low + _13.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local _14 : Uint256 = _4
     local _15 : Uint256 = _3
     let (local param : Uint256, local param_1 : Uint256, local param_2 : Uint256,
@@ -283,4 +279,3 @@ func fun_ENTRY_POINT{
     default_dict_finalize(memory_dict_start, memory_dict, 0)
     return (1, exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
 end
-

--- a/tests/yul/return-var-capturing.cairo
+++ b/tests/yul/return-var-capturing.cairo
@@ -31,16 +31,6 @@ func initialize_address{range_check_ptr, syscall_ptr : felt*, pedersen_ptr : Has
     return ()
 end
 
-func __warp_cond_revert(_3_5 : Uint256) -> ():
-    alloc_locals
-    if _3_5.low + _3_5.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
 func abi_decode_uint256t_uint256{exec_env : ExecutionEnvironment*, range_check_ptr}(
         headStart : Uint256, dataEnd : Uint256) -> (value0 : Uint256, value1 : Uint256):
     alloc_locals
@@ -49,7 +39,10 @@ func abi_decode_uint256t_uint256{exec_env : ExecutionEnvironment*, range_check_p
     local range_check_ptr = range_check_ptr
     let (local _3_5 : Uint256) = slt(_2_4, _1_3)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_3_5)
+    if _3_5.low + _3_5.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     let (local value0 : Uint256) = calldataload(headStart)
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
@@ -68,7 +61,10 @@ func checked_add_uint256{range_check_ptr}(x : Uint256, y : Uint256) -> (sum : Ui
     local range_check_ptr = range_check_ptr
     let (local _2_20 : Uint256) = is_gt(x, _1_19)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_2_20)
+    if _2_20.low + _2_20.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     let (local sum : Uint256) = u256_add(x, y)
     local range_check_ptr = range_check_ptr
     return (sum)
@@ -93,26 +89,26 @@ func __warp_block_3{range_check_ptr}(var_a : Uint256) -> (__warp_leave_2 : Uint2
 end
 
 func __warp_if_2{range_check_ptr}(
-        __warp_leave_9 : Uint256, __warp_subexpr_0 : Uint256, var_a : Uint256, var_b : Uint256) -> (
-        __warp_leave_2 : Uint256, __warp_leave_9 : Uint256, var : Uint256):
+        __warp_leave_8 : Uint256, __warp_subexpr_0 : Uint256, var_a : Uint256, var_b : Uint256) -> (
+        __warp_leave_2 : Uint256, __warp_leave_8 : Uint256, var : Uint256):
     alloc_locals
     if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
         let (local __warp_leave_2 : Uint256, local var : Uint256) = __warp_block_2(var_b)
         local range_check_ptr = range_check_ptr
         if __warp_leave_2.low + __warp_leave_2.high != 0:
-            local __warp_leave_9 : Uint256 = Uint256(low=1, high=0)
-            return (__warp_leave_2, __warp_leave_9, var)
+            local __warp_leave_8 : Uint256 = Uint256(low=1, high=0)
+            return (__warp_leave_2, __warp_leave_8, var)
         else:
-            return (__warp_leave_2, __warp_leave_9, var)
+            return (__warp_leave_2, __warp_leave_8, var)
         end
     else:
         let (local __warp_leave_2 : Uint256, local var : Uint256) = __warp_block_3(var_a)
         local range_check_ptr = range_check_ptr
         if __warp_leave_2.low + __warp_leave_2.high != 0:
-            local __warp_leave_9 : Uint256 = Uint256(low=1, high=0)
-            return (__warp_leave_2, __warp_leave_9, var)
+            local __warp_leave_8 : Uint256 = Uint256(low=1, high=0)
+            return (__warp_leave_2, __warp_leave_8, var)
         else:
-            return (__warp_leave_2, __warp_leave_9, var)
+            return (__warp_leave_2, __warp_leave_8, var)
         end
     end
 end
@@ -120,13 +116,13 @@ end
 func __warp_block_1{range_check_ptr}(match_var : Uint256, var_a : Uint256, var_b : Uint256) -> (
         __warp_leave_2 : Uint256, var : Uint256):
     alloc_locals
-    local __warp_leave_9 : Uint256 = Uint256(low=0, high=0)
+    local __warp_leave_8 : Uint256 = Uint256(low=0, high=0)
     let (local __warp_subexpr_0 : Uint256) = is_eq(match_var, Uint256(low=0, high=0))
     local range_check_ptr = range_check_ptr
-    let (local __warp_leave_2 : Uint256, local __warp_leave_9 : Uint256,
-        local var : Uint256) = __warp_if_2(__warp_leave_9, __warp_subexpr_0, var_a, var_b)
+    let (local __warp_leave_2 : Uint256, local __warp_leave_8 : Uint256,
+        local var : Uint256) = __warp_if_2(__warp_leave_8, __warp_subexpr_0, var_a, var_b)
     local range_check_ptr = range_check_ptr
-    if __warp_leave_9.low + __warp_leave_9.high != 0:
+    if __warp_leave_8.low + __warp_leave_8.high != 0:
         return (__warp_leave_2, var)
     else:
         return (__warp_leave_2, var)
@@ -309,4 +305,3 @@ func fun_ENTRY_POINT{
     default_dict_finalize(memory_dict_start, memory_dict, 0)
     return (1, exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
 end
-

--- a/tests/yul/returndatasize.cairo
+++ b/tests/yul/returndatasize.cairo
@@ -39,8 +39,13 @@ func initialize_address{range_check_ptr, syscall_ptr : felt*, pedersen_ptr : Has
     return ()
 end
 
-func __warp_cond_revert(_3_7 : Uint256) -> ():
+func abi_decode{range_check_ptr}(headStart : Uint256, dataEnd : Uint256) -> ():
     alloc_locals
+    local _1_5 : Uint256 = Uint256(low=0, high=0)
+    let (local _2_6 : Uint256) = uint256_sub(dataEnd, headStart)
+    local range_check_ptr = range_check_ptr
+    let (local _3_7 : Uint256) = slt(_2_6, _1_5)
+    local range_check_ptr = range_check_ptr
     if _3_7.low + _3_7.high != 0:
         assert 0 = 1
         jmp rel 0
@@ -49,23 +54,16 @@ func __warp_cond_revert(_3_7 : Uint256) -> ():
     end
 end
 
-func abi_decode{range_check_ptr}(headStart : Uint256, dataEnd : Uint256) -> ():
-    alloc_locals
-    local _1_5 : Uint256 = Uint256(low=0, high=0)
-    let (local _2_6 : Uint256) = uint256_sub(dataEnd, headStart)
-    local range_check_ptr = range_check_ptr
-    let (local _3_7 : Uint256) = slt(_2_6, _1_5)
-    local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_3_7)
-    return ()
-end
-
 func fun_viewReturndatasize{exec_env : ExecutionEnvironment*}() -> (var_res : Uint256):
     alloc_locals
     let (local var_res : Uint256) = returndata_size()
     local exec_env : ExecutionEnvironment* = exec_env
-    __warp_cond_revert(var_res)
-    return (var_res)
+    if var_res.low + var_res.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    else:
+        return (var_res)
+    end
 end
 
 func abi_encode_uint256_to_uint256{memory_dict : DictAccess*, msize, range_check_ptr}(
@@ -96,7 +94,10 @@ func __warp_block_1{
         _1 : Uint256, _3 : Uint256, _4 : Uint256) -> ():
     alloc_locals
     let (local _13 : Uint256) = __warp_constant_0()
-    __warp_cond_revert(_13)
+    if _13.low + _13.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local _14 : Uint256 = _4
     local _15 : Uint256 = _3
     abi_decode(_3, _4)
@@ -216,4 +217,3 @@ func fun_ENTRY_POINT{
     default_dict_finalize(memory_dict_start, memory_dict, 0)
     return (1, exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
 end
-

--- a/tests/yul/short_string.cairo
+++ b/tests/yul/short_string.cairo
@@ -35,16 +35,6 @@ func initialize_address{range_check_ptr, syscall_ptr : felt*, pedersen_ptr : Has
     return ()
 end
 
-func __warp_cond_revert(_3_7 : Uint256) -> ():
-    alloc_locals
-    if _3_7.low + _3_7.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
 func abi_decode{range_check_ptr}(headStart : Uint256, dataEnd : Uint256) -> ():
     alloc_locals
     local _1_5 : Uint256 = Uint256(low=0, high=0)
@@ -52,8 +42,12 @@ func abi_decode{range_check_ptr}(headStart : Uint256, dataEnd : Uint256) -> ():
     local range_check_ptr = range_check_ptr
     let (local _3_7 : Uint256) = slt(_2_6, _1_5)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_3_7)
-    return ()
+    if _3_7.low + _3_7.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    else:
+        return ()
+    end
 end
 
 func array_allocation_size_string{range_check_ptr}(length_49 : Uint256) -> (size_50 : Uint256):
@@ -65,7 +59,10 @@ func array_allocation_size_string{range_check_ptr}(length_49 : Uint256) -> (size
     local range_check_ptr = range_check_ptr
     let (local _2_52 : Uint256) = is_gt(length_49, _1_51)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_2_52)
+    if _2_52.low + _2_52.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local _3_53 : Uint256 = Uint256(low=32, high=0)
     let (local _4_54 : Uint256) = uint256_not(Uint256(low=31, high=0))
     local range_check_ptr = range_check_ptr
@@ -102,7 +99,10 @@ func finalize_allocation{memory_dict : DictAccess*, msize, range_check_ptr}(
     local range_check_ptr = range_check_ptr
     let (local _8_44 : Uint256) = uint256_sub(_7_43, _5_41)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_8_44)
+    if _8_44.low + _8_44.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local _9_45 : Uint256 = Uint256(low=64, high=0)
     uint256_mstore(offset=_9_45, value=newFreePtr)
     local memory_dict : DictAccess* = memory_dict
@@ -369,7 +369,10 @@ func memory_array_index_access_bytes{memory_dict : DictAccess*, msize, range_che
     local range_check_ptr = range_check_ptr
     let (local _3_83 : Uint256) = is_zero(_2_82)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_3_83)
+    if _3_83.low + _3_83.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local _4_84 : Uint256 = Uint256(low=32, high=0)
     let (local _5_85 : Uint256) = u256_add(baseRef, index)
     local range_check_ptr = range_check_ptr
@@ -427,7 +430,10 @@ func __warp_block_4{
         _2 : Uint256, _3 : Uint256, _4 : Uint256) -> ():
     alloc_locals
     let (local _11 : Uint256) = __warp_constant_0()
-    __warp_cond_revert(_11)
+    if _11.low + _11.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local _12 : Uint256 = _4
     local _13 : Uint256 = _3
     abi_decode(_3, _4)
@@ -459,7 +465,10 @@ func __warp_block_6{
         _2 : Uint256, _3 : Uint256, _4 : Uint256) -> ():
     alloc_locals
     let (local _17 : Uint256) = __warp_constant_0()
-    __warp_cond_revert(_17)
+    if _17.low + _17.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local _18 : Uint256 = _4
     local _19 : Uint256 = _3
     abi_decode(_3, _4)
@@ -643,4 +652,3 @@ func fun_ENTRY_POINT{
     default_dict_finalize(memory_dict_start, memory_dict, 0)
     return (1, exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
 end
-

--- a/tests/yul/simple-storage-var.cairo
+++ b/tests/yul/simple-storage-var.cairo
@@ -39,16 +39,6 @@ func initialize_address{range_check_ptr, syscall_ptr : felt*, pedersen_ptr : Has
     return ()
 end
 
-func __warp_cond_revert(_3_7 : Uint256) -> ():
-    alloc_locals
-    if _3_7.low + _3_7.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
 func abi_decode{range_check_ptr}(headStart : Uint256, dataEnd : Uint256) -> ():
     alloc_locals
     local _1_5 : Uint256 = Uint256(low=0, high=0)
@@ -56,8 +46,12 @@ func abi_decode{range_check_ptr}(headStart : Uint256, dataEnd : Uint256) -> ():
     local range_check_ptr = range_check_ptr
     let (local _3_7 : Uint256) = slt(_2_6, _1_5)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_3_7)
-    return ()
+    if _3_7.low + _3_7.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    else:
+        return ()
+    end
 end
 
 func getter_fun_counter{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}() -> (
@@ -96,7 +90,10 @@ func checked_add_uint256{range_check_ptr}(x : Uint256, y : Uint256) -> (sum : Ui
     local range_check_ptr = range_check_ptr
     let (local _2_21 : Uint256) = is_gt(x, _1_20)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_2_21)
+    if _2_21.low + _2_21.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     let (local sum : Uint256) = u256_add(x, y)
     local range_check_ptr = range_check_ptr
     return (sum)
@@ -136,7 +133,10 @@ func __warp_block_3{
         _1 : Uint256, _3 : Uint256, _4 : Uint256) -> ():
     alloc_locals
     let (local _11 : Uint256) = __warp_constant_0()
-    __warp_cond_revert(_11)
+    if _11.low + _11.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local _12 : Uint256 = _4
     local _13 : Uint256 = _3
     abi_decode(_3, _4)
@@ -166,7 +166,10 @@ func __warp_block_5{
         _2 : Uint256, _3 : Uint256, _4 : Uint256) -> ():
     alloc_locals
     let (local _20 : Uint256) = __warp_constant_0()
-    __warp_cond_revert(_20)
+    if _20.low + _20.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local _21 : Uint256 = _4
     local _22 : Uint256 = _3
     abi_decode(_3, _4)
@@ -374,4 +377,3 @@ func fun_ENTRY_POINT{
     default_dict_finalize(memory_dict_start, memory_dict, 0)
     return (1, exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
 end
-

--- a/tests/yul/sstore-sload.cairo
+++ b/tests/yul/sstore-sload.cairo
@@ -51,16 +51,6 @@ func initialize_address{range_check_ptr, syscall_ptr : felt*, pedersen_ptr : Has
     return ()
 end
 
-func __warp_cond_revert(_3_7 : Uint256) -> ():
-    alloc_locals
-    if _3_7.low + _3_7.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
 func abi_decode{range_check_ptr}(headStart : Uint256, dataEnd : Uint256) -> ():
     alloc_locals
     local _1_5 : Uint256 = Uint256(low=0, high=0)
@@ -68,8 +58,12 @@ func abi_decode{range_check_ptr}(headStart : Uint256, dataEnd : Uint256) -> ():
     local range_check_ptr = range_check_ptr
     let (local _3_7 : Uint256) = slt(_2_6, _1_5)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_3_7)
-    return ()
+    if _3_7.low + _3_7.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    else:
+        return ()
+    end
 end
 
 func fun_test{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}() -> (
@@ -118,7 +112,10 @@ func __warp_block_1{
         _1 : Uint256, _3 : Uint256, _4 : Uint256) -> ():
     alloc_locals
     let (local _13 : Uint256) = __warp_constant_0()
-    __warp_cond_revert(_13)
+    if _13.low + _13.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local _14 : Uint256 = _4
     local _15 : Uint256 = _3
     abi_decode(_3, _4)
@@ -251,4 +248,3 @@ func fun_ENTRY_POINT{
     default_dict_finalize(memory_dict_start, memory_dict, 0)
     return (1, exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
 end
-

--- a/tests/yul/view-function.cairo
+++ b/tests/yul/view-function.cairo
@@ -36,16 +36,6 @@ func initialize_address{range_check_ptr, syscall_ptr : felt*, pedersen_ptr : Has
     return ()
 end
 
-func __warp_cond_revert(_3_7 : Uint256) -> ():
-    alloc_locals
-    if _3_7.low + _3_7.high != 0:
-        assert 0 = 1
-        jmp rel 0
-    else:
-        return ()
-    end
-end
-
 func abi_decode_uint256t_uint256t_uint256t_uint256{
         exec_env : ExecutionEnvironment*, range_check_ptr}(
         headStart : Uint256, dataEnd : Uint256) -> (
@@ -56,7 +46,10 @@ func abi_decode_uint256t_uint256t_uint256t_uint256{
     local range_check_ptr = range_check_ptr
     let (local _3_7 : Uint256) = slt(_2_6, _1_5)
     local range_check_ptr = range_check_ptr
-    __warp_cond_revert(_3_7)
+    if _3_7.low + _3_7.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     let (local value0 : Uint256) = calldataload(headStart)
     local range_check_ptr = range_check_ptr
     local exec_env : ExecutionEnvironment* = exec_env
@@ -161,7 +154,10 @@ func __warp_block_3{
         _1 : Uint256, _3 : Uint256, _4 : Uint256) -> ():
     alloc_locals
     let (local _13 : Uint256) = __warp_constant_0()
-    __warp_cond_revert(_13)
+    if _13.low + _13.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
     local _14 : Uint256 = _4
     local _15 : Uint256 = _3
     let (local param : Uint256, local param_1 : Uint256, local param_2 : Uint256,
@@ -283,4 +279,3 @@ func fun_ENTRY_POINT{
     default_dict_finalize(memory_dict_start, memory_dict, 0)
     return (1, exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
 end
-

--- a/warp/yul/NameGenerator.py
+++ b/warp/yul/NameGenerator.py
@@ -35,9 +35,6 @@ class NameGenerator:
         self.n_ifs += 1
         return self._prefixed(f"if_{self.n_ifs}")
 
-    def take_cond_revert_name(self) -> str:
-        return self._prefixed("cond_revert")
-
     @contextmanager
     def new_block(self):
         old_n_subexpressions = self.n_subexpressions


### PR DESCRIPTION
"reverting" ifs are if-expressions where at least one branch results
     in the revert.

Problem: we extract all "reverting" ifs into one function –
     __warp_cond_revert. It's not correct, sometimes reverting ifs
     have different code.

Solution: disable extracting reverting ifs. It's okay to do. Since at
     least one branch is a revert, references are not ambiguous at the
     end of the if-expression.