### PR TITLE
Implement a printer for the ast that returns a yul-like code

### DIFF
--- a/tests/ast/add-leaves.ast.result
+++ b/tests/ast/add-leaves.ast.result
@@ -1,50 +1,18 @@
-Block:
-	FunctionDefinition:
-		Name: funA
-		Parameters:
-			TypedName:
-				flag:Uint256
-		Return Variables:
-			TypedName:
-				res:Uint256
-		Body:
-			Block:
-				VariableDeclaration:
-					Variables:
-						TypedName:
-							var:Uint256
-					Value:
-						Literal:100
-				If:
-					Identifier:flag
-					Block:
-						Assignment:
-							Variables:
-								Identifier:res
-							Value:
-								Literal:1
-						Leave
-					Block:
-						Assignment:
-							Variables:
-								Identifier:res
-							Value:
-								Literal:0
-						Leave
-	FunctionDefinition:
-		Name: funB
-		Parameters:
-		Return Variables:
-		Body:
-			Block:
-				Leave
-	FunctionDefinition:
-		Name: funC
-		Parameters:
-		Return Variables:
-		Body:
-			Block:
-				ExpressionStatement:
-					FunctionCall:
-						Identifier:funB
-				Leave
+{
+	function funA(flag) -> res {
+		let var := 100
+		if flag {
+			res := 1
+			leave
+		}
+		else {
+			res := 0
+			leave
+		}
+	}
+	function funB() { leave }
+	function funC() {
+		funB()
+		leave
+	}
+}

--- a/tests/ast/cairo-keywords-for-names.ast.result
+++ b/tests/ast/cairo-keywords-for-names.ast.result
@@ -1,56 +1,10 @@
-Block:
-	FunctionDefinition:
-		Name: func__warp_mangled
-		Parameters:
-			TypedName:
-				felt__warp_mangled:Uint256
-			TypedName:
-				end__warp_mangled:Uint256
-		Return Variables:
-			TypedName:
-				jmp__warp_mangled:Uint256
-		Body:
-			Block:
-				VariableDeclaration:
-					Variables:
-						TypedName:
-							_1_7:Uint256
-					Value:
-						FunctionCall:
-							Identifier:iszero
-							Identifier:felt__warp_mangled
-				VariableDeclaration:
-					Variables:
-						TypedName:
-							_2_8:Uint256
-					Value:
-						FunctionCall:
-							Identifier:iszero
-							Identifier:_1_7
-				ExpressionStatement:
-					FunctionCall:
-						Identifier:require_helper
-						Identifier:_2_8
-				VariableDeclaration:
-					Variables:
-						TypedName:
-							_3_9:Uint256
-					Value:
-						Literal:100
-				VariableDeclaration:
-					Variables:
-						TypedName:
-							ret__warp_mangled:Uint256
-					Value:
-						FunctionCall:
-							Identifier:checked_add_uint256
-							Identifier:end__warp_mangled
-							Identifier:felt__warp_mangled
-				Assignment:
-					Variables:
-						Identifier:jmp__warp_mangled
-					Value:
-						FunctionCall:
-							Identifier:gt
-							Identifier:ret__warp_mangled
-							Identifier:_3_9
+{
+	function func__warp_mangled(felt__warp_mangled, end__warp_mangled) -> jmp__warp_mangled {
+		let _1_7 := iszero(felt__warp_mangled)
+		let _2_8 := iszero(_1_7)
+		require_helper(_2_8)
+		let _3_9 := 100
+		let ret__warp_mangled := checked_add_uint256(end__warp_mangled, felt__warp_mangled)
+		jmp__warp_mangled := gt(ret__warp_mangled, _3_9)
+	}
+}

--- a/tests/ast/expression-splitter.ast.result
+++ b/tests/ast/expression-splitter.ast.result
@@ -1,74 +1,11 @@
-Block:
-	FunctionDefinition:
-		Name: fun_power
-		Parameters:
-			TypedName:
-				base:Uint256
-			TypedName:
-				exponent:Uint256
-		Return Variables:
-			TypedName:
-				var:Uint256
-		Body:
-			Block:
-				VariableDeclaration:
-					Variables:
-						TypedName:
-							__warp_subexpr_1:Uint256
-					Value:
-						FunctionCall:
-							Identifier:div
-							Identifier:exponent
-							Literal:2
-				VariableDeclaration:
-					Variables:
-						TypedName:
-							__warp_subexpr_0:Uint256
-					Value:
-						FunctionCall:
-							Identifier:mul
-							Identifier:base
-							Identifier:base
-				VariableDeclaration:
-					Variables:
-						TypedName:
-							result:Uint256
-					Value:
-						FunctionCall:
-							Identifier:power
-							Identifier:__warp_subexpr_0
-							Identifier:__warp_subexpr_1
-				VariableDeclaration:
-					Variables:
-						TypedName:
-							__warp_subexpr_3:Uint256
-					Value:
-						FunctionCall:
-							Identifier:mod
-							Identifier:exponent
-							Literal:2
-				VariableDeclaration:
-					Variables:
-						TypedName:
-							__warp_subexpr_2:Uint256
-					Value:
-						FunctionCall:
-							Identifier:equal
-							Identifier:__warp_subexpr_3
-							Literal:1
-				If:
-					Identifier:__warp_subexpr_2
-					Block:
-						Assignment:
-							Variables:
-								Identifier:result
-							Value:
-								FunctionCall:
-									Identifier:mul
-									Identifier:base
-									Identifier:result
-				Assignment:
-					Variables:
-						Identifier:var
-					Value:
-						Identifier:result
+{
+	function fun_power(base, exponent) -> var {
+		let __warp_subexpr_1 := div(exponent, 2)
+		let __warp_subexpr_0 := mul(base, base)
+		let result := power(__warp_subexpr_0, __warp_subexpr_1)
+		let __warp_subexpr_3 := mod(exponent, 2)
+		let __warp_subexpr_2 := equal(__warp_subexpr_3, 1)
+		if __warp_subexpr_2 { result := mul(base, result) }
+		var := result
+	}
+}

