### PR TITLE
Add benchmarking for tests

### DIFF
--- a/.github/workflows/develop-ci.yml
+++ b/.github/workflows/develop-ci.yml
@@ -2,7 +2,7 @@ name: develop-ci
 
 on:
   push:
-    branches: [ develop ]
+    branches: [develop]
   pull_request:
 
 jobs:
@@ -53,3 +53,19 @@ jobs:
 
       - name: Test yul tests
         run: make test_yul
+
+      - name: Generate benchmarks for tests
+        run: |
+          mkdir -p ./benchmark/stats
+          make test_bench
+
+      - name: Push benchmarks to another repository
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+        with:
+          source-directory: "benchmark/stats"
+          destination-github-username: "NethermindEth"
+          destination-repository-name: ${{ secrets.BENCHMARK_REPO }}
+          user-email: atharvakn@gmail.com
+          target-branch: main

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+
+# Benchmarking
+benchmark/*

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ warp: .warp-activation-token
 	python setup.py install
 	touch .warp-activation-token
 
-test: test_bats test_yul
+test: test_bats test_yul test_bench
 .PHONY: test
 
 test_bats: warp $(BATS_FILES) tests/cli/*.bats
@@ -28,6 +28,12 @@ test_yul: warp
 	python -m pytest tests/yul/ -v --tb=short --workers=auto $(ARGS)
 	python -m pytest tests/ast/ -v --tb=short --workers=auto $(ARGS)
 .PHONY: test_yul
+
+test_bench: warp
+	mkdir -p benchmark/stats
+	python -m pytest tests/benchmark -v --tb=short --workers=auto $(ARGS)
+	python ./warp/logging/generateMarkdown.py
+.PHONY: test_bench
 
 $(BATS_DIR)/test-%.bats: \
 		$(GOLDEN_DIR)/%.template \

--- a/tests/benchmark/BaseJumpRateModelV2.cairo
+++ b/tests/benchmark/BaseJumpRateModelV2.cairo
@@ -1,0 +1,183 @@
+# @title Logic for Compound's JumpRateModel Contract V2.
+# @author Compound (modified by Dharma Labs, refactored by Arr00); StarkWare(Cairo rewrite by Artem)
+# @notice Version 2 modifies Version 1 by enabling updateable parameters.
+
+%lang starknet
+%builtins pedersen range_check
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.math import assert_nn, assert_not_zero, unsigned_div_rem
+from starkware.cairo.common.math_cmp import is_le
+from starkware.starknet.common.syscalls import get_caller_address
+
+# @notice The address of the owner, i.e. the Timelock contract, which can update parameters directly
+@storage_var
+func owner() -> (address):
+end
+
+@view
+func getOwner{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (address):
+    return owner.read()
+end
+
+# @notice The approximate number of blocks per year that is assumed by the interest rate model
+const blocksPerYear = 2102400
+
+@view
+func getBlocksPerYear() -> (res):
+    return (blocksPerYear)
+end
+
+# @notice The multiplier of utilization rate that gives the slope of the interest rate
+@storage_var
+func multiplierPerBlock() -> (res):
+end
+
+@view
+func getMultiplierPerBlock{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (res):
+    return multiplierPerBlock.read()
+end
+
+# @notice The base interest rate which is the y-intercept when utilization rate is 0
+@storage_var
+func baseRatePerBlock() -> (res):
+end
+
+@view
+func getBaseRatePerBlock{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (res):
+    return baseRatePerBlock.read()
+end
+
+# @notice The multiplierPerBlock after hitting a specified utilization point
+@storage_var
+func jumpMultiplierPerBlock() -> (res):
+end
+
+@view
+func getJumpMultiplierPerBlock{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (res):
+    return jumpMultiplierPerBlock.read()
+end
+
+# @notice The utilization point at which the jump multiplier is applied
+@storage_var
+func kink() -> (res):
+end
+
+@view
+func getKink{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (res):
+    return kink.read()
+end
+
+# @notice Construct an interest rate model
+# @param baseRatePerYear The approximate target base APR, as a mantissa (scaled by 1e18)
+# @param multiplierPerYear The rate of increase in interest rate wrt utilization (scaled by 1e18)
+# @param jumpMultiplierPerYear The multiplierPerBlock after hitting a specified utilization point
+# @param kink_ The utilization point at which the jump multiplier is applied
+# @param owner_ The address of the owner, i.e. the Timelock contract (which has the ability to update parameters directly)
+@constructor
+func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        baseRatePerYear, multiplierPerYear, jumpMultiplierPerYear, kink_, owner_):
+    owner.write(owner_)
+    updateJumpRateModelInternal(baseRatePerYear, multiplierPerYear, jumpMultiplierPerYear, kink_)
+    return ()
+end
+
+# @notice Update the parameters of the interest rate model (only callable by owner, i.e. Timelock)
+# @param baseRatePerYear The approximate target base APR, as a mantissa (scaled by 1e18)
+# @param multiplierPerYear The rate of increase in interest rate wrt utilization (scaled by 1e18)
+# @param jumpMultiplierPerYear The multiplierPerBlock after hitting a specified utilization point
+# @param kink_ The utilization point at which the jump multiplier is applied
+@external
+func updateJumpRateModel{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        baseRatePerYear, multiplierPerYear, jumpMultiplierPerYear, kink_):
+    let (owner_) = owner.read()
+    let (sender) = get_caller_address()
+    assert owner_ = sender  # only the owner may call this function
+    return updateJumpRateModelInternal(
+        baseRatePerYear, multiplierPerYear, jumpMultiplierPerYear, kink_)
+end
+
+# @notice Calculates the utilization rate of the market: `borrows / (cash + borrows - reserves)`
+# @param cash The amount of cash in the market
+# @param borrows The amount of borrows in the market
+# @param reserves The amount of reserves in the market (currently unused)
+# @return The utilization rate as a mantissa between [0, 1e18]
+@view
+func utilizationRate{range_check_ptr}(cash, borrows, reserves) -> (res):
+    # Utilization rate is 0 when there are no borrows
+    if borrows == 0:
+        return (0)
+    end
+
+    let divisor = cash + borrows - reserves
+    assert_nn(divisor)
+    return checked_div(borrows * 10 ** 18, divisor)
+end
+
+# @notice Calculates the current borrow rate per block, with the error code expected by the market
+# @param cash The amount of cash in the market
+# @param borrows The amount of borrows in the market
+# @param reserves The amount of reserves in the market
+# @return The borrow rate percentage per block as a mantissa (scaled by 1e18)
+func getBorrowRateInternal{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        cash, borrows, reserves) -> (res):
+    alloc_locals
+    let (util) = utilizationRate(cash, borrows, reserves)
+    let (kink_) = kink.read()
+    let (multiplierPerBlock_) = multiplierPerBlock.read()
+    let (baseRatePerBlock_) = baseRatePerBlock.read()
+    let (le) = is_le(util, kink_)
+    if le != 0:
+        let (res) = checked_div(util * multiplierPerBlock_, 10 ** 18 + baseRatePerBlock_)
+        return (res)
+    else:
+        let (normalRate) = checked_div(kink_ * multiplierPerBlock_, 10 ** 18 + baseRatePerBlock_)
+        let excessUtil = util - kink_
+        let (jumpMultiplierPerBlock_) = jumpMultiplierPerBlock.read()
+        let (res) = checked_div(excessUtil * jumpMultiplierPerBlock_, 10 ** 18 + normalRate)
+        return (res)
+    end
+end
+
+# @notice Calculates the current supply rate per block
+# @param cash The amount of cash in the market
+# @param borrows The amount of borrows in the market
+# @param reserves The amount of reserves in the market
+# @param reserveFactorMantissa The current reserve factor for the market
+# @return The supply rate percentage per block as a mantissa (scaled by 1e18)
+@view
+func getSupplyRate{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        cash, borrows, reserves, reserveFactorMantissa) -> (res):
+    alloc_locals
+    let oneMinusReserveFactor = 10 ** 18 - reserveFactorMantissa
+    let (borrowRate) = getBorrowRateInternal(cash, borrows, reserves)
+    let (rateToPool) = checked_div(borrowRate * oneMinusReserveFactor, 10 ** 18)
+    let (utilizationRate_) = utilizationRate(cash, borrows, reserves)
+    let (res) = checked_div(utilizationRate_ * rateToPool, 10 ** 18)
+    return (res)
+end
+
+# @notice Internal function to update the parameters of the interest rate model
+# @param baseRatePerYear The approximate target base APR, as a mantissa (scaled by 1e18)
+# @param multiplierPerYear The rate of increase in interest rate wrt utilization (scaled by 1e18)
+# @param jumpMultiplierPerYear The multiplierPerBlock after hitting a specified utilization point
+# @param kink_ The utilization point at which the jump multiplier is applied
+func updateJumpRateModelInternal{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        baseRatePerYear, multiplierPerYear, jumpMultiplierPerYear, kink_):
+    alloc_locals
+    let (baseRatePerBlock_) = checked_div(baseRatePerYear, blocksPerYear)
+    let (multiplierPerBlock_) = checked_div(multiplierPerYear * 10 ** 18, blocksPerYear * kink_)
+    let (jumpMultiplierPerBlock_) = checked_div(jumpMultiplierPerYear, blocksPerYear)
+
+    baseRatePerBlock.write(baseRatePerBlock_)
+    multiplierPerBlock.write(multiplierPerBlock_)
+    jumpMultiplierPerBlock.write(jumpMultiplierPerBlock_)
+    kink.write(kink_)
+    return ()
+end
+
+func checked_div{range_check_ptr}(value, div) -> (q):
+    assert_not_zero(div)
+    let (q, _) = unsigned_div_rem(value, div)
+    return (q)
+end

--- a/tests/benchmark/BaseJumpRateModelV2.sol
+++ b/tests/benchmark/BaseJumpRateModelV2.sol
@@ -1,0 +1,171 @@
+pragma solidity ^0.8.6;
+
+/**
+ * @title Logic for Compound's JumpRateModel Contract V2.
+ * @author Compound (modified by Dharma Labs, refactored by Arr00)
+ * @notice Version 2 modifies Version 1 by enabling updateable parameters.
+ */
+contract BaseJumpRateModelV2 {
+    /**
+     * @notice The address of the owner, i.e. the Timelock contract, which can update parameters directly
+     */
+    address public owner;
+
+    /**
+     * @notice The approximate number of blocks per year that is assumed by the interest rate model
+     */
+    uint256 public constant blocksPerYear = 2102400;
+
+    /**
+     * @notice The multiplier of utilization rate that gives the slope of the interest rate
+     */
+    uint256 public multiplierPerBlock;
+
+    /**
+     * @notice The base interest rate which is the y-intercept when utilization rate is 0
+     */
+    uint256 public baseRatePerBlock;
+
+    /**
+     * @notice The multiplierPerBlock after hitting a specified utilization point
+     */
+    uint256 public jumpMultiplierPerBlock;
+
+    /**
+     * @notice The utilization point at which the jump multiplier is applied
+     */
+    uint256 public kink;
+
+    /**
+     * @notice Construct an interest rate model
+     * @param baseRatePerYear The approximate target base APR, as a mantissa (scaled by 1e18)
+     * @param multiplierPerYear The rate of increase in interest rate wrt utilization (scaled by 1e18)
+     * @param jumpMultiplierPerYear The multiplierPerBlock after hitting a specified utilization point
+     * @param kink_ The utilization point at which the jump multiplier is applied
+     * @param owner_ The address of the owner, i.e. the Timelock contract (which has the ability to update parameters directly)
+     */
+    constructor(
+        uint256 baseRatePerYear,
+        uint256 multiplierPerYear,
+        uint256 jumpMultiplierPerYear,
+        uint256 kink_,
+        address owner_
+    ) {
+        owner = owner_;
+
+        updateJumpRateModelInternal(
+            baseRatePerYear,
+            multiplierPerYear,
+            jumpMultiplierPerYear,
+            kink_
+        );
+    }
+
+    /**
+     * @notice Update the parameters of the interest rate model (only callable by owner, i.e. Timelock)
+     * @param baseRatePerYear The approximate target base APR, as a mantissa (scaled by 1e18)
+     * @param multiplierPerYear The rate of increase in interest rate wrt utilization (scaled by 1e18)
+     * @param jumpMultiplierPerYear The multiplierPerBlock after hitting a specified utilization point
+     * @param kink_ The utilization point at which the jump multiplier is applied
+     */
+    function updateJumpRateModel(
+        uint256 baseRatePerYear,
+        uint256 multiplierPerYear,
+        uint256 jumpMultiplierPerYear,
+        uint256 kink_
+    ) external {
+        require(msg.sender == owner, "only the owner may call this function.");
+
+        updateJumpRateModelInternal(
+            baseRatePerYear,
+            multiplierPerYear,
+            jumpMultiplierPerYear,
+            kink_
+        );
+    }
+
+    /**
+     * @notice Calculates the utilization rate of the market: `borrows / (cash + borrows - reserves)`
+     * @param cash The amount of cash in the market
+     * @param borrows The amount of borrows in the market
+     * @param reserves The amount of reserves in the market (currently unused)
+     * @return The utilization rate as a mantissa between [0, 1e18]
+     */
+    function utilizationRate(
+        uint256 cash,
+        uint256 borrows,
+        uint256 reserves
+    ) public pure returns (uint256) {
+        // Utilization rate is 0 when there are no borrows
+        if (borrows == 0) {
+            return 0;
+        }
+
+        return (borrows * 1e18) / ((cash + borrows) - reserves);
+    }
+
+    /**
+     * @notice Calculates the current borrow rate per block, with the error code expected by the market
+     * @param cash The amount of cash in the market
+     * @param borrows The amount of borrows in the market
+     * @param reserves The amount of reserves in the market
+     * @return The borrow rate percentage per block as a mantissa (scaled by 1e18)
+     */
+    function getBorrowRateInternal(
+        uint256 cash,
+        uint256 borrows,
+        uint256 reserves
+    ) internal view returns (uint256) {
+        uint256 util = utilizationRate(cash, borrows, reserves);
+
+        if (util <= kink) {
+            return (util * multiplierPerBlock) / (1e18 + baseRatePerBlock);
+        } else {
+            uint256 normalRate = (kink * multiplierPerBlock) /
+                (1e18 + baseRatePerBlock);
+            uint256 excessUtil = util - kink;
+            return (excessUtil * jumpMultiplierPerBlock) / (1e18 + normalRate);
+        }
+    }
+
+    /**
+     * @notice Calculates the current supply rate per block
+     * @param cash The amount of cash in the market
+     * @param borrows The amount of borrows in the market
+     * @param reserves The amount of reserves in the market
+     * @param reserveFactorMantissa The current reserve factor for the market
+     * @return The supply rate percentage per block as a mantissa (scaled by 1e18)
+     */
+    function getSupplyRate(
+        uint256 cash,
+        uint256 borrows,
+        uint256 reserves,
+        uint256 reserveFactorMantissa
+    ) public view returns (uint256) {
+        uint256 oneMinusReserveFactor = uint256(1e18) - (reserveFactorMantissa);
+        uint256 borrowRate = getBorrowRateInternal(cash, borrows, reserves);
+        uint256 rateToPool = (borrowRate * oneMinusReserveFactor) / 1e18;
+        return (utilizationRate(cash, borrows, reserves) * rateToPool) / 1e18;
+    }
+
+    /**
+     * @notice Internal function to update the parameters of the interest rate model
+     * @param baseRatePerYear The approximate target base APR, as a mantissa (scaled by 1e18)
+     * @param multiplierPerYear The rate of increase in interest rate wrt utilization (scaled by 1e18)
+     * @param jumpMultiplierPerYear The multiplierPerBlock after hitting a specified utilization point
+     * @param kink_ The utilization point at which the jump multiplier is applied
+     */
+    function updateJumpRateModelInternal(
+        uint256 baseRatePerYear,
+        uint256 multiplierPerYear,
+        uint256 jumpMultiplierPerYear,
+        uint256 kink_
+    ) internal {
+        baseRatePerBlock = baseRatePerYear / blocksPerYear;
+        multiplierPerBlock =
+            (multiplierPerYear * 1e18) /
+            (blocksPerYear * kink_);
+        jumpMultiplierPerBlock = jumpMultiplierPerYear / blocksPerYear;
+        kink = kink_;
+    }
+}

