### PR TITLE
add upper limit on the numpy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ eth-hash==0.2.0
 ecdsa
 fastecdsa
 sympy
+numpy<1.22
 pytest==6.2.4
 pytest-parallel
 pytest-check


### PR DESCRIPTION
numpy1.22 requires python3.8+