--- a/tests/ast/functions-to-prune.ast.result
+++ b/tests/ast/functions-to-prune.ast.result
@@ -1,16 +1,4 @@
-Block:
-	FunctionDefinition:
-		Name: funD
-		Parameters:
-		Return Variables:
-		Body:
-			Block:
-	FunctionDefinition:
-		Name: fun_ENTRY_POINT
-		Parameters:
-		Return Variables:
-		Body:
-			Block:
-				ExpressionStatement:
-					FunctionCall:
-						Identifier:funD
+{
+	function funD() {  }
+	function fun_ENTRY_POINT() { funD() }
+}

--- a/tests/ast/ifs-to-flatten-scope.ast.result
+++ b/tests/ast/ifs-to-flatten-scope.ast.result
@@ -1,76 +1,13 @@
-Block:
-	FunctionDefinition:
-		Name: fun_transfer
-		Parameters:
-			TypedName:
-				sender:Uint256
-			TypedName:
-				recipient:Uint256
-			TypedName:
-				amount:Uint256
-		Return Variables:
-			TypedName:
-				res:Uint256
-		Body:
-			Block:
-				If:
-					FunctionCall:
-						Identifier:not
-						FunctionCall:
-							Identifier:equal
-							Identifier:sender
-							Identifier:recipient
-					Block:
-						If:
-							FunctionCall:
-								Identifier:not
-								FunctionCall:
-									Identifier:greater
-									Identifier:amount
-									Literal:0
-							Block:
-								ExpressionStatement:
-									FunctionCall:
-										Identifier:revert
-										Literal:0
-										Literal:0
-						Assignment:
-							Variables:
-								Identifier:res
-							Value:
-								FunctionCall:
-									Identifier:__warp_if_0
-									Identifier:amount
-					Block:
-						Assignment:
-							Variables:
-								Identifier:res
-							Value:
-								Literal:0
-	FunctionDefinition:
-		Name: __warp_if_0
-		Parameters:
-			TypedName:
-				amount:Uint256
-		Return Variables:
-			TypedName:
-				res:Uint256
-		Body:
-			Block:
-				If:
-					FunctionCall:
-						Identifier:greater
-						Identifier:amount
-						Literal:100
-					Block:
-						Assignment:
-							Variables:
-								Identifier:res
-							Value:
-								Literal:100
-					Block:
-						Assignment:
-							Variables:
-								Identifier:res
-							Value:
-								Identifier:amount
+{
+	function fun_transfer(sender, recipient, amount) -> res {
+		if not(equal(sender, recipient)) {
+			if not(greater(amount, 0)) { revert(0, 0) }
+			res := __warp_if_0(amount)
+		}
+		else { res := 0 }
+	}
+	function __warp_if_0(amount) -> res {
+		if greater(amount, 100) { res := 100 }
+		else { res := amount }
+	}
+}