--- a/tests/benchmark/BaseJumpRateModelV2_test.py
+++ b/tests/benchmark/BaseJumpRateModelV2_test.py
@@ -1,0 +1,111 @@
+import os
+
+import pytest
+from starkware.starknet.compiler.compile import compile_starknet_files
+from starkware.starknet.testing.starknet import Starknet
+from starkware.starknet.testing.state import StarknetState
+from yul.main import transpile_from_solidity
+from yul.starknet_utils import invoke_method
+
+from warp.logging.generateMarkdown import bytecodeDetails, sizeOfFile, stepsInFunction
+
+warp_root = os.path.abspath(os.path.join(__file__, "../../.."))
+test_dir = __file__
+
+
+@pytest.mark.asyncio
+async def test_starknet():
+    contract_file = test_dir[:-8] + ".cairo"
+    sol_file = test_dir[:-8] + ".sol"
+    cairo_path = f"{warp_root}/warp/cairo-src"
+
+    # ======= Handwritten Cairo =======
+    constructor_inputs = [10000000, 11000000, 10000000, 10, 0x0]
+
+    contractDef = compile_starknet_files(
+        [contract_file], debug_info=True, cairo_path=[cairo_path]
+    )
+    bytecodeDetails(
+        "BaseJumpRateModelV2", contractDef.program.data, "BaseJumpRateModelV2"
+    )
+
+    starknet = await Starknet.empty()
+    contract = await starknet.deploy(
+        contract_def=contractDef, constructor_calldata=constructor_inputs
+    )
+
+    exec_info = await contract.getSupplyRate(500, 100, 200, 2).invoke()
+    stepsInFunction(
+        "BaseJumpRateModelV2", "getSupplyRate", exec_info, "BaseJumpRateModelV2"
+    )
+    assert exec_info.result._asdict()["res"] == 0
+
+    exec_info = await contract.utilizationRate(500, 100, 200).invoke()
+    stepsInFunction(
+        "BaseJumpRateModelV2", "utilizationRate", exec_info, "BaseJumpRateModelV2"
+    )
+    assert exec_info.result._asdict()["res"] == 250000000000000000
+
+    exec_info = await contract.updateJumpRateModel(
+        10000000, 11000000, 10000000, 7
+    ).invoke()
+    stepsInFunction(
+        "BaseJumpRateModelV2", "updateJumpRateModel", exec_info, "BaseJumpRateModelV2"
+    )
+
+    sizeOfFile("BaseJumpRateModelV2", contract_file, "BaseJumpRateModelV2")
+
+    # ======= Compiled Cairo =======
+
+    program_info = transpile_from_solidity(sol_file, "BaseJumpRateModelV2")
+    program_cairo = os.path.join(
+        warp_root, "benchmark", "BaseJumpRateModelV2_compiled.cairo"
+    )
+
+    with open(program_cairo, "w") as f:
+        f.write(program_info["cairo_code"])
+
+    contractDef = compile_starknet_files(
+        [program_cairo], debug_info=True, cairo_path=[cairo_path]
+    )
+
+    starknet = await StarknetState.empty()
+    contract_address = await starknet.deploy(
+        contract_definition=contractDef,
+        constructor_calldata=[10000000, 0, 11000000, 0, 10000000, 0, 10, 0, 0x0, 0],
+    )
+
+    res = await invoke_method(
+        starknet, program_info, contract_address, "getSupplyRate", 500, 100, 200, 2
+    )
+    stepsInFunction(
+        "BaseJumpRateModelV2_warp", "getSupplyRate", res, "BaseJumpRateModelV2"
+    )
+    assert res.retdata == [1, 32, 2, 0, 0]
+
+    res = await invoke_method(
+        starknet, program_info, contract_address, "utilizationRate", 500, 100, 200
+    )
+    stepsInFunction(
+        "BaseJumpRateModelV2_warp", "utilizationRate", res, "BaseJumpRateModelV2"
+    )
+    assert res.retdata == [1, 32, 2, 0, 250000000000000000]
+
+    res = await invoke_method(
+        starknet,
+        program_info,
+        contract_address,
+        "updateJumpRateModel",
+        10000000,
+        11000000,
+        10000000,
+        7,
+    )
+    stepsInFunction(
+        "BaseJumpRateModelV2_warp", "updateJumpRateModel", res, "BaseJumpRateModelV2"
+    )
+
+    sizeOfFile("BaseJumpRateModelV2_warp", program_cairo, "BaseJumpRateModelV2")
+    bytecodeDetails(
+        "BaseJumpRateModelV2_warp", contractDef.program.data, "BaseJumpRateModelV2"
+    )

