### PR TITLE
support for delegatecall

### DIFF
--- a/tests/behaviour/delegatecall-attack.sol
+++ b/tests/behaviour/delegatecall-attack.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.6;
+
+/*
+MIT License
+
+Copyright (c) 2018 Tasuku Nakamura
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+/*
+HackMe is a contract that uses delegatecall to execute code.
+It it is not obvious that the owner of HackMe can be changed since there is no
+function inside HackMe to do so. However an attacker can hijack the
+contract by exploiting delegatecall. Let's see how.
+
+1. Alice deploys Lib
+2. Alice deploys HackMe with address of Lib
+3. Eve deploys Attack with address of HackMe
+4. Eve calls Attack.attack()
+5. Attack is now the owner of HackMe
+
+What happened?
+Eve called Attack.attack().
+Attack called the fallback function of HackMe sending the function
+selector of pwn(). HackMe forwards the call to Lib using delegatecall.
+Here msg.data contains the function selector of pwn().
+This tells Solidity to call the function pwn() inside Lib.
+The function pwn() updates the owner to msg.sender.
+Delegatecall runs the code of Lib using the context of HackMe.
+Therefore HackMe's storage was updated to msg.sender where msg.sender is the
+caller of HackMe, in this case Attack.
+*/
+
+contract Lib {
+    address public owner;
+
+    function pwn() public {
+        owner = msg.sender;
+    }
+}
+
+contract HackMe {
+    address public owner;
+    Lib public lib;
+
+    constructor(Lib _lib) {
+        owner = msg.sender;
+        lib = Lib(_lib);
+    }
+
+    fallback() external payable {
+        address(lib).delegatecall(msg.data);
+    }
+}
+
+contract Attack {
+    address public hackMe;
+
+    constructor(address _hackMe) {
+        hackMe = _hackMe;
+    }
+
+    function attack() public {
+        hackMe.call(abi.encodeWithSignature("pwn()"));
+    }
+}

--- a/tests/behaviour/delegatecall-attack_test.py
+++ b/tests/behaviour/delegatecall-attack_test.py
@@ -1,0 +1,72 @@
+import os.path as path
+import shutil
+from pathlib import Path
+from tempfile import mkdtemp
+
+import pytest
+from starkware.starknet.compiler.compile import compile_starknet_files
+from starkware.starknet.testing.state import StarknetState
+from yul.main import transpile_from_solidity
+from yul.starknet_utils import deploy_contract, invoke_method
+
+WARP_ROOT = Path(__file__).parents[2]
+CAIRO_PATH = WARP_ROOT / "warp" / "cairo-src"
+TEST_DIR = Path(__file__).parent
+
+
+def spit(fname, content):
+    """Writes 'content' to the file named 'fname'"""
+    with open(fname, "w") as f:
+        f.write(content)
+
+
+@pytest.mark.asyncio
+async def test_attack():
+    sol = TEST_DIR / "delegatecall-attack.sol"
+    tmpdir = mkdtemp()
+    lib_cairo = path.join(tmpdir, "lib.cairo")
+    hackme_cairo = path.join(tmpdir, "hackme.cairo")
+    attack_cairo = path.join(tmpdir, "attack.cairo")
+
+    lib_info = transpile_from_solidity(sol, "Lib")
+    hackme_info = transpile_from_solidity(sol, "HackMe")
+    attack_info = transpile_from_solidity(sol, "Attack")
+
+    spit(lib_cairo, lib_info["cairo_code"])
+    spit(hackme_cairo, hackme_info["cairo_code"])
+    spit(attack_cairo, attack_info["cairo_code"])
+
+    lib_def = compile_starknet_files(
+        [lib_cairo],
+        debug_info=True,
+        cairo_path=[CAIRO_PATH],
+    )
+    hackme_def = compile_starknet_files(
+        [hackme_cairo],
+        debug_info=True,
+        cairo_path=[CAIRO_PATH],
+    )
+    attack_def = compile_starknet_files(
+        [attack_cairo],
+        debug_info=True,
+        cairo_path=[CAIRO_PATH],
+    )
+
+    starknet = await StarknetState.empty()
+    # step 1
+    lib_address = await deploy_contract(starknet, lib_info, lib_def)
+    # step 2
+    hackme_address = await deploy_contract(
+        starknet, hackme_info, hackme_def, lib_address
+    )
+    # step 3
+    attack_address = await deploy_contract(
+        starknet, attack_info, attack_def, hackme_address
+    )
+    # step 4
+    await invoke_method(starknet, attack_info, attack_address, "attack")
+    # step 5
+    result = await invoke_method(starknet, hackme_info, hackme_address, "owner")
+    high, low = divmod(attack_address, 2 ** 128)
+    assert result.retdata == [32, 2, high, low]
+    shutil.rmtree(tmpdir)