--- a/tests/ast/multiple-for-loops.ast.result
+++ b/tests/ast/multiple-for-loops.ast.result
@@ -1,222 +1,32 @@
-Block:
-	FunctionDefinition:
-		Name: fun_transferFrom
-		Parameters:
-			TypedName:
-				var_i:Uint256
-			TypedName:
-				var_j:Uint256
-		Return Variables:
-			TypedName:
-				var:Uint256
-		Body:
-			Block:
-				VariableDeclaration:
-					Variables:
-						TypedName:
-							var_cant:Uint256
-					Value:
-						Literal:0
-				VariableDeclaration:
-					Variables:
-						TypedName:
-							var_k:Uint256
-					Value:
-						Identifier:var_cant
-				Block:
-					Block:
-						Assignment:
-							Variables:
-								Identifier:var_cant
-								Identifier:var_k
-							Value:
-								FunctionCall:
-									Identifier:__warp_loop_0
-									Identifier:var_cant
-									Identifier:var_i
-									Identifier:var_j
-									Identifier:var_k
-				VariableDeclaration:
-					Variables:
-						TypedName:
-							var_k_1:Uint256
-					Value:
-						Literal:0
-				Block:
-					Block:
-						Assignment:
-							Variables:
-								Identifier:var_cant
-								Identifier:var_k_1
-							Value:
-								FunctionCall:
-									Identifier:__warp_loop_1
-									Identifier:var_cant
-									Identifier:var_i
-									Identifier:var_j
-									Identifier:var_k_1
-				Assignment:
-					Variables:
-						Identifier:var
-					Value:
-						Identifier:var_cant
-	FunctionDefinition:
-		Name: __warp_loop_body_0
-		Parameters:
-			TypedName:
-				var_cant:Uint256
-			TypedName:
-				var_j:Uint256
-			TypedName:
-				var_k:Uint256
-		Return Variables:
-			TypedName:
-				var_cant:Uint256
-			TypedName:
-				var_k:Uint256
-		Body:
-			Block:
-				Assignment:
-					Variables:
-						Identifier:var_cant
-					Value:
-						FunctionCall:
-							Identifier:checked_add_uint256
-							Identifier:var_cant
-							Identifier:var_k
-				Assignment:
-					Variables:
-						Identifier:var_k
-					Value:
-						FunctionCall:
-							Identifier:checked_add_uint256
-							Identifier:var_k
-							Identifier:var_j
-	FunctionDefinition:
-		Name: __warp_loop_0
-		Parameters:
-			TypedName:
-				var_cant:Uint256
-			TypedName:
-				var_i:Uint256
-			TypedName:
-				var_j:Uint256
-			TypedName:
-				var_k:Uint256
-		Return Variables:
-			TypedName:
-				var_cant:Uint256
-			TypedName:
-				var_k:Uint256
-		Body:
-			Block:
-				If:
-					FunctionCall:
-						Identifier:iszero
-						FunctionCall:
-							Identifier:lt
-							Identifier:var_k
-							Identifier:var_i
-					Block:
-						Leave
-				Assignment:
-					Variables:
-						Identifier:var_cant
-						Identifier:var_k
-					Value:
-						FunctionCall:
-							Identifier:__warp_loop_body_0
-							Identifier:var_cant
-							Identifier:var_j
-							Identifier:var_k
-				Assignment:
-					Variables:
-						Identifier:var_cant
-						Identifier:var_k
-					Value:
-						FunctionCall:
-							Identifier:__warp_loop_0
-							Identifier:var_cant
-							Identifier:var_i
-							Identifier:var_j
-							Identifier:var_k
-	FunctionDefinition:
-		Name: __warp_loop_body_1
-		Parameters:
-			TypedName:
-				var_cant:Uint256
-			TypedName:
-				var_i:Uint256
-			TypedName:
-				var_k_1:Uint256
-		Return Variables:
-			TypedName:
-				var_cant:Uint256
-			TypedName:
-				var_k_1:Uint256
-		Body:
-			Block:
-				Assignment:
-					Variables:
-						Identifier:var_cant
-					Value:
-						FunctionCall:
-							Identifier:checked_add_uint256
-							Identifier:var_cant
-							Identifier:var_k_1
-				Assignment:
-					Variables:
-						Identifier:var_k_1
-					Value:
-						FunctionCall:
-							Identifier:checked_add_uint256
-							Identifier:var_k_1
-							Identifier:var_i
-	FunctionDefinition:
-		Name: __warp_loop_1
-		Parameters:
-			TypedName:
-				var_cant:Uint256
-			TypedName:
-				var_i:Uint256
-			TypedName:
-				var_j:Uint256
-			TypedName:
-				var_k_1:Uint256
-		Return Variables:
-			TypedName:
-				var_cant:Uint256
-			TypedName:
-				var_k_1:Uint256
-		Body:
-			Block:
-				If:
-					FunctionCall:
-						Identifier:iszero
-						FunctionCall:
-							Identifier:lt
-							Identifier:var_k_1
-							Identifier:var_j
-					Block:
-						Leave
-				Assignment:
-					Variables:
-						Identifier:var_cant
-						Identifier:var_k_1
-					Value:
-						FunctionCall:
-							Identifier:__warp_loop_body_1
-							Identifier:var_cant
-							Identifier:var_i
-							Identifier:var_k_1
-				Assignment:
-					Variables:
-						Identifier:var_cant
-						Identifier:var_k_1
-					Value:
-						FunctionCall:
-							Identifier:__warp_loop_1
-							Identifier:var_cant
-							Identifier:var_i
-							Identifier:var_j
-							Identifier:var_k_1
+{
+	function fun_transferFrom(var_i, var_j) -> var {
+		let var_cant := 0
+		let var_k := var_cant
+		{
+			{ var_cant, var_k := __warp_loop_0(var_cant, var_i, var_j, var_k) }
+		}
+		let var_k_1 := 0
+		{
+			{ var_cant, var_k_1 := __warp_loop_1(var_cant, var_i, var_j, var_k_1) }
+		}
+		var := var_cant
+	}
+	function __warp_loop_body_0(var_cant, var_j, var_k) -> var_cant, var_k {
+		var_cant := checked_add_uint256(var_cant, var_k)
+		var_k := checked_add_uint256(var_k, var_j)
+	}
+	function __warp_loop_0(var_cant, var_i, var_j, var_k) -> var_cant, var_k {
+		if iszero(lt(var_k, var_i)) { leave }
+		var_cant, var_k := __warp_loop_body_0(var_cant, var_j, var_k)
+		var_cant, var_k := __warp_loop_0(var_cant, var_i, var_j, var_k)
+	}
+	function __warp_loop_body_1(var_cant, var_i, var_k_1) -> var_cant, var_k_1 {
+		var_cant := checked_add_uint256(var_cant, var_k_1)
+		var_k_1 := checked_add_uint256(var_k_1, var_i)
+	}
+	function __warp_loop_1(var_cant, var_i, var_j, var_k_1) -> var_cant, var_k_1 {
+		if iszero(lt(var_k_1, var_j)) { leave }
+		var_cant, var_k_1 := __warp_loop_body_1(var_cant, var_i, var_k_1)
+		var_cant, var_k_1 := __warp_loop_1(var_cant, var_i, var_j, var_k_1)
+	}
+}