--- a/tests/benchmark/IntegralMath.cairo
+++ b/tests/benchmark/IntegralMath.cairo
@@ -1,0 +1,330 @@
+%lang starknet
+%builtins pedersen range_check
+
+from evm.uint256 import (
+    is_eq, is_gt, is_lt, u256_add, u256_div, u256_mul, u256_shl, u256_shr, uint256_exp,
+    uint256_mod, uint256_mulmod)
+from starkware.cairo.common.uint256 import (
+    Uint256, uint256_and, uint256_or, uint256_not, uint256_sub)
+
+const MAX_VAL = 2 ** 128 - 1
+
+@view
+func safeAdd{range_check_ptr}(x : Uint256, y : Uint256) -> (sum : Uint256):
+    alloc_locals
+    let (_not_y : Uint256) = uint256_not(y)
+    let (_cond : Uint256) = is_gt(x, _not_y)
+    if _cond.low + _cond.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
+    return u256_add(x, y)
+end
+
+@view
+func unsafeAdd{range_check_ptr}(x : Uint256, y : Uint256) -> (sum : Uint256):
+    return u256_add(x, y)
+end
+
+@view
+func unsafeSub{range_check_ptr}(x : Uint256, y : Uint256) -> (diff : Uint256):
+    return uint256_sub(x, y)
+end
+
+@view
+func unsafeMul{range_check_ptr}(x : Uint256, y : Uint256) -> (prod : Uint256):
+    return u256_mul(x, y)
+end
+
+@view
+func mulMod{range_check_ptr}(x : Uint256, y : Uint256, z : Uint256) -> (res : Uint256):
+    return uint256_mulmod(x, y, z)
+end
+
+@view
+func mulModMax{range_check_ptr}(x : Uint256, y : Uint256) -> (res : Uint256):
+    return uint256_mulmod(x, y, Uint256(MAX_VAL, MAX_VAL))
+end
+
+func block_0{range_check_ptr}(n : Uint256, r : felt) -> (n : Uint256, r : felt):
+    alloc_locals
+    let (_cond : Uint256) = is_gt(n, Uint256(1, 0))
+    if _cond.low + _cond.low == 0:
+        return (n, r)
+    end
+
+    let (_val_0 : Uint256) = u256_shr(Uint256(1, 0), n)
+    return block_0(_val_0, r + 1)
+end
+
+func block_5{range_check_ptr}(_cond : Uint256, n : Uint256, s : Uint256, r : felt) -> (
+        a : Uint256, b : felt):
+    alloc_locals
+    if _cond.low + _cond.low == 0:
+        let (_val_0 : Uint256) = u256_shr(s, n)
+        let (_val_1 : Uint256) = uint256_or(Uint256(r, 0), s)
+        return (_val_0, _val_1.low)
+    end
+    return (n, r)
+end
+
+func block_1{range_check_ptr}(n : Uint256, r : felt, s : Uint256) -> (n : Uint256, r : felt):
+    alloc_locals
+    let (_cond_0 : Uint256) = is_gt(s, Uint256(0, 0))
+    if _cond_0.low + _cond_0.low == 0:
+        return (n, r)
+    end
+
+    let (_val_0 : Uint256) = u256_shl(Uint256(1, 0), s)
+    let (_cond_1 : Uint256) = is_lt(n, _val_0)
+    let (n, r) = block_5(_cond_1, n, s, r)
+
+    let (_val_1 : Uint256) = u256_shr(Uint256(1, 0), s)
+    let s = _val_1
+    return block_1(n, r, s)
+end
+
+# @dev Compute the largest integer smaller than or equal to the binary logarithm of `n`
+@external
+func floorLog2{range_check_ptr}(n : Uint256) -> (res):
+    alloc_locals
+
+    let (_cond : Uint256) = is_lt(n, Uint256(256, 0))
+    if _cond.low + _cond.high != 0:
+        let (_, res : felt) = block_0(n, 0)
+        return (res)
+    else:
+        let (_, res : felt) = block_1(n, 0, Uint256(128, 0))
+        return (res)
+    end
+end
+
+func block_2{range_check_ptr}(n : Uint256, x : Uint256, y : Uint256) -> (x : Uint256, y : Uint256):
+    alloc_locals
+    let (_cond : Uint256) = is_gt(x, y)
+    if _cond.low + _cond.low == 0:
+        return (x, y)
+    end
+
+    let (_val_0 : Uint256) = u256_div(n, y)
+    let (_val_1 : Uint256) = u256_add(y, _val_0)
+    let (y_val : Uint256) = u256_div(_val_1, Uint256(2, 0))
+
+    return block_2(n, y, y_val)
+end
+
+# @dev Compute the largest integer smaller than or equal to the square root of `n`
+@external
+func floorSqrt{range_check_ptr}(n : Uint256) -> (res : Uint256):
+    alloc_locals
+    let (_cond : Uint256) = is_gt(n, Uint256(0, 0))
+    if _cond.low + _cond.high != 0:
+        let (_val_0 : Uint256) = u256_div(n, Uint256(2, 0))
+        let (x : Uint256) = u256_add(_val_0, Uint256(1, 0))
+        let (_val_1 : Uint256) = u256_div(n, x)
+        let (_val_2 : Uint256) = u256_add(x, _val_1)
+        let (y : Uint256) = u256_div(_val_2, Uint256(2, 0))
+        let (x, _) = block_2(n, x, y)
+        return (res=x)
+    end
+    let res : Uint256 = Uint256(low=0, high=0)
+    return (res)
+end
+
+# @dev Compute the smallest integer larger than or equal to the square root of `n`
+@external
+func ceilSqrt{range_check_ptr}(n : Uint256) -> (res : Uint256):
+    alloc_locals
+    let (x : Uint256) = floorSqrt(n)
+    let (_val_0 : Uint256) = uint256_exp(x, Uint256(2, 0))
+    let (_cond : Uint256) = is_eq(_val_0, n)
+    if _cond.low + _cond.high != 0:
+        return (res=x)
+    end
+    return u256_add(x, Uint256(1, 0))
+end
+
+func block_6{range_check_ptr}(
+        _cond : Uint256, x : Uint256, y : Uint256, z : Uint256, n : Uint256) -> (
+        a : Uint256, b : Uint256):
+    if _cond.low + _cond.high == 0:
+        let (_val : Uint256) = u256_mul(y, z)
+        let (n_val : Uint256) = uint256_sub(n, _val)
+        let (x_val : Uint256) = u256_add(x, Uint256(1, 0))
+        return (x_val, n_val)
+    end
+    return (x, n)
+end
+
+func block_3{range_check_ptr}(n : Uint256, x : Uint256, y : Uint256) -> (n : Uint256, x : Uint256):
+    alloc_locals
+    let (_cond_0 : Uint256) = is_gt(y, Uint256(0, 0))
+    if _cond_0.low + _cond_0.high == 0:
+        return (n, x)
+    end
+    let (x_val : Uint256) = u256_shl(Uint256(1, 0), x)
+    let (_val_0 : Uint256) = u256_mul(Uint256(3, 0), x_val)
+    let (_val_1 : Uint256) = u256_add(x_val, Uint256(1, 0))
+    let (_val_2 : Uint256) = u256_mul(_val_0, _val_1)
+    let (z : Uint256) = u256_add(_val_2, Uint256(1, 0))
+    let (_val_3 : Uint256) = u256_div(n, y)
+    let (_cond_1 : Uint256) = is_lt(_val_3, z)
+    let (x_val, n_val : Uint256) = block_6(_cond_1, x_val, y, z, n)
+    let (y_val : Uint256) = u256_shr(Uint256(3, 0), y)
+    return block_3(n_val, x_val, y_val)
+end
+
+# @dev Compute the largest integer smaller than or equal to the cubic root of `n`
+@external
+func floorCbrt{range_check_ptr}(n : Uint256) -> (res : Uint256):
+    alloc_locals
+    let x : Uint256 = Uint256(0, 0)
+    let (y : Uint256) = u256_shl(Uint256(255, 0), Uint256(1, 0))
+    let (_, x) = block_3(n, x, y)
+    return (res=x)
+end
+
+# @dev Compute the smallest integer larger than or equal to the cubic root of `n`
+@external
+func ceilCbrt{range_check_ptr}(n : Uint256) -> (res : Uint256):
+    alloc_locals
+    let (x : Uint256) = floorCbrt(n)
+    let (_sq : Uint256) = u256_mul(x, x)
+    let (_val : Uint256) = u256_mul(x, _sq)
+    let (_cond : Uint256) = is_eq(_val, n)
+    if _cond.low + _cond.high != 0:
+        return (res=x)
+    end
+    return u256_add(x, Uint256(1, 0))
+end
+
+# @dev Compute the nearest integer to the quotient of `n` and `d` (or `n / d`)
+@external
+func roundDiv{range_check_ptr}(n : Uint256, d : Uint256) -> (res : Uint256):
+    alloc_locals
+    let (_val_0 : Uint256) = u256_div(n, d)
+    let (_val_1 : Uint256) = uint256_mod(n, d)
+    let (_val_2 : Uint256) = u256_div(d, Uint256(2, 0))
+    let (_val_3 : Uint256) = uint256_sub(d, _val_2)
+    let (_val_4 : Uint256) = u256_div(_val_1, _val_3)
+    return u256_add(_val_0, _val_4)
+end
+
+# @dev Compute the value of `x * y`
+@external
+func mul512{range_check_ptr}(x : Uint256, y : Uint256) -> (a : Uint256, b : Uint256):
+    alloc_locals
+    let (p : Uint256) = mulModMax(x, y)
+    let (q : Uint256) = unsafeMul(x, y)
+    let (_cond : Uint256) = is_lt(p, q)
+    if _cond.low + _cond.high == 0:
+        let (_val : Uint256) = uint256_sub(p, q)
+        return (_val, q)
+    end
+    let (_val_0 : Uint256) = unsafeSub(p, q)
+    let (_val_1 : Uint256) = uint256_sub(_val_0, Uint256(1, 0))
+    return (_val_1, q)
+end
+
+# @dev Compute the value of `2 ^ 256 * xh + xl - y`, where `2 ^ 256 * xh + xl >= y`
+@external
+func sub512{range_check_ptr}(xh : Uint256, xl : Uint256, y : Uint256) -> (a : Uint256, b : Uint256):
+    alloc_locals
+    let (_cond : Uint256) = is_lt(xl, y)
+    if _cond.low + _cond.high == 0:
+        let (_val_0 : Uint256) = uint256_sub(xl, y)
+        return (xh, _val_0)
+    end
+    let (_val_1 : Uint256) = uint256_sub(xh, Uint256(1, 0))
+    let (_val_2 : Uint256) = unsafeSub(xl, y)
+    return (_val_1, _val_2)
+end
+
+# @dev Compute the value of `(2 ^ 256 * xh + xl) / pow2n`, where `xl` is divisible by `pow2n`
+@external
+func div512{range_check_ptr}(xh : Uint256, xl : Uint256, pow2n : Uint256) -> (res : Uint256):
+    alloc_locals
+    let (_val_0 : Uint256) = unsafeSub(Uint256(0, 0), pow2n)
+    let (_val_1 : Uint256) = u256_div(_val_0, pow2n)
+    # `1 << (256 - n)`
+    let (pow2nInv : Uint256) = unsafeAdd(_val_1, Uint256(1, 0))
+    let (_val_2 : Uint256) = unsafeMul(xh, pow2nInv)
+    let (_val_3 : Uint256) = u256_div(xl, pow2n)
+    let (_val_4 : Uint256) = uint256_or(_val_2, _val_3)
+    # `(xh << (256 - n)) | (xl >> n)`
+    return (res=_val_4)
+end
+
+func block_4{range_check_ptr}(x : Uint256, d : Uint256, i : Uint256) -> (res : Uint256):
+    alloc_locals
+    let (_cond : Uint256) = is_lt(i, Uint256(8, 0))
+    if _cond.low + _cond.high == 0:
+        return (res=x)
+    end
+    # `x = x * (2 - x * d) mod 2 ^ 256`
+    let (_val_0 : Uint256) = unsafeMul(x, d)
+    let (_val_1 : Uint256) = unsafeSub(Uint256(2, 0), _val_0)
+    let (x_val : Uint256) = unsafeMul(x, _val_1)
+    let (i_val : Uint256) = u256_add(i, Uint256(1, 0))
+    return block_4(x_val, d, i_val)
+end
+
+# @dev Compute the inverse of `d` modulo `2 ^ 256`, where `d` is congruent to `1` modulo `2`
+@external
+func inv256{range_check_ptr}(d : Uint256) -> (res : Uint256):
+    alloc_locals
+    # approximate the root of `f(x) = 1 / x - d` using the newton–raphson convergence method
+    let x : Uint256 = Uint256(1, 0)
+    return block_4(x, d, Uint256(0, 0))
+end
+
+# @dev Compute the largest integer smaller than or equal to `x * y / z`
+@external
+func mulDivF{range_check_ptr}(x : Uint256, y : Uint256, z : Uint256) -> (res : Uint256):
+    alloc_locals
+    let (xyh : Uint256, xyl : Uint256) = mul512(x, y)
+    let (_cond_0 : Uint256) = is_eq(xyh, Uint256(0, 0))
+    # `x * y < 2 ^ 256`
+    if _cond_0.low + _cond_0.high != 0:
+        return u256_div(xyl, z)
+    end
+    # `x * y / z < 2 ^ 256`
+    let (_cond_1 : Uint256) = is_lt(xyh, z)
+    if _cond_1.low + _cond_1.high != 0:
+        # `m = x * y % z`
+        let (m : Uint256) = mulMod(x, y, z)
+        # `n = x * y - m` hence `n / z = floor(x * y / z)`
+        let (nh : Uint256, nl : Uint256) = sub512(xyh, xyl, m)
+        # `n < 2 ^ 256`
+        let (_cond_2 : Uint256) = is_eq(nh, Uint256(0, 0))
+        if _cond_2.low + _cond_2.high != 0:
+            return u256_div(nl, z)
+        end
+        let (_val_0 : Uint256) = unsafeSub(Uint256(0, 0), z)
+        # `p` is the largest power of 2 which `z` is divisible by
+        let (p : Uint256) = uint256_and(_val_0, z)
+        # `n` is divisible by `p` because `n` is divisible by `z` and `z` is divisible by `p`
+        let (q : Uint256) = div512(nh, nl, p)
+        let (_val_1 : Uint256) = u256_div(z, p)
+        # `z / p = 1 mod 2` hence `inverse(z / p) = 1 mod 2 ^ 256`
+        let (r : Uint256) = inv256(_val_1)
+        # `q * r = (n / p) * inverse(z / p) = n / z`
+        return unsafeMul(q, r)
+    end
+    # `x * y / z >= 2 ^ 256`
+    assert 0 = 1
+    jmp rel 0
+end
+
+# @dev Compute the smallest integer larger than or equal to `x * y / z`
+@external
+func mulDivC{range_check_ptr}(x : Uint256, y : Uint256, z : Uint256) -> (res : Uint256):
+    alloc_locals
+    let (w : Uint256) = mulDivF(x, y, z)
+    let (_val_0 : Uint256) = mulMod(x, y, z)
+    let (_cond_0 : Uint256) = is_gt(_val_0, Uint256(0, 0))
+    if _cond_0.low + _cond_0.high != 0:
+        return safeAdd(w, Uint256(1, 0))
+    end
+    return (res=w)
+end