--- a/tests/golden/c2c.cairo
+++ b/tests/golden/c2c.cairo
@@ -2,11 +2,11 @@
 %builtins pedersen range_check bitwise
 
 from evm.array import validate_array
-from evm.calls import calldataload, calldatasize, warp_call, warp_static_call
+from evm.calls import calldataload, calldatasize
 from evm.exec_env import ExecutionEnvironment
 from evm.memory import uint256_mload, uint256_mstore
 from evm.uint256 import is_eq, is_gt, is_lt, is_zero, slt, u256_add, u256_shr
-from evm.yul_api import warp_return
+from evm.yul_api import staticcall, warp_call, warp_return
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin, HashBuiltin
 from starkware.cairo.common.default_dict import default_dict_finalize, default_dict_new
 from starkware.cairo.common.dict_access import DictAccess
@@ -235,7 +235,7 @@ func fun_checkMoneyz{
     let (__warp_subexpr_0 : Uint256) = u256_add(_1, Uint256(low=4, high=0))
     uint256_mstore(offset=__warp_subexpr_0, value=var_to)
     let (__warp_subexpr_1 : Uint256) = __warp_constant_10000000000000000000000000000000000000000()
-    let (_2 : Uint256) = warp_static_call(
+    let (_2 : Uint256) = staticcall(
         __warp_subexpr_1, var_addr, _1, Uint256(low=36, high=0), _1, Uint256(low=32, high=0))
     let (__warp_subexpr_2 : Uint256) = is_zero(_2)
     if __warp_subexpr_2.low + __warp_subexpr_2.high != 0:

--- a/tests/golden/delegatecall.cairo
+++ b/tests/golden/delegatecall.cairo
@@ -6,7 +6,7 @@ from evm.calls import calldatacopy, calldataload, calldatasize, caller, returnda
 from evm.exec_env import ExecutionEnvironment
 from evm.memory import uint256_mload, uint256_mstore
 from evm.uint256 import is_eq, is_gt, is_lt, is_zero, slt, u256_add, u256_shr
-from evm.yul_api import warp_call, warp_return
+from evm.yul_api import delegatecall, warp_return
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin, HashBuiltin
 from starkware.cairo.common.default_dict import default_dict_finalize, default_dict_new
 from starkware.cairo.common.dict_access import DictAccess
@@ -309,14 +309,8 @@ func __main_meat{
     uint256_mstore(offset=_5, value=Uint256(low=0, high=0))
     let (__warp_subexpr_7 : Uint256) = uint256_sub(_5, _3)
     let (__warp_subexpr_6 : Uint256) = __warp_constant_10000000000000000000000000000000000000000()
-    let (__warp_subexpr_5 : Uint256) = warp_call(
-        __warp_subexpr_6,
-        _2,
-        Uint256(low=0, high=0),
-        _3,
-        __warp_subexpr_7,
-        Uint256(low=0, high=0),
-        Uint256(low=0, high=0))
+    let (__warp_subexpr_5 : Uint256) = delegatecall(
+        __warp_subexpr_6, _2, _3, __warp_subexpr_7, Uint256(low=0, high=0), Uint256(low=0, high=0))
 
     __warp_block_6()
     warp_return(Uint256(low=0, high=0), Uint256(low=0, high=0))

--- a/tests/golden/delegatecall.sol
+++ b/tests/golden/delegatecall.sol
@@ -1,0 +1,15 @@
+pragma solidity ^0.8.6;
+
+contract WARP {
+    address public owner;
+    address public lib;
+
+    constructor(address _lib) {
+        owner = msg.sender;
+        lib = _lib;
+    }
+
+    fallback() external payable {
+        lib.delegatecall(msg.data);
+    }
+}

--- a/warp/cairo-src/evm/array.cairo
+++ b/warp/cairo-src/evm/array.cairo
@@ -126,16 +126,6 @@ func safe_read{range_check_ptr}(array_length, array : felt*, index) -> (value):
     end
 end
 
-func extend_array_to_len(array_len : felt, array : felt*, length):
-    if length == array_len:
-        return ()
-    end
-
-    assert array[array_len] = 0
-    extend_array_to_len(array_len + 1, array, length)
-    return ()
-end
-
 func validate_array{range_check_ptr}(array_len, array : felt*):
     # Verifies that all felts in the 'array' of length 'array_len' are
     # in the range [0, 2^128).

--- a/warp/cairo-src/evm/calls.cairo
+++ b/warp/cairo-src/evm/calls.cairo
@@ -24,7 +24,7 @@ func calldatacopy{
     alloc_locals
     let (msize) = update_msize(msize, dest_offset.low, length.low)
     array_copy_to_memory(
-        exec_env.calldata_size, exec_env.calldata, dest_offset.low, offset.low, length.low)
+        exec_env.calldata_size, exec_env.calldata, offset.low, dest_offset.low, length.low)
     return ()
 end
 

--- a/warp/cairo-src/evm/calls.cairo
+++ b/warp/cairo-src/evm/calls.cairo
@@ -2,16 +2,15 @@
 
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.dict_access import DictAccess
-from starkware.cairo.common.math import split_felt, unsigned_div_rem
-from starkware.cairo.common.pow import pow
 from starkware.cairo.common.registers import get_fp_and_pc
 from starkware.cairo.common.uint256 import Uint256
 from starkware.starknet.common.syscalls import get_caller_address
 
 from evm.array import (
-    array_copy_to_memory, array_create_from_memory, array_load, extend_array_to_len, validate_array)
+    array_copy_from_memory, array_copy_to_memory, array_create_from_memory, array_load,
+    validate_array)
 from evm.exec_env import ExecutionEnvironment
-from evm.utils import felt_to_uint256, uint256_to_address_felt, update_msize
+from evm.utils import ceil_div, felt_to_uint256, update_msize
 
 func caller{syscall_ptr : felt*, range_check_ptr}() -> (caller_data : Uint256):
     let (caller_address) = get_caller_address()
@@ -52,37 +51,38 @@ end
 
 # ######################### Making remote calls ###############################
 
-@contract_interface
-namespace GenericCallInterface:
-    func __main(calldata_size : felt, calldata_len : felt, calldata : felt*) -> (
-            returndata_size : felt, returndata_len : felt, returndata : felt*):
-    end
-end
+# get_selector_from_name('__main')
+const main_selector = 0x1b999a79a454af1c08c7c350b2dcee00593e13477465ce7e83f9b73d4c4ab98
 
-func calculate_data_len{range_check_ptr}(calldata_size) -> (calldata_len):
-    let (calldata_len_, rem) = unsigned_div_rem(calldata_size, 16)
-    if rem != 0:
-        return (calldata_len=calldata_len_ + 1)
-    else:
-        return (calldata_len=calldata_len_)
-    end
-end
-
-func warp_call{
+func general_call{
         syscall_ptr : felt*, exec_env : ExecutionEnvironment*, memory_dict : DictAccess*,
-        range_check_ptr}(
-        gas : Uint256, address : Uint256, value : Uint256, in : Uint256, insize : Uint256,
-        out : Uint256, outsize : Uint256) -> (success : Uint256):
+        range_check_ptr}(call_function, address, in_offset, in_size, out_offset, out_size) -> (
+        success):
     alloc_locals
     let (__fp__, _) = get_fp_and_pc()
-    let (mem : felt*) = array_create_from_memory{
-        memory_dict=memory_dict, range_check_ptr=range_check_ptr}(in.low, insize.low)
-    let (calldata_len) = calculate_data_len(insize.low)
-    let (address_felt : felt) = uint256_to_address_felt(address)
-    let (returndata_size, returndata_len, returndata) = GenericCallInterface.__main(
-        address_felt, insize.low, calldata_len, mem)
+    let (in_len) = ceil_div(in_size, 16)
+    let (cairo_calldata) = alloc()
+    cairo_calldata[0] = in_size
+    cairo_calldata[1] = in_len
+    array_copy_from_memory(in_offset, in_size, cairo_calldata + 2)
+
+    [ap] = syscall_ptr; ap++
+    [ap] = address; ap++
+    [ap] = main_selector; ap++
+    [ap] = 2 + in_len; ap++
+    [ap] = cairo_calldata; ap++
+    call abs call_function
+    let syscall_ptr = cast([ap - 3], felt*)
+    let cairo_retdata_size = [ap - 2]
+    let cairo_retdata = cast([ap - 1], felt*)
+
+    let returndata_size = cairo_retdata[0]
+    let returndata_len = cairo_retdata[1]
+    let returndata = cairo_retdata + 2
+    assert cairo_retdata_size = returndata_len + 2
+
     validate_array(returndata_len, returndata)
-    array_copy_to_memory(returndata_size, returndata, 0, out.low, outsize.low)
+    array_copy_to_memory(returndata_size, returndata, 0, out_offset, out_size)
     local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(
         calldata_size=exec_env.calldata_size,
         calldata_len=exec_env.calldata_len,
@@ -94,15 +94,7 @@ func warp_call{
         to_returndata_len=exec_env.to_returndata_len,
         to_returndata=exec_env.to_returndata)
     let exec_env : ExecutionEnvironment* = &exec_env_
-    return (Uint256(1, 0))
-end
-
-func warp_static_call{
-        syscall_ptr : felt*, exec_env : ExecutionEnvironment*, memory_dict : DictAccess*,
-        range_check_ptr}(
-        gas : Uint256, address : Uint256, in : Uint256, insize : Uint256, out : Uint256,
-        outsize : Uint256) -> (success : Uint256):
-    return warp_call(gas, address, Uint256(0, 0), in, insize, out, outsize)
+    return (1)
 end
 
 func returndata_write{memory_dict : DictAccess*, exec_env : ExecutionEnvironment*, range_check_ptr}(
@@ -110,7 +102,7 @@ func returndata_write{memory_dict : DictAccess*, exec_env : ExecutionEnvironment
     alloc_locals
     let (__fp__, _) = get_fp_and_pc()
     let (returndata : felt*) = array_create_from_memory(returndata_ptr, returndata_size)
-    let (returndata_len) = calculate_data_len(returndata_size)
+    let (returndata_len) = ceil_div(returndata_size, 16)
     local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(
         calldata_size=exec_env.calldata_size,
         calldata_len=exec_env.calldata_len,

--- a/warp/yul/BuiltinHandler.py
+++ b/warp/yul/BuiltinHandler.py
@@ -467,15 +467,11 @@ class Gas(DynamicHandler):
         return super().get_function_call([])
 
 
-class Delegatecall(NotImplementedOp):
-    pass
-
-
 class Call(StaticHandler):
     def __init__(self):
         super().__init__(
             function_name="warp_call",
-            module="evm.calls",
+            module="evm.yul_api",
             used_implicits=(
                 "syscall_ptr",
                 "exec_env",
@@ -488,8 +484,22 @@ class Call(StaticHandler):
 class StaticCall(StaticHandler):
     def __init__(self):
         super().__init__(
-            function_name="warp_static_call",
-            module="evm.calls",
+            function_name="staticcall",
+            module="evm.yul_api",
+            used_implicits=(
+                "syscall_ptr",
+                "exec_env",
+                "memory_dict",
+                "range_check_ptr",
+            ),
+        )
+
+
+class Delegatecall(StaticHandler):
+    def __init__(self):
+        super().__init__(
+            function_name="delegatecall",
+            module="evm.yul_api",
             used_implicits=(
                 "syscall_ptr",
                 "exec_env",
@@ -626,7 +636,7 @@ def get_default_builtins(
         "coinbase": Coinbase(),
         "create": Create(),
         "create2": Create2(),
-        "delegatecall": Delegatecall(cairo_functions),
+        "delegatecall": Delegatecall(),
         "difficulty": Difficulty(),
         "div": Div(),
         "eq": Eq(),


### PR DESCRIPTION
The implementation abstracts from the concrete (usual or delegate)
     call function. It takes the call function as a parameter. This is
     unnecessary and will have to be reverted if/when functions for
     delegate and usual calls will differ in signature. The
     generalization was done as a fun exercise in low-level Cairo.

Adding a more complex test is complicated by some bugs in the way
     constructors are generated.