--- a/tests/ast/nested-for-loops.ast.result
+++ b/tests/ast/nested-for-loops.ast.result
@@ -1,349 +1,56 @@
-Block:
-	FunctionDefinition:
-		Name: fun_deposit
-		Parameters:
-		Return Variables:
-			TypedName:
-				var:Uint256
-		Body:
-			Block:
-				VariableDeclaration:
-					Variables:
-						TypedName:
-							var_amount:Uint256
-					Value:
-						Literal:0
-				VariableDeclaration:
-					Variables:
-						TypedName:
-							var_i:Uint256
-					Value:
-						Identifier:var_amount
-				Block:
-					Block:
-						Assignment:
-							Variables:
-								Identifier:var_amount
-								Identifier:var_i
-							Value:
-								FunctionCall:
-									Identifier:__warp_loop_0
-									Identifier:var_amount
-									Identifier:var_i
-				Assignment:
-					Variables:
-						Identifier:var
-					Value:
-						Identifier:var_amount
-	FunctionDefinition:
-		Name: __warp_loop_body_2
-		Parameters:
-			TypedName:
-				expr:Uint256
-			TypedName:
-				var_amount:Uint256
-			TypedName:
-				var_k:Uint256
-		Return Variables:
-			TypedName:
-				var_amount:Uint256
-			TypedName:
-				var_k:Uint256
-		Body:
-			Block:
-				VariableDeclaration:
-					Variables:
-						TypedName:
-							_4_26:Uint256
-					Value:
-						FunctionCall:
-							Identifier:checked_add_uint256
-							Identifier:expr
-							Identifier:var_k
-				Assignment:
-					Variables:
-						Identifier:var_amount
-					Value:
-						FunctionCall:
-							Identifier:checked_add_uint256
-							Identifier:var_amount
-							Identifier:_4_26
-				Assignment:
-					Variables:
-						Identifier:var_k
-					Value:
-						FunctionCall:
-							Identifier:increment_uint256
-							Identifier:var_k
-	FunctionDefinition:
-		Name: __warp_loop_2
-		Parameters:
-			TypedName:
-				expr:Uint256
-			TypedName:
-				var_amount:Uint256
-			TypedName:
-				var_k:Uint256
-		Return Variables:
-			TypedName:
-				var_amount:Uint256
-			TypedName:
-				var_k:Uint256
-		Body:
-			Block:
-				If:
-					FunctionCall:
-						Identifier:iszero
-						FunctionCall:
-							Identifier:iszero
-							FunctionCall:
-								Identifier:gt
-								Identifier:var_k
-								Literal:3
-					Block:
-						Leave
-				Assignment:
-					Variables:
-						Identifier:var_amount
-						Identifier:var_k
-					Value:
-						FunctionCall:
-							Identifier:__warp_loop_body_2
-							Identifier:expr
-							Identifier:var_amount
-							Identifier:var_k
-				Assignment:
-					Variables:
-						Identifier:var_amount
-						Identifier:var_k
-					Value:
-						FunctionCall:
-							Identifier:__warp_loop_2
-							Identifier:expr
-							Identifier:var_amount
-							Identifier:var_k
-	FunctionDefinition:
-		Name: __warp_loop_body_1
-		Parameters:
-			TypedName:
-				var_amount:Uint256
-			TypedName:
-				var_i:Uint256
-			TypedName:
-				var_j:Uint256
-		Return Variables:
-			TypedName:
-				var_amount:Uint256
-			TypedName:
-				var_j:Uint256
-		Body:
-			Block:
-				VariableDeclaration:
-					Variables:
-						TypedName:
-							expr:Uint256
-					Value:
-						FunctionCall:
-							Identifier:checked_mul_uint256
-							Identifier:var_i
-							Identifier:var_j
-				VariableDeclaration:
-					Variables:
-						TypedName:
-							var_k:Uint256
-					Value:
-						Literal:0
-				Block:
-					Block:
-						Assignment:
-							Variables:
-								Identifier:var_amount
-								Identifier:var_k
-							Value:
-								FunctionCall:
-									Identifier:__warp_loop_2
-									Identifier:expr
-									Identifier:var_amount
-									Identifier:var_k
-				Assignment:
-					Variables:
-						Identifier:var_j
-					Value:
-						FunctionCall:
-							Identifier:checked_add_uint256_278
-							Identifier:var_j
-	FunctionDefinition:
-		Name: __warp_loop_1
-		Parameters:
-			TypedName:
-				_1_23:Uint256
-			TypedName:
-				var_amount:Uint256
-			TypedName:
-				var_i:Uint256
-			TypedName:
-				var_j:Uint256
-		Return Variables:
-			TypedName:
-				var_amount:Uint256
-			TypedName:
-				var_j:Uint256
-		Body:
-			Block:
-				If:
-					FunctionCall:
-						Identifier:iszero
-						FunctionCall:
-							Identifier:lt
-							Identifier:var_j
-							Identifier:_1_23
-					Block:
-						Leave
-				Assignment:
-					Variables:
-						Identifier:var_amount
-						Identifier:var_j
-					Value:
-						FunctionCall:
-							Identifier:__warp_loop_body_1
-							Identifier:var_amount
-							Identifier:var_i
-							Identifier:var_j
-				Assignment:
-					Variables:
-						Identifier:var_amount
-						Identifier:var_j
-					Value:
-						FunctionCall:
-							Identifier:__warp_loop_1
-							Identifier:_1_23
-							Identifier:var_amount
-							Identifier:var_i
-							Identifier:var_j
-	FunctionDefinition:
-		Name: __warp_loop_body_0
-		Parameters:
-			TypedName:
-				__warp_break_0:Uint256
-			TypedName:
-				var_amount:Uint256
-			TypedName:
-				var_i:Uint256
-		Return Variables:
-			TypedName:
-				__warp_break_0:Uint256
-			TypedName:
-				var_amount:Uint256
-			TypedName:
-				var_i:Uint256
-		Body:
-			Block:
-				VariableDeclaration:
-					Variables:
-						TypedName:
-							_1_23:Uint256
-					Value:
-						Literal:10
-				VariableDeclaration:
-					Variables:
-						TypedName:
-							_2_24:Uint256
-					Value:
-						FunctionCall:
-							Identifier:lt
-							Identifier:var_i
-							Identifier:_1_23
-				VariableDeclaration:
-					Variables:
-						TypedName:
-							_3_25:Uint256
-					Value:
-						FunctionCall:
-							Identifier:iszero
-							Identifier:_2_24
-				If:
-					Identifier:_3_25
-					Block:
-						Block:
-							Assignment:
-								Variables:
-									Identifier:__warp_break_0
-								Value:
-									Literal:True
-							Leave
-				VariableDeclaration:
-					Variables:
-						TypedName:
-							var_j:Uint256
-					Value:
-						Identifier:var_i
-				Block:
-					Block:
-						Assignment:
-							Variables:
-								Identifier:var_amount
-								Identifier:var_j
-							Value:
-								FunctionCall:
-									Identifier:__warp_loop_1
-									Identifier:_1_23
-									Identifier:var_amount
-									Identifier:var_i
-									Identifier:var_j
-				Assignment:
-					Variables:
-						Identifier:var_i
-					Value:
-						FunctionCall:
-							Identifier:increment_uint256
-							Identifier:var_i
-	FunctionDefinition:
-		Name: __warp_loop_0
-		Parameters:
-			TypedName:
-				var_amount:Uint256
-			TypedName:
-				var_i:Uint256
-		Return Variables:
-			TypedName:
-				var_amount:Uint256
-			TypedName:
-				var_i:Uint256
-		Body:
-			Block:
-				VariableDeclaration:
-					Variables:
-						TypedName:
-							__warp_break_0:Uint256
-					Value:
-						Literal:False
-				If:
-					FunctionCall:
-						Identifier:iszero
-						Literal:1
-					Block:
-						Leave
-				Assignment:
-					Variables:
-						Identifier:__warp_break_0
-						Identifier:var_amount
-						Identifier:var_i
-					Value:
-						FunctionCall:
-							Identifier:__warp_loop_body_0
-							Identifier:__warp_break_0
-							Identifier:var_amount
-							Identifier:var_i
-				If:
-					Identifier:__warp_break_0
-					Block:
-						Leave
-				Assignment:
-					Variables:
-						Identifier:var_amount
-						Identifier:var_i
-					Value:
-						FunctionCall:
-							Identifier:__warp_loop_0
-							Identifier:var_amount
-							Identifier:var_i
+{
+	function fun_deposit() -> var {
+		let var_amount := 0
+		let var_i := var_amount
+		{
+			{ var_amount, var_i := __warp_loop_0(var_amount, var_i) }
+		}
+		var := var_amount
+	}
+	function __warp_loop_body_2(expr, var_amount, var_k) -> var_amount, var_k {
+		let _4_26 := checked_add_uint256(expr, var_k)
+		var_amount := checked_add_uint256(var_amount, _4_26)
+		var_k := increment_uint256(var_k)
+	}
+	function __warp_loop_2(expr, var_amount, var_k) -> var_amount, var_k {
+		if iszero(iszero(gt(var_k, 3))) { leave }
+		var_amount, var_k := __warp_loop_body_2(expr, var_amount, var_k)
+		var_amount, var_k := __warp_loop_2(expr, var_amount, var_k)
+	}
+	function __warp_loop_body_1(var_amount, var_i, var_j) -> var_amount, var_j {
+		let expr := checked_mul_uint256(var_i, var_j)
+		let var_k := 0
+		{
+			{ var_amount, var_k := __warp_loop_2(expr, var_amount, var_k) }
+		}
+		var_j := checked_add_uint256_278(var_j)
+	}
+	function __warp_loop_1(_1_23, var_amount, var_i, var_j) -> var_amount, var_j {
+		if iszero(lt(var_j, _1_23)) { leave }
+		var_amount, var_j := __warp_loop_body_1(var_amount, var_i, var_j)
+		var_amount, var_j := __warp_loop_1(_1_23, var_amount, var_i, var_j)
+	}
+	function __warp_loop_body_0(__warp_break_0, var_amount, var_i) -> __warp_break_0, var_amount, var_i {
+		let _1_23 := 10
+		let _2_24 := lt(var_i, _1_23)
+		let _3_25 := iszero(_2_24)
+		if _3_25 {
+			{
+				__warp_break_0 := True
+				leave
+			}
+		}
+		let var_j := var_i
+		{
+			{ var_amount, var_j := __warp_loop_1(_1_23, var_amount, var_i, var_j) }
+		}
+		var_i := increment_uint256(var_i)
+	}
+	function __warp_loop_0(var_amount, var_i) -> var_amount, var_i {
+		let __warp_break_0 := False
+		if iszero(1) { leave }
+		__warp_break_0, var_amount, var_i := __warp_loop_body_0(__warp_break_0, var_amount, var_i)
+		if __warp_break_0 { leave }
+		var_amount, var_i := __warp_loop_0(var_amount, var_i)
+	}
+}