--- a/tests/benchmark/IntegralMath.sol
+++ b/tests/benchmark/IntegralMath.sol
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: SEE LICENSE IN LICENSE
+pragma solidity ^0.8.6;
+
+uint256 constant MAX_VAL = type(uint256).max;
+
+// reverts on overflow
+function safeAdd(uint256 x, uint256 y) pure returns (uint256) {
+    return x + y;
+}
+
+// does not revert on overflow
+function unsafeAdd(uint256 x, uint256 y) pure returns (uint256) {
+    unchecked {
+        return x + y;
+    }
+}
+
+// does not revert on overflow
+function unsafeSub(uint256 x, uint256 y) pure returns (uint256) {
+    unchecked {
+        return x - y;
+    }
+}
+
+// does not revert on overflow
+function unsafeMul(uint256 x, uint256 y) pure returns (uint256) {
+    unchecked {
+        return x * y;
+    }
+}
+
+// does not overflow
+function mulModMax(uint256 x, uint256 y) pure returns (uint256) {
+    unchecked {
+        return mulmod(x, y, MAX_VAL);
+    }
+}
+
+// does not overflow
+function mulMod(
+    uint256 x,
+    uint256 y,
+    uint256 z
+) pure returns (uint256) {
+    unchecked {
+        return mulmod(x, y, z);
+    }
+}
+
+contract IntegralMath {
+    /**
+     * @dev Compute the largest integer smaller than or equal to the binary logarithm of `n`
+     */
+    function floorLog2(uint256 n) public pure returns (uint8) {
+        unchecked {
+            uint8 res = 0;
+
+            if (n < 256) {
+                // at most 8 iterations
+                while (n > 1) {
+                    n >>= 1;
+                    res += 1;
+                }
+            } else {
+                // exactly 8 iterations
+                for (uint8 s = 128; s > 0; s >>= 1) {
+                    if (n >= 1 << s) {
+                        n >>= s;
+                        res |= s;
+                    }
+                }
+            }
+
+            return res;
+        }
+    }
+
+    /**
+     * @dev Compute the largest integer smaller than or equal to the square root of `n`
+     */
+    function floorSqrt(uint256 n) public pure returns (uint256) {
+        unchecked {
+            if (n > 0) {
+                uint256 x = n / 2 + 1;
+                uint256 y = (x + n / x) / 2;
+                while (x > y) {
+                    x = y;
+                    y = (x + n / x) / 2;
+                }
+                return x;
+            }
+            return 0;
+        }
+    }
+
+    /**
+     * @dev Compute the smallest integer larger than or equal to the square root of `n`
+     */
+    function ceilSqrt(uint256 n) public pure returns (uint256) {
+        unchecked {
+            uint256 x = floorSqrt(n);
+            return x**2 == n ? x : x + 1;
+        }
+    }
+
+    /**
+     * @dev Compute the largest integer smaller than or equal to the cubic root of `n`
+     */
+    function floorCbrt(uint256 n) public pure returns (uint256) {
+        unchecked {
+            uint256 x = 0;
+            for (uint256 y = 1 << 255; y > 0; y >>= 3) {
+                x <<= 1;
+                uint256 z = 3 * x * (x + 1) + 1;
+                if (n / y >= z) {
+                    n -= y * z;
+                    x += 1;
+                }
+            }
+            return x;
+        }
+    }
+
+    /**
+     * @dev Compute the smallest integer larger than or equal to the cubic root of `n`
+     */
+    function ceilCbrt(uint256 n) public pure returns (uint256) {
+        unchecked {
+            uint256 x = floorCbrt(n);
+            return x**3 == n ? x : x + 1;
+        }
+    }
+
+    /**
+     * @dev Compute the nearest integer to the quotient of `n` and `d` (or `n / d`)
+     */
+    function roundDiv(uint256 n, uint256 d) public pure returns (uint256) {
+        unchecked {
+            return n / d + (n % d) / (d - d / 2);
+        }
+    }
+
+    /**
+     * @dev Compute the largest integer smaller than or equal to `x * y / z`
+     */
+    function mulDivF(
+        uint256 x,
+        uint256 y,
+        uint256 z
+    ) public pure returns (uint256) {
+        unchecked {
+            (uint256 xyh, uint256 xyl) = mul512(x, y);
+            if (xyh == 0) {
+                // `x * y < 2 ^ 256`
+                return xyl / z;
+            }
+            if (xyh < z) {
+                // `x * y / z < 2 ^ 256`
+                uint256 m = mulMod(x, y, z); // `m = x * y % z`
+                (uint256 nh, uint256 nl) = sub512(xyh, xyl, m); // `n = x * y - m` hence `n / z = floor(x * y / z)`
+                if (nh == 0) {
+                    // `n < 2 ^ 256`
+                    return nl / z;
+                }
+                uint256 p = unsafeSub(0, z) & z; // `p` is the largest power of 2 which `z` is divisible by
+                uint256 q = div512(nh, nl, p); // `n` is divisible by `p` because `n` is divisible by `z` and `z` is divisible by `p`
+                uint256 r = inv256(z / p); // `z / p = 1 mod 2` hence `inverse(z / p) = 1 mod 2 ^ 256`
+                return unsafeMul(q, r); // `q * r = (n / p) * inverse(z / p) = n / z`
+            }
+            revert(); // `x * y / z >= 2 ^ 256`
+        }
+    }
+
+    /**
+     * @dev Compute the smallest integer larger than or equal to `x * y / z`
+     */
+    function mulDivC(
+        uint256 x,
+        uint256 y,
+        uint256 z
+    ) public pure returns (uint256) {
+        unchecked {
+            uint256 w = mulDivF(x, y, z);
+            if (mulMod(x, y, z) > 0) return safeAdd(w, 1);
+            return w;
+        }
+    }
+
+    /**
+     * @dev Compute the value of `x * y`
+     */
+    function mul512(uint256 x, uint256 y)
+        public
+        pure
+        returns (uint256, uint256)
+    {
+        unchecked {
+            uint256 p = mulModMax(x, y);
+            uint256 q = unsafeMul(x, y);
+            if (p >= q) return (p - q, q);
+            return (unsafeSub(p, q) - 1, q);
+        }
+    }
+
+    /**
+     * @dev Compute the value of `2 ^ 256 * xh + xl - y`, where `2 ^ 256 * xh + xl >= y`
+     */
+    function sub512(
+        uint256 xh,
+        uint256 xl,
+        uint256 y
+    ) public pure returns (uint256, uint256) {
+        unchecked {
+            if (xl >= y) return (xh, xl - y);
+            return (xh - 1, unsafeSub(xl, y));
+        }
+    }
+
+    /**
+     * @dev Compute the value of `(2 ^ 256 * xh + xl) / pow2n`, where `xl` is divisible by `pow2n`
+     */
+    function div512(
+        uint256 xh,
+        uint256 xl,
+        uint256 pow2n
+    ) public pure returns (uint256) {
+        unchecked {
+            uint256 pow2nInv = unsafeAdd(unsafeSub(0, pow2n) / pow2n, 1); // `1 << (256 - n)`
+            return unsafeMul(xh, pow2nInv) | (xl / pow2n); // `(xh << (256 - n)) | (xl >> n)`
+        }
+    }
+
+    /**
+     * @dev Compute the inverse of `d` modulo `2 ^ 256`, where `d` is congruent to `1` modulo `2`
+     */
+    function inv256(uint256 d) public pure returns (uint256) {
+        unchecked {
+            // approximate the root of `f(x) = 1 / x - d` using the newton–raphson convergence method
+            uint256 x = 1;
+            for (uint256 i = 0; i < 8; ++i)
+                x = unsafeMul(x, unsafeSub(2, unsafeMul(x, d))); // `x = x * (2 - x * d) mod 2 ^ 256`
+            return x;
+        }
+    }
+}

--- a/tests/benchmark/IntegralMath_test.py
+++ b/tests/benchmark/IntegralMath_test.py
@@ -1,0 +1,136 @@
+import os
+
+import pytest
+from starkware.starknet.compiler.compile import compile_starknet_files
+from starkware.starknet.testing.starknet import Starknet
+from starkware.starknet.testing.state import StarknetState
+from yul.main import transpile_from_solidity
+from yul.starknet_utils import invoke_method
+
+from warp.logging.generateMarkdown import bytecodeDetails, sizeOfFile, stepsInFunction
+
+warp_root = os.path.abspath(os.path.join(__file__, "../../.."))
+test_dir = __file__
+
+
+@pytest.mark.asyncio
+async def test_starknet():
+    contract_file = test_dir[:-8] + ".cairo"
+    sol_file = test_dir[:-8] + ".sol"
+    cairo_path = f"{warp_root}/warp/cairo-src"
+
+    # ======= Handwritten Cairo =======
+    contractDef = compile_starknet_files(
+        [contract_file], debug_info=True, cairo_path=[cairo_path]
+    )
+    bytecodeDetails("IntegralMath", contractDef.program.data, "IntegralMath")
+    sizeOfFile("IntegralMath", contract_file, "IntegralMath")
+
+    starknet = await Starknet.empty()
+    contract = await starknet.deploy(contract_def=contractDef, constructor_calldata=[])
+
+    exec_info = await contract.floorLog2((10, 0)).invoke()
+    stepsInFunction("IntegralMath", "floorLog2", exec_info, "IntegralMath")
+    assert exec_info.result._asdict()["res"] == 3
+
+    exec_info = await contract.floorSqrt((10, 0)).invoke()
+    stepsInFunction("IntegralMath", "floorSqrt", exec_info, "IntegralMath")
+    assert exec_info.result._asdict()["res"] == (3, 0)
+
+    # exec_info = await contract.ceilSqrt((10, 0)).invoke()
+    # stepsInFunction("IntegralMath", "ceilSqrt", exec_info)
+    # assert exec_info.result._asdict()["res"] == (4, 0)
+
+    exec_info = await contract.floorCbrt((10, 0)).invoke()
+    stepsInFunction("IntegralMath", "floorCbrt", exec_info, "IntegralMath")
+    assert exec_info.result._asdict()["res"] == (2, 0)
+
+    exec_info = await contract.ceilCbrt((10, 0)).invoke()
+    stepsInFunction("IntegralMath", "ceilCbrt", exec_info, "IntegralMath")
+    assert exec_info.result._asdict()["res"] == (3, 0)
+
+    # exec_info = await contract.roundDiv((4, 0), (5, 0)).invoke()
+    # stepsInFunction("IntegralMath", "roundDiv", exec_info)
+    # assert exec_info.result._asdict()["res"] == (1, 0)
+
+    # exec_info = await contract.mulDivF((2, 0), (3, 0), (5, 0)).invoke()
+    # stepsInFunction("IntegralMath", "mulDivF", exec_info)
+    # assert exec_info.result._asdict()["res"] == (1, 0)
+
+    # exec_info = await contract.mulDivC((2, 0), (3, 0), (5, 0)).invoke()
+    # stepsInFunction("IntegralMath", "floorLog2", exec_info)
+    # assert exec_info.result._asdict()["res"] == (2, 0)
+
+    # exec_info = await contract.mul512((4, 0), (5, 0)).invoke()
+    # stepsInFunction("IntegralMath", "floorLog2", exec_info)
+    # assert exec_info.result._asdict()["res"] == (20, 0)
+
+    exec_info = await contract.sub512((1, 0), (2, 0), (100, 0)).invoke()
+    stepsInFunction("IntegralMath", "sub512", exec_info, "IntegralMath")
+    assert exec_info.result._asdict()["a"] == (0, 0)
+    assert exec_info.result._asdict()["b"] == (
+        340282366920938463463374607431768211358,
+        340282366920938463463374607431768211455,
+    )
+
+    exec_info = await contract.div512((1, 0), (2, 0), (100, 0)).invoke()
+    stepsInFunction("IntegralMath", "div512", exec_info, "IntegralMath")
+    assert exec_info.result._asdict()["res"] == (
+        190558125475725539539489780161790198415,
+        3402823669209384634633746074317682114,
+    )
+
+    exec_info = await contract.inv256((10, 0)).invoke()
+    stepsInFunction("IntegralMath", "floorLog2", exec_info, "IntegralMath")
+    assert exec_info.result._asdict()["res"] == (
+        154392981352639047313616789111798275072,
+        184428587268969546226628472350316351187,
+    )
+
+    # ======= Compiled Cairo =======
+
+    program_info = transpile_from_solidity(sol_file, "IntegralMath")
+    program_cairo = os.path.join(warp_root, "benchmark", "IntegralMath_warp.cairo")
+
+    with open(program_cairo, "w") as f:
+        f.write(program_info["cairo_code"])
+
+    # contractDef = compile_starknet_files(
+    #     [program_cairo], debug_info=True, cairo_path=[cairo_path]
+    # )
+
+    # starknet = await StarknetState.empty()
+    # contract_address = await starknet.deploy(
+    #     contract_definition=contractDef,
+    #     constructor_calldata=[],
+    # )
+    # bytecodeDetails("IntegralMath_warp", contractDef.program.data)
+    # sizeOfFile("IntegralMath_warp", program_cairo)
+
+    # res = await invoke_method(starknet, program_info, contract_address, "floorLog2", 10)
+    # stepsInFunction("IntegralMath_warp", "floorLog2", res)
+    # assert res.retdata == [1, 32, 2, 0, 3]
+
+    # res = await invoke_method(starknet, program_info, contract_address, "floorSqrt", 10)
+    # stepsInFunction("IntegralMath_warp", "floorSqrt", res)
+    # assert res.retdata == [1, 32, 2, 0, 3]
+
+    # res = await invoke_method(starknet, program_info, contract_address, "floorCbrt", 10)
+    # stepsInFunction("IntegralMath_warp", "floorCbrt", res)
+    # assert res.retdata == [1, 32, 2, 0, 3]
+
+    # res = await invoke_method(starknet, program_info, contract_address, "ceilCbrt", 10)
+    # stepsInFunction("IntegralMath_warp", "ceilCbrt", res)
+    # assert res.retdata == [1, 32, 2, 0, 3]
+
+    # res = await invoke_method(starknet, program_info, contract_address, "sub512", 10)
+    # stepsInFunction("IntegralMath_warp", "sub512", res)
+    # assert res.retdata == [1, 32, 2, 0, 3]
+
+    # res = await invoke_method(starknet, program_info, contract_address, "div512", 10)
+    # stepsInFunction("IntegralMath_warp", "div512", res)
+    # assert res.retdata == [1, 32, 2, 0, 3]
+
+    # res = await invoke_method(starknet, program_info, contract_address, "inv256", 10)
+    # stepsInFunction("IntegralMath_warp", "inv256", res)
+    # assert res.retdata == [1, 32, 2, 0, 3]

--- a/tests/benchmark/WETH10.cairo
+++ b/tests/benchmark/WETH10.cairo
@@ -1,0 +1,397 @@
+%lang starknet
+%builtins pedersen range_check ecdsa
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
+from starkware.starknet.common.syscalls import get_contract_address, get_caller_address
+from starkware.cairo.common.math_cmp import is_le
+
+from starkware.cairo.common.uint256 import Uint256, uint256_add, uint256_sub, uint256_le, uint256_lt
+
+const true = 1
+const false = 0
+const maxUint112 = 0x1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111
+
+const maxFelt = 0x11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111
+
+@contract_interface
+namespace IERC3156FlashBorrower:
+    func onFlashLoan(
+            initiator : felt, token : felt, amount : felt, fee : felt, data_len : felt,
+            data : felt*) -> (res : Uint256):
+    end
+end
+
+@contract_interface
+namespace ITransferReceiver:
+    func onTokenTransfer(add : felt, val : felt, cd_len : felt, cd : felt*) -> (success : felt):
+    end
+end
+
+@contract_interface
+namespace IApprovalReceiver:
+    func onTokenApproval(add : felt, val : felt, cd_len : felt, cd : felt*) -> (success : felt):
+    end
+end
+
+const name = 'Wrapped Ether v10'
+const symbol = 'WETH10'
+const decimals = 18
+
+# keccak256("ERC3156FlashBorrower.onFlashLoan");
+const CALLBACK_SUCCESS_high = 0x439148f0bbc682ca079e46d6e2c2f0c1
+const CALLBACK_SUCCESS_low = 0xe3b820f1a291b069d8882abf8cf18dd9
+
+# keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+# const PERMIT_TYPEHASH.high = 0x6e71edae12b1b97f4d1f60370fef1010
+# const PERMIT_TYPEHASH.low  = 0x5fa2faae0126114a169c64845d6126c9
+
+@storage_var
+func balanceOf(add : felt) -> (res : felt):
+end
+
+@storage_var
+func nonces(add : felt) -> (res : felt):
+end
+
+@storage_var
+func allowance(owner : felt, spender : felt) -> (res : felt):
+end
+
+@storage_var
+func flashMinted() -> (res : felt):
+end
+
+@view
+func totalSupply{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+        res : felt):
+    let (fMinted) = flashMinted.read()
+    let (add) = get_contract_address()
+    let (balance) = balanceOf.read(add)
+    return (fMinted + balance)
+end
+
+@external
+func receive{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(value : felt):
+    let (sender) = get_caller_address()
+    let (balance) = balanceOf.read(sender)
+    balanceOf.write(sender, balance + value)
+    return ()
+end
+
+@external
+func deposit{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(value : felt):
+    let (sender) = get_caller_address()
+    let (balance) = balanceOf.read(sender)
+    balanceOf.write(sender, balance + value)
+    return ()
+end
+
+@external
+func depositTo{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        add : felt, value : felt):
+    let (balance) = balanceOf.read(add)
+    balanceOf.write(add, balance + value)
+    return ()
+end
+
+@external
+func depositToAndCall{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        add_to : felt, value : felt, data_len : felt, data : felt*) -> (success : felt):
+    alloc_locals
+    depositTo(add_to, value)
+    let (sender) = get_caller_address()
+    let (success) = ITransferReceiver.onTokenTransfer(add_to, sender, value, data_len, data)
+    return (success)
+end
+
+@view
+func maxFlashLoan{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        token : felt) -> (res : felt):
+    let (add) = get_contract_address()
+    if add == token:
+        let (fMinted) = flashMinted.read()
+        return (maxUint112 - fMinted)
+    else:
+        return (0)
+    end
+end
+
+@view
+func flashFee{syscall_ptr : felt*, range_check_ptr}(token : felt, ignore : felt) -> (
+        success : felt):
+    alloc_locals
+    let (add) = get_contract_address()
+    # "WETH: flash mint only WETH10"
+    assert add = token
+    return (0)
+end
+
+@external
+func flashLoan{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        receiver : felt, token : felt, value : felt, data_len : felt, data : felt*) -> (
+        success : felt):
+    alloc_locals
+    let (add) = get_contract_address()
+    assert token = add
+    # "WETH: flash mint only WETH10"
+    let (cond) = is_le(maxUint112 + 1, value)
+    assert cond = 0
+    # WETH: individual loan limit exceeded
+    let (fMinted) = flashMinted.read()
+    let (cond) = is_le(maxUint112 + 1, fMinted + value)
+    assert cond = 0
+    # WETH: total loan limit exceeded
+    flashMinted.write(fMinted + value)
+
+    let (balance) = balanceOf.read(receiver)
+    balanceOf.write(receiver, balance + value)
+    let (sender) = get_caller_address()
+    let (add) = get_contract_address()
+    let (res) = IERC3156FlashBorrower.onFlashLoan(receiver, sender, add, value, 0, data_len, data)
+    assert res.high = CALLBACK_SUCCESS_high
+    # WATH: flash loan failed
+
+    assert res.low = CALLBACK_SUCCESS_low
+    # WATH: flash loan failed
+    let (allowed) = allowance.read(receiver, add)
+    let (cond) = is_le(allowed + 1, value)
+
+    if allowed != maxFelt:
+        assert cond = 0
+        # WETH: request exceeds allowance
+        let reduced = allowed - value
+        allowance.write(receiver, add, reduced)
+        tempvar syscall_ptr : felt* = syscall_ptr
+        tempvar range_check_ptr = range_check_ptr
+        tempvar pedersen_ptr : HashBuiltin* = pedersen_ptr
+    else:
+        tempvar syscall_ptr : felt* = syscall_ptr
+        tempvar range_check_ptr = range_check_ptr
+        tempvar pedersen_ptr : HashBuiltin* = pedersen_ptr
+    end
+
+    let (balance) = balanceOf.read(receiver)
+    let (cond) = is_le(balance + 1, value)
+    assert cond = 0
+    # WETH: burn amount exceeds balance
+
+    balanceOf.write(receiver, balance - value)
+    let (fMinted) = flashMinted.read()
+    flashMinted.write(fMinted - value)
+    return (true)
+end
+
+@external
+func withdraw{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(value : felt):
+    alloc_locals
+    let (local sender) = get_caller_address()
+    let (balance) = balanceOf.read(sender)
+    let (cond) = is_le(balance + 1, value)
+    assert cond = 0
+    # WETH: burn amount axceeds balance
+    balanceOf.write(sender, balance - value)
+    # add value to calling contract
+    # (bool success, ) = msg.sender.call{value: value}("");
+    return ()
+end
+
+@external
+func withdrawTo{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        to : felt, value : felt):
+    alloc_locals
+    let (local sender) = get_caller_address()
+    let (balance) = balanceOf.read(sender)
+    let (cond) = is_le(balance + 1, value)
+    assert cond = 0
+    # "WETH: burn amount exceeds balance"
+    balanceOf.write(sender, balance - value)
+    # emit Transfer(sender, get_current_address(), value)
+    # add value to the calling contract
+    # (bool success, ) = to.call{value: value}("")
+    # if success == 0:
+    #  assert 1 = 0
+    # end
+    return ()
+end
+@external
+func approve{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        spender : felt, value : felt) -> (success : felt):
+    let (sender) = get_caller_address()
+    allowance.write(sender, spender, value)
+    return (true)
+end
+
+@external
+func approveAndCall{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        spender : felt, value : felt, data_len : felt, data : felt*) -> (success : felt):
+    alloc_locals
+    let (sender) = get_caller_address()
+    allowance.write(sender, spender, value)
+    let (success) = IApprovalReceiver.onTokenApproval(spender, sender, value, data_len, data)
+    return (success)
+end
+
+@external
+func permit{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        owner : felt, spender : felt, value : felt, v : felt, r : felt, s : felt):
+    return ()
+end
+
+@external
+func transfer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        to : felt, value : felt) -> (success : felt):
+    alloc_locals
+    let (sender) = get_caller_address()
+    if to != 0:
+        let balance : felt = balanceOf.read(sender)
+        let (cond) = is_le(balance + 1, value)
+        assert cond = 0
+        # WETH: transfer amount exceeds balance
+        balanceOf.write(sender, balance - value)
+        let (balance_to) = balanceOf.read(to)
+        balanceOf.write(to, balance_to + value)
+    else:
+        let (balance) = balanceOf.read(sender)
+        let (cond) = is_le(balance + 1, value)
+        assert cond = 0
+        # WETH: burn amount axceeds balance
+        balanceOf.write(sender, balance - value)
+        # (bool success, ) = msg.sender.call{value: value}("");
+        # require(success, "WETH: ETH transfer failed");
+    end
+    return (true)
+end
+
+@external
+func transferFrom{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        from_ : felt, to : felt, value : felt) -> (success : felt):
+    alloc_locals
+    let (local sender) = get_caller_address()
+    let (balance) = balanceOf.read(from_)
+
+    if from_ != sender:
+        let (allowed) = allowance.read(from_, sender)
+
+        if allowed != maxFelt:
+            let (cond) = is_le(allowed + 1, value)
+            assert cond = 0
+            # WETH: request exceedss allowance
+            let reduced = allowed - value
+            allowance.write(from_, sender, reduced)
+            tempvar syscall_ptr : felt* = syscall_ptr
+            tempvar range_check_ptr = range_check_ptr
+            tempvar pedersen_ptr : HashBuiltin* = pedersen_ptr
+        else:
+            tempvar syscall_ptr : felt* = syscall_ptr
+            tempvar range_check_ptr = range_check_ptr
+            tempvar pedersen_ptr : HashBuiltin* = pedersen_ptr
+        end
+        tempvar syscall_ptr : felt* = syscall_ptr
+        tempvar range_check_ptr = range_check_ptr
+        tempvar pedersen_ptr : HashBuiltin* = pedersen_ptr
+    else:
+        tempvar syscall_ptr : felt* = syscall_ptr
+        tempvar range_check_ptr = range_check_ptr
+        tempvar pedersen_ptr : HashBuiltin* = pedersen_ptr
+    end
+
+    tempvar syscall_ptr : felt* = syscall_ptr
+    tempvar range_check_ptr = range_check_ptr
+    tempvar pedersen_ptr : HashBuiltin* = pedersen_ptr
+    if to != 0:
+        let (cond) = is_le(balance + 1, value)
+        assert cond = 0
+        # WETH: transfer amount exceeds balance
+        let (balance_to) = balanceOf.read(to)
+        balanceOf.write(from_, balance - value)
+        balanceOf.write(to, balance_to + value)
+        tempvar syscall_ptr : felt* = syscall_ptr
+        tempvar range_check_ptr = range_check_ptr
+        tempvar pedersen_ptr : HashBuiltin* = pedersen_ptr
+    else:
+        let (cond) = is_le(balance + 1, value)
+        assert cond = 0
+        # WETH: transfer amount exceeds balance
+
+        balanceOf.write(from_, balance - value)
+        # (bool success, ) = msg.sender.call{value: value}("");
+        # require(success, "WETH: ETH transfer failed");
+        tempvar syscall_ptr : felt* = syscall_ptr
+        tempvar range_check_ptr = range_check_ptr
+        tempvar pedersen_ptr : HashBuiltin* = pedersen_ptr
+    end
+    return (true)
+end
+
+@external
+func transferAndCall{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        to : felt, value : felt, data_len : felt, data : felt*) -> (success : felt):
+    alloc_locals
+    let (local sender) = get_caller_address()
+    if to != 0:
+        let (balance) = balanceOf.read(sender)
+        let (cond) = is_le(balance + 1, value)
+        assert cond = 0
+        # WETH: transfer amount exceeds balance
+        balanceOf.write(sender, balance - value)
+        let (balance_to) = balanceOf.read(to)
+        balanceOf.write(to, balance_to + value)
+    else:
+        let (balance) = balanceOf.read(sender)
+        let (cond) = is_le(balance + 1, value)
+        assert cond = 0
+        # WETH: burn amount axceeds balance
+        balanceOf.write(sender, balance - value)
+        # (bool success, ) = msg.sender.call{value: value}("");
+        # require(success, "WETH: ETH transfer failed");
+    end
+    local pedersen_ptr : HashBuiltin* = pedersen_ptr
+    let (success) = ITransferReceiver.onTokenTransfer(to, sender, value, data_len, data)
+    return (success)
+end
+
+@external
+func withdrawFrom{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        from_ : felt, to : felt, value : felt):
+    alloc_locals
+    let (sender) = get_caller_address()
+    if from_ != sender:
+        let (allowed) = allowance.read(from_, sender)
+        let (cond) = is_le(allowed + 1, value)
+        if allowed != maxFelt:
+            assert cond = 0
+            # WETH: request exceeds allowance
+            let reduced = allowed - value
+            allowance.write(from_, sender, reduced)
+            # emit Approval(from_, sender, reduced)
+            tempvar syscall_ptr : felt* = syscall_ptr
+            tempvar range_check_ptr = range_check_ptr
+            tempvar pedersen_ptr : HashBuiltin* = pedersen_ptr
+        else:
+            tempvar syscall_ptr : felt* = syscall_ptr
+            tempvar range_check_ptr = range_check_ptr
+            tempvar pedersen_ptr : HashBuiltin* = pedersen_ptr
+        end
+        tempvar syscall_ptr : felt* = syscall_ptr
+        tempvar range_check_ptr = range_check_ptr
+        tempvar pedersen_ptr : HashBuiltin* = pedersen_ptr
+    else:
+        tempvar syscall_ptr : felt* = syscall_ptr
+        tempvar range_check_ptr = range_check_ptr
+        tempvar pedersen_ptr : HashBuiltin* = pedersen_ptr
+    end
+
+    let (balance) = balanceOf.read(from_)
+    let (cond) = is_le(balance + 1, value)
+    assert cond = 0
+    # "WETH: burn amount exceeds balance"
+    # WETH: Ether transfer failed
+
+    balanceOf.write(from_, balance - value)
+    # emit Transfer(from_, address(0), value)
+    # (bool success, ) = to.call{value: value}("")
+    # if success == 0:
+    #  assert 1 = 0
+    # end
+    return ()
+end

--- a/tests/benchmark/WETH10.sol
+++ b/tests/benchmark/WETH10.sol
@@ -1,0 +1,367 @@
+interface IERC20 {
+    function totalSupply() external view returns (uint256);
+
+    function balanceOf(address account) external view returns (uint256);
+
+    function transfer(address recipient, uint256 amount)
+        external
+        returns (bool);
+
+    function allowance(address owner, address spender)
+        external
+        view
+        returns (uint256);
+
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) external returns (bool);
+}
+
+interface IERC2612 {
+    function permit(
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
+
+    function nonces(address owner) external view returns (uint256);
+
+    function DOMAIN_SEPARATOR() external view returns (bytes32);
+}
+
+interface IERC3156FlashBorrower {
+    function onFlashLoan(
+        address initiator,
+        address token,
+        uint256 amount,
+        uint256 fee,
+        bytes calldata data
+    ) external returns (bytes32);
+}
+
+interface IERC3156FlashLender {
+    function maxFlashLoan(address token) external view returns (uint256);
+
+    function flashFee(address token, uint256 amount)
+        external
+        view
+        returns (uint256);
+
+    function flashLoan(
+        IERC3156FlashBorrower receiver,
+        address token,
+        uint256 amount,
+        bytes calldata data
+    ) external returns (bool);
+}
+
+interface IWETH10 is IERC20, IERC2612, IERC3156FlashLender {
+    function flashMinted() external view returns (uint256);
+
+    function deposit(uint256 value) external payable;
+
+    function depositTo(address to, uint256 value) external payable;
+
+    function withdraw(uint256 value) external;
+
+    function withdrawTo(address payable to, uint256 value) external;
+
+    function withdrawFrom(
+        address from,
+        address payable to,
+        uint256 value
+    ) external;
+
+    function depositToAndCall(address to, bytes calldata data)
+        external
+        payable
+        returns (bool);
+
+    function approveAndCall(
+        address spender,
+        uint256 value,
+        bytes calldata data
+    ) external returns (bool);
+
+    function transferAndCall(
+        address to,
+        uint256 value,
+        bytes calldata data
+    ) external returns (bool);
+}
+pragma solidity >=0.7.6;
+
+interface ITransferReceiver {
+    function onTokenTransfer(
+        address,
+        uint256,
+        bytes calldata
+    ) external returns (bool);
+}
+
+interface IApprovalReceiver {
+    function onTokenApproval(
+        address,
+        uint256,
+        bytes calldata
+    ) external returns (bool);
+}
+
+contract WETH10 is IWETH10 {
+    string public constant name = "Wrapped Ether v10";
+    string public constant symbol = "WETH10";
+    uint8 public constant decimals = 18;
+    bytes32 public CALLBACK_SUCCESS =
+        keccak256("ERC3156FlashBorrower.onFlashLoan");
+    bytes32 public PERMIT_TYPEHASH =
+        keccak256(
+            "Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"
+        );
+    uint256 public deploymentChainId;
+    bytes32 private _DOMAIN_SEPARATOR;
+    mapping(address => uint256) public override balanceOf;
+    mapping(address => uint256) public override nonces;
+    mapping(address => mapping(address => uint256)) public override allowance;
+    uint256 public override flashMinted;
+
+    function DOMAIN_SEPARATOR() external view override returns (bytes32) {}
+
+    function totalSupply() external view override returns (uint256) {
+        return balanceOf[address(this)] + flashMinted;
+    }
+
+    receive() external payable {
+        balanceOf[msg.sender] += msg.value;
+    }
+
+    function deposit(uint256 value) external payable override {
+        balanceOf[msg.sender] += value;
+    }
+
+    function depositTo(address to, uint256 value) external payable {
+        balanceOf[to] += value;
+    }
+
+    function depositToAndCall(address to, bytes calldata data)
+        external
+        payable
+        override
+        returns (bool success)
+    {
+        balanceOf[to] += msg.value;
+        return
+            ITransferReceiver(to).onTokenTransfer(msg.sender, msg.value, data);
+    }
+
+    function maxFlashLoan(address token)
+        external
+        view
+        override
+        returns (uint256)
+    {
+        return token == address(this) ? type(uint112).max - flashMinted : 0; // Can't underflow
+    }
+
+    function flashFee(address token, uint256)
+        external
+        view
+        override
+        returns (uint256)
+    {
+        require(token == address(this), "WETH: flash mint only WETH10");
+        return 0;
+    }
+
+    function flashLoan(
+        IERC3156FlashBorrower receiver,
+        address token,
+        uint256 value,
+        bytes calldata data
+    ) external override returns (bool) {
+        require(token == address(this), "WETH: flash mint only WETH10");
+        require(
+            value <= type(uint112).max,
+            "WETH: individual loan limit exceeded"
+        );
+        flashMinted = flashMinted + value;
+        require(
+            flashMinted <= type(uint112).max,
+            "WETH: total loan limit exceeded"
+        );
+
+        balanceOf[address(receiver)] += value;
+        require(
+            receiver.onFlashLoan(msg.sender, address(this), value, 0, data) ==
+                CALLBACK_SUCCESS,
+            "WETH: flash loan failed"
+        );
+
+        uint256 allowed = allowance[address(receiver)][address(this)];
+        if (allowed != type(uint256).max) {
+            require(allowed >= value, "WETH: request exceeds allowance");
+            uint256 reduced = allowed - value;
+            allowance[address(receiver)][address(this)] = reduced;
+        }
+        uint256 balance = balanceOf[address(receiver)];
+        require(balance >= value, "WETH: burn amount exceeds balance");
+        balanceOf[address(receiver)] = balance - value;
+
+        flashMinted = flashMinted - value;
+        return true;
+    }
+
+    function withdraw(uint256 value) external override {
+        uint256 balance = balanceOf[msg.sender];
+        require(balance >= value, "WETH: burn amount exceeds balance");
+        balanceOf[msg.sender] = balance - value;
+        (bool success, ) = msg.sender.call{value: value}("");
+        require(success, "WETH: ETH transfer failed");
+    }
+
+    function withdrawTo(address payable to, uint256 value) external override {
+        uint256 balance = balanceOf[msg.sender];
+        require(balance >= value, "WETH: burn amount exceeds balance");
+        balanceOf[msg.sender] = balance - value;
+        (bool success, ) = to.call{value: value}("");
+        require(success, "WETH: ETH transfer failed");
+    }
+
+    function withdrawFrom(
+        address from,
+        address payable to,
+        uint256 value
+    ) external override {
+        if (from != msg.sender) {
+            uint256 allowed = allowance[from][msg.sender];
+            if (allowed != type(uint256).max) {
+                require(allowed >= value, "WETH: request exceeds allowance");
+                uint256 reduced = allowed - value;
+                allowance[from][msg.sender] = reduced;
+            }
+        }
+
+        uint256 balance = balanceOf[from];
+        require(balance >= value, "WETH: burn amount exceeds balance");
+        balanceOf[from] = balance - value;
+        (bool success, ) = to.call{value: value}("");
+        require(success, "WETH: Ether transfer failed");
+    }
+
+    function approve(address spender, uint256 value)
+        external
+        override
+        returns (bool)
+    {
+        allowance[msg.sender][spender] = value;
+        return true;
+    }
+
+    function approveAndCall(
+        address spender,
+        uint256 value,
+        bytes calldata data
+    ) external override returns (bool) {
+        allowance[msg.sender][spender] = value;
+
+        return
+            IApprovalReceiver(spender).onTokenApproval(msg.sender, value, data);
+    }
+
+    function permit(
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external override {}
+
+    function transfer(address to, uint256 value)
+        external
+        override
+        returns (bool)
+    {
+        if (to != address(0)) {
+            // Transfer
+            uint256 balance = balanceOf[msg.sender];
+            require(balance >= value, "WETH: transfer amount exceeds balance");
+            balanceOf[msg.sender] = balance - value;
+            balanceOf[to] += value;
+        } else {
+            // Withdraw
+            uint256 balance = balanceOf[msg.sender];
+            require(balance >= value, "WETH: burn amount exceeds balance");
+            balanceOf[msg.sender] = balance - value;
+
+            (bool success, ) = msg.sender.call{value: value}("");
+            require(success, "WETH: ETH transfer failed");
+        }
+
+        return true;
+    }
+
+    function transferFrom(
+        address from,
+        address to,
+        uint256 value
+    ) external override returns (bool) {
+        if (from != msg.sender) {
+            uint256 allowed = allowance[from][msg.sender];
+            if (allowed != type(uint256).max) {
+                require(allowed >= value, "WETH: request exceeds allowance");
+                uint256 reduced = allowed - value;
+                allowance[from][msg.sender] = reduced;
+            }
+        }
+
+        if (to != address(0)) {
+            // Transfer
+            uint256 balance = balanceOf[from];
+            require(balance >= value, "WETH: transfer amount exceeds balance");
+            balanceOf[from] = balance - value;
+            balanceOf[to] += value;
+        } else {
+            // Withdraw
+            uint256 balance = balanceOf[from];
+            require(balance >= value, "WETH: burn amount exceeds balance");
+            balanceOf[from] = balance - value;
+
+            (bool success, ) = msg.sender.call{value: value}("");
+            require(success, "WETH: ETH transfer failed");
+        }
+
+        return true;
+    }
+
+    function transferAndCall(
+        address to,
+        uint256 value,
+        bytes calldata data
+    ) external override returns (bool) {
+        if (to != address(0)) {
+            // Transfer
+            uint256 balance = balanceOf[msg.sender];
+            require(balance >= value, "WETH: transfer amount exceeds balance");
+            balanceOf[msg.sender] = balance - value;
+            balanceOf[to] += value;
+        } else {
+            // Withdraw
+            uint256 balance = balanceOf[msg.sender];
+            require(balance >= value, "WETH: burn amount exceeds balance");
+            balanceOf[msg.sender] = balance - value;
+
+            (bool success, ) = msg.sender.call{value: value}("");
+            require(success, "WETH: ETH transfer failed");
+        }
+        return ITransferReceiver(to).onTokenTransfer(msg.sender, value, data);
+    }
+}

--- a/tests/benchmark/WETH10_test.py
+++ b/tests/benchmark/WETH10_test.py
@@ -1,0 +1,152 @@
+import os
+
+import pytest
+from starkware.starknet.compiler.compile import compile_starknet_files
+from starkware.starknet.testing.starknet import Starknet
+from starkware.starknet.testing.state import StarknetState
+from yul.main import transpile_from_solidity
+from yul.starknet_utils import invoke_method
+
+from warp.logging.generateMarkdown import bytecodeDetails, sizeOfFile, stepsInFunction
+
+warp_root = os.path.abspath(os.path.join(__file__, "../../.."))
+test_dir = __file__
+
+
+@pytest.mark.asyncio
+async def test_starknet():
+    contract_file = test_dir[:-8] + ".cairo"
+    sol_file = test_dir[:-8] + ".sol"
+    cairo_path = f"{warp_root}/warp/cairo-src"
+
+    # ======= Handwritten Cairo =======
+    contractDef = compile_starknet_files(
+        [contract_file], debug_info=True, cairo_path=[cairo_path]
+    )
+    bytecodeDetails("WETH10", contractDef.program.data, "WETH10")
+    sizeOfFile("WETH10", contract_file, "WETH10")
+
+    starknet = await Starknet.empty()
+    contract = await starknet.deploy(contract_def=contractDef, constructor_calldata=[])
+
+    exec_info = await contract.totalSupply().invoke()
+    stepsInFunction("WETH10", "totalSupply", exec_info, "WETH10")
+    assert exec_info.result._asdict()["res"] == 0
+
+    # exec_info = await contract.receive(100).invoke()
+    # stepsInFunction("WETH10", "receive", exec_info)
+
+    exec_info = await contract.deposit(100).invoke()
+    stepsInFunction("WETH10", "deposit", exec_info, "WETH10")
+
+    exec_info = await contract.depositTo(0x0, 100).invoke()
+    stepsInFunction("WETH10", "depositTo", exec_info, "WETH10")
+
+    exec_info = await contract.maxFlashLoan(0x0).invoke()
+    stepsInFunction("WETH10", "maxFlashLoan", exec_info, "WETH10")
+    assert exec_info.result._asdict()["res"] == 0
+
+    exec_info = await contract.flashFee(contract.contract_address, 100).invoke()
+    stepsInFunction("WETH10", "flashFee", exec_info, "WETH10")
+    assert exec_info.result._asdict()["success"] == 0
+
+    # exec_info = await contract.withdraw(100).invoke()
+    # stepsInFunction("WETH10", "withdraw", exec_info)
+
+    # exec_info = await contract.withdrawTo(0x0, 100).invoke()
+    # stepsInFunction("WETH10", "withdrawTo", exec_info)
+
+    # exec_info = await contract.withdrawFrom(0x0, 0x1, 100).invoke()
+    # stepsInFunction("WETH10", "withdrawFrom", exec_info)
+
+    exec_info = await contract.approve(0x0, 10).invoke()
+    stepsInFunction("WETH10", "approve", exec_info, "WETH10")
+    assert exec_info.result._asdict()["success"] == 1
+
+    exec_info = await contract.transfer(0x1, 0).invoke()
+    stepsInFunction("WETH10", "transfer", exec_info, "WETH10")
+    assert exec_info.result._asdict()["success"] == 1
+
+    exec_info = await contract.transferFrom(0x0, 0x1, 0).invoke()
+    stepsInFunction("WETH10", "transferFrom", exec_info, "WETH10")
+    assert exec_info.result._asdict()["success"] == 1
+
+    # ======= Compiled Cairo =======
+
+    program_info = transpile_from_solidity(sol_file, "WETH10")
+    program_cairo = os.path.join(warp_root, "benchmark", "WETH10_warp.cairo")
+
+    with open(program_cairo, "w") as f:
+        f.write(program_info["cairo_code"])
+
+    contractDef = compile_starknet_files(
+        [program_cairo], debug_info=True, cairo_path=[cairo_path]
+    )
+
+    starknet = await StarknetState.empty()
+    contract_address = await starknet.deploy(
+        contract_definition=contractDef,
+        constructor_calldata=[],
+    )
+    bytecodeDetails("WETH10_warp", contractDef.program.data, "WETH10")
+    sizeOfFile("WETH10_warp", program_cairo, "WETH10")
+
+    res = await invoke_method(
+        starknet,
+        program_info,
+        contract_address,
+        "totalSupply",
+    )
+    stepsInFunction("WETH10_warp", "totalSupply", res, "WETH10")
+    assert res.retdata == [1, 32, 2, 0, 0]
+
+    res = await invoke_method(starknet, program_info, contract_address, "deposit", 100)
+    stepsInFunction("WETH10_warp", "deposit", res, "WETH10")
+
+    res = await invoke_method(
+        starknet, program_info, contract_address, "depositTo", 0x0, 100
+    )
+    stepsInFunction("WETH10_warp", "depositTo", res, "WETH10")
+
+    res = await invoke_method(
+        starknet, program_info, contract_address, "maxFlashLoan", 0x0
+    )
+    stepsInFunction("WETH10_warp", "maxFlashLoan", res, "WETH10")
+    assert res.retdata == [1, 32, 2, 0, 0]
+
+    res = await invoke_method(
+        starknet, program_info, contract_address, "flashFee", contract_address, 100
+    )
+    stepsInFunction("WETH10_warp", "flashFee", res, "WETH10")
+    assert res.retdata == [1, 32, 2, 0, 0]
+
+    # res = await invoke_method(starknet, program_info, contract_address, "withdraw", 100)
+    # stepsInFunction("WETH10_warp", "withdraw", res)
+
+    # res = await invoke_method(
+    #     starknet, program_info, contract_address, "withdrawTo", 0x0, 100
+    # )
+    # stepsInFunction("WETH10_warp", "withdrawTo", res)
+
+    # res = await invoke_method(
+    #     starknet, program_info, contract_address, "withdrawFrom", 0x0, 0x1, 100
+    # )
+    # stepsInFunction("WETH10_warp", "withdrawFrom", res)
+
+    res = await invoke_method(
+        starknet, program_info, contract_address, "approve", 0x0, 10
+    )
+    stepsInFunction("WETH10_warp", "approve", res, "WETH10")
+    assert res.retdata == [1, 32, 2, 0, 1]
+
+    res = await invoke_method(
+        starknet, program_info, contract_address, "transfer", 0x1, 0
+    )
+    stepsInFunction("WETH10_warp", "transfer", res, "WETH10")
+    assert res.retdata == [1, 32, 2, 0, 1]
+
+    res = await invoke_method(
+        starknet, program_info, contract_address, "transferFrom", 0x0, 0x1, 0
+    )
+    stepsInFunction("WETH10_warp", "transferFrom", res, "WETH10")
+    assert res.retdata == [1, 32, 2, 0, 1]

--- a/tests/yul/ERC20_storage_test.py
+++ b/tests/yul/ERC20_storage_test.py
@@ -7,6 +7,8 @@ from starkware.starknet.testing.state import StarknetState
 from yul.main import transpile_from_solidity
 from yul.starknet_utils import invoke_method
 
+from warp.logging.generateMarkdown import stepsInFunction
+
 warp_root = os.path.abspath(os.path.join(__file__, "../../.."))
 test_dir = __file__
 
@@ -31,6 +33,7 @@ async def test_starknet():
     res = await invoke_method(
         starknet, program_info, contract_address, "deposit", sender, 500
     )
+    stepsInFunction(sol_file, "deposit", res, "ERC20_storage_test")
     check.equal(res.retdata, [1, 0, 0])
 
     res = await invoke_method(
@@ -40,19 +43,23 @@ async def test_starknet():
         "transferFrom",
         *[sender, receiver, 400, sender],
     )
+    stepsInFunction(sol_file, "transferFrom", res, "ERC20_storage_test")
     check.equal(res.retdata, [1, 32, 2, 0, 1])
 
     res = await invoke_method(
         starknet, program_info, contract_address, "withdraw", 80, sender
     )
+    stepsInFunction(sol_file, "withdraw", res, "ERC20_storage_test")
     check.equal(res.retdata, [1, 0, 0])
 
     res = await invoke_method(
         starknet, program_info, contract_address, "get_balance", sender
     )
+    stepsInFunction(sol_file, "get_balance", res, "ERC20_storage_test")
     check.equal(res.retdata, [1, 32, 2, 0, 20])
 
     res = await invoke_method(
         starknet, program_info, contract_address, "get_balance", receiver
     )
+    stepsInFunction(sol_file, "get_balance", res, "ERC20_storage_test")
     check.equal(res.retdata, [1, 32, 2, 0, 400])

--- a/tests/yul/c2c_test.py
+++ b/tests/yul/c2c_test.py
@@ -6,6 +6,8 @@ from starkware.starknet.testing.state import StarknetState
 from yul.main import transpile_from_solidity
 from yul.starknet_utils import invoke_method
 
+from warp.logging.generateMarkdown import stepsInFunction
+
 warp_root = os.path.abspath(os.path.join(__file__, "../../.."))
 test_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -50,6 +52,7 @@ async def test_starknet():
         erc20_address,
         0x6044EC4F3C64A75078096F7C7A6892D16569921C8B5C86986A28F4BB39FEDDF,
     )
+    stepsInFunction("c2c.sol", "gimmeMoney", mint_res, "c2c")
     assert mint_res.retdata == [1, 32, 2, 0, 1]
 
     balances1_res = await invoke_method(
@@ -61,6 +64,7 @@ async def test_starknet():
         0x6044EC4F3C64A75078096F7C7A6892D16569921C8B5C86986A28F4BB39FEDDF,
     )
     print(balances1_res)
+    stepsInFunction("c2c.sol", "checkMoneyz", balances1_res, "c2c")
     assert balances1_res.retdata == [1, 32, 2, 0, 42]
 
     transfer_res = await invoke_method(
@@ -74,6 +78,7 @@ async def test_starknet():
         42,
     )
     print(transfer_res)
+    stepsInFunction("c2c.sol", "sendMoneyz", transfer_res, "c2c")
     assert transfer_res.retdata == [1, 32, 2, 0, 1]
 
     # check transfer worked
@@ -86,4 +91,5 @@ async def test_starknet():
         0x6044EC4F3C64A75078096F7C7A6892D16569921C8B5C86986A28F4BB39FEDDF,
     )
     print(balance_after_transfer)
+    stepsInFunction("c2c.sol", "checkMoneyz", balance_after_transfer, "c2c")
     assert balance_after_transfer.retdata == [1, 32, 2, 0, 0]

--- a/tests/yul/calldatacopy_test.py
+++ b/tests/yul/calldatacopy_test.py
@@ -6,6 +6,8 @@ from starkware.starknet.testing.state import StarknetState
 from yul.main import transpile_from_solidity
 from yul.starknet_utils import invoke_method
 
+from warp.logging.generateMarkdown import stepsInFunction
+
 warp_root = os.path.abspath(os.path.join(__file__, "../../.."))
 test_dir = __file__
 
@@ -26,4 +28,5 @@ async def test_calldatacopy():
     )
 
     res = await invoke_method(starknet, program_info, contract_address, "callMe")