--- a/tests/ast/revert-condition.ast.result
+++ b/tests/ast/revert-condition.ast.result
@@ -1,138 +1,22 @@
-Block:
-	FunctionDefinition:
-		Name: checked_sub_uint256
-		Parameters:
-			TypedName:
-				x:Uint256
-			TypedName:
-				y:Uint256
-		Return Variables:
-			TypedName:
-				diff:Uint256
-		Body:
-			Block:
-				VariableDeclaration:
-					Variables:
-						TypedName:
-							_1_5:Uint256
-					Value:
-						FunctionCall:
-							Identifier:lt
-							Identifier:x
-							Identifier:y
-				If:
-					Identifier:_1_5
-					Block:
-						ExpressionStatement:
-							FunctionCall:
-								Identifier:revert
-								Literal:0
-								Literal:0
-				Assignment:
-					Variables:
-						Identifier:diff
-					Value:
-						FunctionCall:
-							Identifier:sub
-							Identifier:x
-							Identifier:y
-	FunctionDefinition:
-		Name: require_helper
-		Parameters:
-			TypedName:
-				condition:Uint256
-		Return Variables:
-		Body:
-			Block:
-				VariableDeclaration:
-					Variables:
-						TypedName:
-							_1_17:Uint256
-					Value:
-						FunctionCall:
-							Identifier:iszero
-							Identifier:condition
-				If:
-					Identifier:_1_17
-					Block:
-						ExpressionStatement:
-							FunctionCall:
-								Identifier:revert
-								Literal:0
-								Literal:0
-	FunctionDefinition:
-		Name: fun_transfer
-		Parameters:
-			TypedName:
-				var_sender:Uint256
-			TypedName:
-				var_sender_balance:Uint256
-			TypedName:
-				var_recipient:Uint256
-			TypedName:
-				var_amount:Uint256
-		Return Variables:
-			TypedName:
-				var:Uint256
-		Body:
-			Block:
-				VariableDeclaration:
-					Variables:
-						TypedName:
-							_1_6:Uint256
-					Value:
-						FunctionCall:
-							Identifier:eq
-							Identifier:var_sender
-							Identifier:var_recipient
-				VariableDeclaration:
-					Variables:
-						TypedName:
-							_2_7:Uint256
-					Value:
-						FunctionCall:
-							Identifier:iszero
-							Identifier:_1_6
-				ExpressionStatement:
-					FunctionCall:
-						Identifier:require_helper
-						Identifier:_2_7
-				VariableDeclaration:
-					Variables:
-						TypedName:
-							_3_8:Uint256
-					Value:
-						FunctionCall:
-							Identifier:gt
-							Identifier:var_amount
-							Identifier:var_sender_balance
-				VariableDeclaration:
-					Variables:
-						TypedName:
-							_4_9:Uint256
-					Value:
-						FunctionCall:
-							Identifier:iszero
-							Identifier:_3_8
-				ExpressionStatement:
-					FunctionCall:
-						Identifier:require_helper
-						Identifier:_4_9
-				VariableDeclaration:
-					Variables:
-						TypedName:
-							_5_10:Uint256
-					Value:
-						FunctionCall:
-							Identifier:checked_sub_uint256
-							Identifier:var_sender_balance
-							Identifier:var_amount
-				ExpressionStatement:
-					FunctionCall:
-						Identifier:pop
-						Identifier:_5_10
-				Assignment:
-					Variables:
-						Identifier:var
-					Value:
-						Literal:1
+{
+	function checked_sub_uint256(x, y) -> diff {
+		let _1_5 := lt(x, y)
+		if _1_5 { revert(0, 0) }
+		diff := sub(x, y)
+	}
+	function require_helper(condition) {
+		let _1_17 := iszero(condition)
+		if _1_17 { revert(0, 0) }
+	}
+	function fun_transfer(var_sender, var_sender_balance, var_recipient, var_amount) -> var {
+		let _1_6 := eq(var_sender, var_recipient)
+		let _2_7 := iszero(_1_6)
+		require_helper(_2_7)
+		let _3_8 := gt(var_amount, var_sender_balance)
+		let _4_9 := iszero(_3_8)
+		require_helper(_4_9)
+		let _5_10 := checked_sub_uint256(var_sender_balance, var_amount)
+		pop(_5_10)
+		var := 1
+	}
+}