+    stepsInFunction(sol_file, "callMe", res, "calldatacopy_test")
     assert res.retdata == [1, 32, 2, 0, 0]

--- a/tests/yul/constructors_test.py
+++ b/tests/yul/constructors_test.py
@@ -9,6 +9,8 @@ from starkware.starknet.testing.state import StarknetState
 from yul.main import transpile_from_solidity
 from yul.starknet_utils import invoke_method
 
+from warp.logging.generateMarkdown import stepsInFunction
+
 warp_root = os.path.abspath(os.path.join(__file__, "../../.."))
 test_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -68,6 +70,15 @@ async def test_constructors():
             "validate_constructor",
             *non_dyn_inputs,
         ),
+    )
+    stepsInFunction(
+        "constructors_dyn.sol", "validate_constructor", dyn_result, "constructors_dyn"
+    )
+    stepsInFunction(
+        "constructors_nonDyn.sol",
+        "validate_constructor",
+        non_dyn_result,
+        "constructors_nonDyn",
     )
     print(f"dyn_result: {dyn_result}\n non_dyn_result: {non_dyn_result}")
     assert dyn_result.retdata == [1, 32, 2, 0, 1]

--- a/tests/yul/payable-function_test.py
+++ b/tests/yul/payable-function_test.py
@@ -6,6 +6,8 @@ from starkware.starknet.testing.state import StarknetState
 from yul.main import transpile_from_solidity
 from yul.starknet_utils import invoke_method
 