--- a/tests/ast/switch.ast.result
+++ b/tests/ast/switch.ast.result
@@ -1,83 +1,20 @@
-FunctionDefinition:
-	Name: power
-	Parameters:
-		TypedName:
-			base:Uint256
-		TypedName:
-			exponent:Uint256
-	Return Variables:
-		TypedName:
-			result:Uint256
-	Body:
-		Block:
-			Block:
-				VariableDeclaration:
-					Variables:
-						TypedName:
-							match_var:Uint256
-					Value:
-						Identifier:exponent
-				Block:
-					If:
-						FunctionCall:
-							Identifier:eq
-							Identifier:match_var
-							Literal:0
-						Block:
-							Assignment:
-								Variables:
-									Identifier:result
-								Value:
-									Literal:1
-						Block:
-							If:
-								FunctionCall:
-									Identifier:eq
-									Identifier:match_var
-									Literal:1
-								Block:
-									Assignment:
-										Variables:
-											Identifier:result
-										Value:
-											Identifier:base
-								Block:
-									Assignment:
-										Variables:
-											Identifier:result
-										Value:
-											FunctionCall:
-												Identifier:power
-												FunctionCall:
-													Identifier:mul
-													Identifier:base
-													Identifier:base
-												FunctionCall:
-													Identifier:div
-													Identifier:exponent
-													Literal:2
-									Block:
-										VariableDeclaration:
-											Variables:
-												TypedName:
-													match_var:Uint256
-											Value:
-												FunctionCall:
-													Identifier:mod
-													Identifier:exponent
-													Literal:2
-										Block:
-											If:
-												FunctionCall:
-													Identifier:eq
-													Identifier:match_var
-													Literal:1
-												Block:
-													Assignment:
-														Variables:
-															Identifier:result
-														Value:
-															FunctionCall:
-																Identifier:mul
-																Identifier:base
-																Identifier:result
+function power(base, exponent) -> result {
+	{
+		let match_var := exponent
+		{
+			if eq(match_var, 0) { result := 1 }
+			else {
+				if eq(match_var, 1) { result := base }
+				else {
+					result := power(mul(base, base), div(exponent, 2))
+					{
+						let match_var := mod(exponent, 2)
+						{
+							if eq(match_var, 1) { result := mul(base, result) }
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/tests/ast/switch_test.py
+++ b/tests/ast/switch_test.py
@@ -1,6 +1,5 @@
 import pytest
 from utils import check_ast
-from yul.AstTools import AstParser, AstPrinter
 from yul.SwitchToIfVisitor import SwitchToIfVisitor
 
 

--- a/tests/ast/utils.py
+++ b/tests/ast/utils.py
@@ -1,7 +1,7 @@
 import difflib
 import os
 
-from yul.AstTools import AstParser, AstPrinter
+from yul.AstTools import AstParser, YulPrinter
 
 
 def check_ast(file_path):
@@ -14,7 +14,7 @@ def check_ast(file_path):
             yul_ast = parser.parse_node()
             yul_ast = func(yul_ast)
 
-            generated_ast = AstPrinter().format(yul_ast)
+            generated_ast = YulPrinter().format(yul_ast)
             temp_file_path = f"{ast_file_path}.temp"
             with open(temp_file_path, "w") as temp_file:
                 temp_file.write(generated_ast)

--- a/warp/yul/AstTools.py
+++ b/warp/yul/AstTools.py
@@ -1,129 +1,11 @@
 from __future__ import annotations
 
 import re
-from typing import List, Optional
+from typing import List
 
 import yul.yul_ast as ast
 from yul.AstVisitor import AstVisitor
 from yul.WarpException import WarpException
-
-
-class AstPrinter(AstVisitor):
-    def format(self, node: ast.Node, tabs: int = 0) -> str:
-        res = self.visit(node, tabs)
-        return "\n".join(res)
-
-    def visit_typed_name(self, node: ast.TypedName, tabs: int) -> List(str):
-        node_type = "\t" * tabs + "TypedName:"
-        res = "\t" * (tabs + 1) + f"{node.name}:{node.type}"
-        return [node_type, res]
-
-    def visit_literal(self, node: ast.Literal, tabs: int) -> List(str):
-        return ["\t" * tabs + f"Literal:{node.value}"]
-
-    def visit_identifier(self, node: ast.Identifier, tabs: int) -> List(str):
-        return ["\t" * tabs + f"Identifier:{node.name}"]
-
-    def visit_assignment(self, node: ast.Assignment, tabs: int) -> List(str):
-        res = ["\t" * tabs + "Assignment:"]
-        res.append("\t" * (tabs + 1) + "Variables:")
-        for item in self.visit_list(node.variable_names, tabs + 2):
-            res.extend(item)
-        res.append("\t" * (tabs + 1) + "Value:")
-        res.extend(self.visit(node.value, tabs + 2))
-        return res
-
-    def visit_function_call(self, node: ast.FunctionCall, tabs: int) -> List(str):
-        res = ["\t" * tabs + "FunctionCall:"]
-        res.extend(self.visit(node.function_name, tabs + 1))
-        for item in self.visit_list(node.arguments, tabs + 1):
-            res.extend(item)
-        return res
-
-    def visit_expression_statement(
-        self, node: ast.ExpressionStatement, tabs: int
-    ) -> List(str):
-        res = ["\t" * tabs + "ExpressionStatement:"]
-        res.extend(self.visit(node.expression, tabs + 1))
-        return res
-
-    def visit_variable_declaration(
-        self, node: ast.VariableDeclaration, tabs: int
-    ) -> List(str):
-        res = ["\t" * tabs + "VariableDeclaration:"]
-        res.append("\t" * (tabs + 1) + "Variables:")
-        for item in self.visit_list(node.variables, tabs + 2):
-            res.extend(item)
-
-        if node.value is not None:
-            res.append("\t" * (tabs + 1) + "Value:")
-            res.extend(self.visit(node.value, tabs + 2))
-        else:
-            res.append("\t" * (tabs + 1) + "Value: None")
-
-        return res
-
-    def visit_block(self, node: ast.Block, tabs: int) -> List(str):
-        res = ["\t" * tabs + "Block:"]
-        for item in self.visit_list(node.statements, tabs + 1):
-            res.extend(item)
-        return res
-
-    def visit_function_definition(
-        self, node: ast.FunctionDefinition, tabs: int
-    ) -> List(str):
-        res = ["\t" * tabs + "FunctionDefinition:"]
-        res.append("\t" * (tabs + 1) + f"Name: {node.name}")
-        res.append("\t" * (tabs + 1) + "Parameters:")
-        for item in self.visit_list(node.parameters, tabs + 2):
-            res.extend(item)
-        res.append("\t" * (tabs + 1) + "Return Variables:")
-        for item in self.visit_list(node.return_variables, tabs + 2):
-            res.extend(item)
-        res.append("\t" * (tabs + 1) + "Body:")
-        res.extend(self.visit(node.body, tabs + 2))
-        return res
-
-    def visit_if(self, node: ast.If, tabs: int) -> List(str):
-        res = ["\t" * tabs + "If:"]
-        res.extend(self.visit(node.condition, tabs + 1))
-        res.extend(self.visit(node.body, tabs + 1))
-        if node.else_body is not None:
-            res.extend(self.visit(node.else_body, tabs + 1))
-        return res
-
-    def visit_case(self, node: ast.Case, tabs: int) -> List(str):
-        res = ["\t" * tabs + "Case:"]
-        if node.value is not None:
-            res.extend(self.visit(node.value, tabs + 1))
-        else:
-            res.append("\t" * (tabs + 1) + "Default")
-        res.extend(self.visit(node.body, tabs + 1))
-        return res
-
-    def visit_switch(self, node: ast.Switch, tabs: int) -> List(str):
-        res = ["\t" * tabs + "Switch:"]
-        res.extend(self.visit(node.expression, tabs + 1))
-        for item in self.visit_list(node.cases, tabs + 1):
-            res.extend(item)
-        return res
-
-    def visit_for_loop(self, node: ast.ForLoop, tabs: int) -> List(str):
-        res = ["\t" * tabs + "ForLoop:"]
-        res.extend(self.visit(node.pre, tabs + 1))
-        res.extend(self.visit(node.condition, tabs + 1))
-        res.extend(self.visit(node.post, tabs + 1))
-        res.extend(self.visit(node.body, tabs + 1))
-        return res
-
-    def visit_break(self, node: ast.Break, tabs: int) -> List(str):
-        return ["\t" * tabs + "Break"]
-
-    def visit_continue(self, node: ast.Continue, tabs: int) -> List(str):
-        return ["\t" * tabs + "Continue"]
-
-    def visit_leave(self, node: ast.Leave, tabs: int) -> List(str):
-        return ["\t" * tabs + "Leave"]
 
 
 class AstParser:
@@ -341,7 +223,7 @@ class AstParser:
         assert self.get_word(tabs) == "Leave", "This node should be of type Leave"
         self.pos += 1
 
-        return ast.LEAVE, pos
+        return ast.LEAVE
 
     def parse_node(self) -> ast.Node:
         tabs = self.get_tabs()
@@ -413,3 +295,121 @@ class AstParser:
     def get_name(self, name):
         name = "_".join(re.findall("[A-Z][^A-Z]*", name))
         return name.lower()
+
+
+class YulPrinter(AstVisitor):
+    def format(self, node: ast.Node, tabs: int = 0) -> str:
+        return self.visit(node, tabs)
+
+    def visit_typed_name(self, node: ast.TypedName, tabs: int = 0) -> str:
+        return f"{node.name}"
+
+    def visit_literal(self, node: ast.Literal, tabs: int = 0) -> str:
+        return f"{node.value}"
+
+    def visit_identifier(self, node: ast.Identifier, tabs: int = 0) -> str:
+        return f"{node.name}"
+
+    def visit_assignment(self, node: ast.Assignment, tabs: int = 0) -> str:
+        variables = ", ".join(self.visit_list(node.variable_names))
+        value = self.visit(node.value, 0)
+        return f"{variables} := {value}"
+
+    def visit_function_call(self, node: ast.FunctionCall, tabs: int = 0) -> str:
+        name = self.visit(node.function_name)
+        args = ", ".join(self.visit_list(node.arguments))
+        return f"{name}({args})"
+
+    def visit_expression_statement(
+        self, node: ast.ExpressionStatement, tabs: int = 0
+    ) -> str:
+        return self.visit(node.expression, tabs)
+
+    def visit_variable_declaration(
+        self, node: ast.VariableDeclaration, tabs: int = 0
+    ) -> str:
+        variables = ", ".join(self.visit_list(node.variables))
+
+        value = ""
+        if node.value is not None:
+            value = f" := {self.visit(node.value)}"
+
+        return f"let {variables}{value}"
+
+    def visit_block(self, node: ast.Block, tabs: int = 0) -> str:
+        open_block = "{"
+        close_block = "}"
+        if self.is_short(node.statements):
+            statements = "".join(self.visit_list(node.statements))
+            return " ".join([open_block, statements, close_block])
+
+        statements = self.visit_list(node.statements, tabs + 1)
+        statements = ["\t" * (tabs + 1) + stmt for stmt in statements]
+        statements = "\n".join(statements)
+        close_block = "\t" * tabs + close_block
+        res = "\n".join([open_block, statements, close_block])
+
+        return res
+
+    def visit_function_definition(
+        self, node: ast.FunctionDefinition, tabs: int = 0
+    ) -> str:
+        parameters = ", ".join(self.visit_list(node.parameters, 0))
+        ret_vars = ", ".join(self.visit_list(node.return_variables, 0))
+        body = self.visit(node.body, tabs)
+
+        res = f"function {node.name}({parameters})"
+        if len(node.return_variables) > 0:
+            res += f" -> {ret_vars}"
+        res += f" {body}"
+        return res
+
+    def visit_if(self, node: ast.If, tabs: int = 0) -> str:
+        res = f"if {self.visit(node.condition)} "
+        res += self.visit(node.body, tabs)
+        if node.else_body is not None:
+            res += "\n" + "\t" * tabs + "else "
+            res += self.visit(node.else_body, tabs)
+        return res
+
+    def visit_case(self, node: ast.Case, tabs: int = 0) -> str:
+        res = "\t" * tabs
+        if node.value is not None:
+            res += f"case {self.visit(node.value)} "
+        else:
+            res += "default "
+        res += self.visit(node.body, tabs)
+        return res
+
+    def visit_switch(self, node: ast.Switch, tabs: int = 0) -> str:
+        res = f"switch {self.visit(node.expression)}\n"
+        res += "\n".join(self.visit_list(node.cases, tabs))
+        return res
+
+    def visit_for_loop(self, node: ast.ForLoop, tabs: int = 0) -> str:
+        res = "for "
+        res += self.visit(node.pre, tabs)
+        res += f" {self.visit(node.condition)} "
+        res += self.visit(node.post, tabs)
+        res += f"\n{self.visit(node.body, tabs)}"
+        return res
+
+    def visit_break(self, node: ast.Break, tabs: int = 0) -> str:
+        return "break"
+
+    def visit_continue(self, node: ast.Continue, tabs: int = 0) -> str:
+        return "continue"
+
+    def visit_leave(self, node: ast.Leave, tabs: int = 0) -> str:
+        return "leave"
+
+    def is_short(self, stmts: tuple) -> bool:
+        if len(stmts) == 0:
+            return True
+        return len(stmts) == 1 and type(stmts[0]).__name__ not in [
+            "Block",
+            "FunctionDefinition",
+            "If",
+            "Switch",
+            "ForLoop",
+        ]


### PR DESCRIPTION
- The new printer for ast generates yul code, except for the `if` statements. Yul language does not support `else` branches, however our visitors generate them, therefore the printer outputs them. Also, type Uint256 is omitted from type annotations, since it is the default one.
- The `AstPrinter` was removed and test cases results were fixed according to the new format