+from warp.logging.generateMarkdown import stepsInFunction
+
 warp_root = os.path.abspath(os.path.join(__file__, "../../.."))
 test_dir = __file__
 
@@ -28,4 +30,5 @@ async def test_starknet():
     res = await invoke_method(
         starknet, program_info, contract_address, "payableFunction", 510, 40, 21, 450
     )
+    stepsInFunction(sol_file, "payableFunction", res, "payable-function_test")
     assert res.retdata == [1, 32, 2, 0, 451]

--- a/tests/yul/pure-function_test.py
+++ b/tests/yul/pure-function_test.py
@@ -6,6 +6,8 @@ from starkware.starknet.testing.state import StarknetState
 from yul.main import transpile_from_solidity
 from yul.starknet_utils import invoke_method
 
+from warp.logging.generateMarkdown import stepsInFunction
+
 warp_root = os.path.abspath(os.path.join(__file__, "../../.."))
 test_dir = __file__
 
@@ -28,4 +30,5 @@ async def test_starknet():
     res = await invoke_method(
         starknet, program_info, contract_address, "pureFunction", 30, 500, 90, 445
     )
+    stepsInFunction(sol_file, "pureFunction", res, "pure-function_test")
     assert res.retdata == [1, 32, 2, 0, 432]

--- a/tests/yul/short_string_test.py
+++ b/tests/yul/short_string_test.py
@@ -1,10 +1,13 @@
 import os
 
 import pytest
+from cli.encoding import get_evm_calldata
 from starkware.starknet.compiler.compile import compile_starknet_files
 from starkware.starknet.testing.state import StarknetState
 from yul.main import transpile_from_solidity
 from yul.starknet_utils import invoke_method
+
+from warp.logging.generateMarkdown import stepsInFunction
 
 warp_root = os.path.abspath(os.path.join(__file__, "../../.."))
 test_dir = __file__
@@ -26,7 +29,9 @@ async def test_starknet():
     )
 
     res = await invoke_method(starknet, contract_info, contract_address, "returnFun")
+    stepsInFunction(solidity_file, "returnFun", res, "short_string")
     assert res.retdata == [1, 96, 6, 0, 32, 0, 3, 0x41424300000000000000000000000000, 0]
 
     res = await invoke_method(starknet, contract_info, contract_address, "bytesFun")
+    stepsInFunction(solidity_file, "bytesFun", res, "short_string")
     assert res.retdata == [1, 96, 6, 0, 32, 0, 3, 0x41424300000000000000000000000000, 0]

--- a/tests/yul/view-function_test.py
+++ b/tests/yul/view-function_test.py
@@ -6,6 +6,8 @@ from starkware.starknet.testing.state import StarknetState
 from yul.main import transpile_from_solidity
 from yul.starknet_utils import invoke_method
 
+from warp.logging.generateMarkdown import stepsInFunction
+
 warp_root = os.path.abspath(os.path.join(__file__, "../../.."))
 test_dir = __file__
 
@@ -28,4 +30,5 @@ async def test_starknet():
     res = await invoke_method(
         starknet, program_info, contract_address, "viewFunction", 550, 80, 11, 45
     )
+    stepsInFunction(sol_file, "viewFunction", res, "view-function_test")
     assert res.retdata == [1, 32, 2, 0, 637]

--- a/warp/logging/generateMarkdown.py
+++ b/warp/logging/generateMarkdown.py
@@ -1,0 +1,93 @@
+import json
+import os
+import sys
+
+
+def human_readable_size(size, decimal_places=3):
+    for unit in ["B", "KiB", "MiB", "GiB", "TiB"]:
+        if size < 1024.0:
+            break
+        size /= 1024.0
+    return f"{size:.{decimal_places}f}{unit}"
+
+
+def sizeOfFile(contractName, file, fileName):
+    jsonPath = os.path.abspath(
+        os.path.join(__file__, "../../../benchmark/", fileName + ".json")
+    )
+    if os.path.exists(jsonPath):
+        functionSteps = json.load(open(jsonPath, "r"))
+    else:
+        functionSteps = {}
+    bytes = os.path.getsize(file)
+    if contractName not in functionSteps.keys():
+        functionSteps[contractName] = {}
+    functionSteps[contractName]["Cairo file size"] = human_readable_size(bytes)
+
+    json.dump(functionSteps, open(jsonPath, "w"), indent=3)
+
+
+def bytecodeDetails(contractName, bytecode, fileName):
+    jsonPath = os.path.abspath(
+        os.path.join(__file__, "../../../benchmark/", fileName + ".json")
+    )
+    if os.path.exists(jsonPath):
+        functionSteps = json.load(open(jsonPath, "r"))
+    else:
+        functionSteps = {}
+
+    if contractName not in functionSteps.keys():
+        functionSteps[contractName] = {}
+    functionSteps[contractName]["Bytecode size"] = human_readable_size(
+        sys.getsizeof(bytecode)
+    )
+    functionSteps[contractName]["Bytecode length"] = len(bytecode)
+
+    json.dump(functionSteps, open(jsonPath, "w"), indent=3)
+    pass
+
+
+def stepsInFunction(contractName, functionName, result, fileName):
+    jsonPath = os.path.abspath(
+        os.path.join(__file__, "../../../benchmark/", fileName + ".json")
+    )
+    if os.path.exists(jsonPath):
+        functionSteps = json.load(open(jsonPath, "r"))
+    else:
+        functionSteps = {}
+
+    if contractName not in functionSteps.keys():
+        functionSteps[contractName] = {}
+    functionSteps[contractName][
+        f"Steps in {functionName}"
+    ] = result.call_info.cairo_usage.n_steps
+
+    json.dump(functionSteps, open(jsonPath, "w"), indent=3)
+
+
+def createMarkdown():
+    jsonPath = os.path.abspath(os.path.join(__file__, "../../../benchmark"))
+    functionSteps = {}
+
+    for file in os.listdir(jsonPath):
+        if not file.endswith(".json"):
+            continue
+
+        fileDict = json.load(open(os.path.join(jsonPath, file), "r"))
+        functionSteps.update(fileDict)
+
+    warp_root = os.path.abspath(os.path.join(__file__, "../../.."))
+    mdFile = open(os.path.join(warp_root, "benchmark/stats/stats.md"), "w")
+    mdFile.write("# Warp status\n")
+
+    for contract, data in functionSteps.items():
+        mdFile.write(f"### {os.path.basename(contract)}:\n")
+        mdFile.write("| Name | Value |\n")
+        mdFile.write("| ----------- | ----------- |\n")
+
+        for function, steps in sorted(data.items()):
+            mdFile.write(f"| {function} | {steps} |\n")
+
+
+if __name__ == "__main__":
+    createMarkdown()

--- a/warp/yul/BuiltinHandler.py
+++ b/warp/yul/BuiltinHandler.py
@@ -427,6 +427,12 @@ class Return(StaticHandler):
         )
 
 
+class Stop(Return):
+    def get_function_call(self, _args) -> str:
+        assert not _args
+        return super().get_function_call(["Uint256(0, 0)", "Uint256(0, 0)"])
+
+
 class Address(StaticHandler):
     def __init__(self):
         super().__init__(
@@ -598,9 +604,9 @@ def get_default_builtins(
         "calldatasize": CallDataSize(),
         "caller": Caller(),
         "callvalue": CallValue(cairo_functions),
-        "coinbase": Coinbase(),
         "codecopy": CodeCopy(),
         "codesize": CodeSize(),
+        "coinbase": Coinbase(),
         "create": Create(),
         "create2": Create2(),
         "delegatecall": Delegatecall(cairo_functions),
@@ -616,12 +622,12 @@ def get_default_builtins(
         "gt": Gt(),
         "iszero": IsZero(),
         "keccak256": SHA3(),
-        "lt": Lt(),
         "log0": Log0(),
         "log1": Log1(),
         "log2": Log2(),
         "log3": Log3(),
         "log4": Log4(),
+        "lt": Lt(),
         "mload": MLoad(),
         "mod": Mod(),
         "msize": MSize(),
@@ -648,6 +654,7 @@ def get_default_builtins(
         "smod": SMod(),
         "sstore": SStore(cairo_functions),
         "staticcall": StaticCall(),
+        "stop": Stop(),
         "sub": Sub(),
         "timestamp": Timestamp(),
         "xor": Xor(),


### PR DESCRIPTION
Adds an automation to `make test_yul` that benchmarks the number of steps per function invocation for each contract in a markdown called `stats.md`

I've switched the number of workers in the MakeFile to 1 for the yul tests. This is to prevent concurrent writes to `stats.json` through `stepsInFunction()`. Will find a fix for this. 

Will be adding support for benchmarking contract sizes.