### PR TITLE
fix missing returns in the entry point function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,10 @@ test_bats: warp $(BATS_FILES) tests/cli/*.bats
 test_yul: warp
 	mkdir -p benchmark/stats
 	mkdir -p benchmark/tmp
+	python -m pytest tests/ast/ -v --tb=short --workers=auto $(ARGS)
 	python -m pytest scripts/yul/transpile_test.py -v --tb=short --workers=auto $(ARGS)
 	python -m pytest scripts/yul/compilation_test.py -v --tb=short --workers=auto $(ARGS)
 	python -m pytest tests/yul/ -v --tb=short --workers=auto $(ARGS)
-	python -m pytest tests/ast/ -v --tb=short --workers=auto $(ARGS)
 .PHONY: test_yul
 
 benchmark: warp

--- a/tests/ast/deployment-runtime-mix_test.py
+++ b/tests/ast/deployment-runtime-mix_test.py
@@ -24,9 +24,9 @@ def test_function_with_the_same_name_in_deployment_and_runtime():
     actual = YulPrinter().format(combined)
     expected = """
 {
-\tfunction constructor() { do_stuff_deployment() }
+\tfunction __constructor_meat() { do_stuff_deployment() }
 \tfunction do_stuff_deployment() {  }
-\tfunction fun_ENTRY_POINT() { do_stuff() }
+\tfunction __main_meat() { do_stuff() }
 \tfunction do_stuff() {  }
 }
 """

--- a/tests/ast/functions-to-prune.ast
+++ b/tests/ast/functions-to-prune.ast
@@ -6,7 +6,7 @@ Block:
 		Body:
 			Block:
 	FunctionDefinition:
-		Name: fun_ENTRY_POINT
+		Name: __main_meat
 		Parameters:
 		Return Variables:
 		Body:

--- a/tests/ast/functions-to-prune.ast.result
+++ b/tests/ast/functions-to-prune.ast.result
@@ -1,4 +1,4 @@
 {
 	function funD() {  }
-	function fun_ENTRY_POINT() { funD() }
+	function __main_meat() { funD() }
 }

--- a/tests/yul/ERC20.cairo
+++ b/tests/yul/ERC20.cairo
@@ -7,7 +7,6 @@ from evm.hashing import uint256_pedersen
 from evm.memory import uint256_mload, uint256_mstore
 from evm.uint256 import is_eq, is_gt, is_lt, is_zero, slt, u256_add, u256_shr
 from evm.yul_api import warp_return
-from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin, HashBuiltin
 from starkware.cairo.common.default_dict import default_dict_finalize, default_dict_new
 from starkware.cairo.common.dict_access import DictAccess
@@ -39,28 +38,50 @@ func evm_storage(arg0_low, arg0_high) -> (res : Uint256):
 end
 
 @constructor
-func constructor{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*):
+func constructor{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
+        calldata_size, calldata_len, calldata : felt*):
     alloc_locals
-    let termination_token = 0
-    let (returndata_ptr : felt*) = alloc()
+    let (memory_dict) = default_dict_new(0)
+    let memory_dict_start = memory_dict
+    let msize = 0
+    with memory_dict, msize:
+        __constructor_meat()
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return ()
+end
+
+@external
+func __main{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
+        calldata_size, calldata_len, calldata : felt*) -> (
+        returndata_size, returndata_len, returndata : felt*):
+    alloc_locals
     let (__fp__, _) = get_fp_and_pc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
+    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=cast(0, felt*), to_returndata_size=0, to_returndata_len=0, to_returndata=cast(0, felt*))
     let exec_env : ExecutionEnvironment* = &exec_env_
     let (memory_dict) = default_dict_new(0)
     let memory_dict_start = memory_dict
     let msize = 0
-    with memory_dict, msize, exec_env, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
-        if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-            assert 0 = 1
-            jmp rel 0
-        end
-        sstore(key=Uint256(low=1, high=0), value=Uint256(low=100000000000000, high=0))
-        return ()
+    let termination_token = 0
+    with exec_env, memory_dict, msize, termination_token:
+        __main_meat()
     end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
+end
+
+func __constructor_meat{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        syscall_ptr : felt*}() -> ():
+    alloc_locals
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
+    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
+    sstore(key=Uint256(low=1, high=0), value=Uint256(low=100000000000000, high=0))
+    return ()
 end
 
 func abi_decode{range_check_ptr}(dataEnd : Uint256) -> ():
@@ -589,31 +610,19 @@ func __warp_if_0{
     end
 end
 
-@external
-func fun_ENTRY_POINT{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*) -> (
-        returndata_size : felt, returndata_len : felt, returndata : felt*):
+func __main_meat{
+        exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize,
+        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*, termination_token}() -> (
+        ):
     alloc_locals
-    let termination_token = 0
-    let (__fp__, _) = get_fp_and_pc()
-    let (returndata_ptr : felt*) = alloc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
-    let exec_env = &exec_env_
-    let (memory_dict) = default_dict_new(0)
-    let memory_dict_start = memory_dict
-    let msize = 0
-    with exec_env, msize, memory_dict, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_2 : Uint256) = calldatasize()
-        let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
-        let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
-        __warp_if_0(__warp_subexpr_0)
-        if termination_token == 1:
-            default_dict_finalize(memory_dict_start, memory_dict, 0)
-            return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
-        end
-        assert 0 = 1
-        jmp rel 0
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_2 : Uint256) = calldatasize()
+    let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
+    let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
+    __warp_if_0(__warp_subexpr_0)
+    if termination_token == 1:
+        return ()
     end
+    assert 0 = 1
+    jmp rel 0
 end

--- a/tests/yul/ERC20_storage.cairo
+++ b/tests/yul/ERC20_storage.cairo
@@ -7,7 +7,6 @@ from evm.hashing import uint256_pedersen
 from evm.memory import uint256_mload, uint256_mstore
 from evm.uint256 import is_eq, is_gt, is_lt, is_zero, slt, u256_add, u256_shr
 from evm.yul_api import warp_return
-from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin, HashBuiltin
 from starkware.cairo.common.default_dict import default_dict_finalize, default_dict_new
 from starkware.cairo.common.dict_access import DictAccess
@@ -39,36 +38,58 @@ func evm_storage(arg0_low, arg0_high) -> (res : Uint256):
 end
 
 @constructor
-func constructor{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*):
+func constructor{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
+        calldata_size, calldata_len, calldata : felt*):
     alloc_locals
-    let termination_token = 0
-    let (returndata_ptr : felt*) = alloc()
+    let (memory_dict) = default_dict_new(0)
+    let memory_dict_start = memory_dict
+    let msize = 0
+    with memory_dict, msize:
+        __constructor_meat()
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return ()
+end
+
+@external
+func __main{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
+        calldata_size, calldata_len, calldata : felt*) -> (
+        returndata_size, returndata_len, returndata : felt*):
+    alloc_locals
     let (__fp__, _) = get_fp_and_pc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
+    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=cast(0, felt*), to_returndata_size=0, to_returndata_len=0, to_returndata=cast(0, felt*))
     let exec_env : ExecutionEnvironment* = &exec_env_
     let (memory_dict) = default_dict_new(0)
     let memory_dict_start = memory_dict
     let msize = 0
-    with memory_dict, msize, exec_env, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
-        if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-            assert 0 = 1
-            jmp rel 0
-        end
-        let (__warp_subexpr_3 : Uint256) = sload(Uint256(low=0, high=0))
-        let (__warp_subexpr_2 : Uint256) = uint256_and(
-            __warp_subexpr_3,
-            Uint256(low=340282366920938463463374607431768211200, high=340282366920938463463374607431768211455))
-        let (__warp_subexpr_1 : Uint256) = uint256_sub(__warp_subexpr_2, Uint256(low=18, high=0))
-        sstore(key=Uint256(low=0, high=0), value=__warp_subexpr_1)
-        sstore(
-            key=Uint256(low=1, high=0),
-            value=Uint256(low=100000000000000000000000000000000000, high=0))
-        return ()
+    let termination_token = 0
+    with exec_env, memory_dict, msize, termination_token:
+        __main_meat()
     end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
+end
+
+func __constructor_meat{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        syscall_ptr : felt*}() -> ():
+    alloc_locals
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
+    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
+    let (__warp_subexpr_3 : Uint256) = sload(Uint256(low=0, high=0))
+    let (__warp_subexpr_2 : Uint256) = uint256_and(
+        __warp_subexpr_3,
+        Uint256(low=340282366920938463463374607431768211200, high=340282366920938463463374607431768211455))
+    let (__warp_subexpr_1 : Uint256) = uint256_sub(__warp_subexpr_2, Uint256(low=18, high=0))
+    sstore(key=Uint256(low=0, high=0), value=__warp_subexpr_1)
+    sstore(
+        key=Uint256(low=1, high=0),
+        value=Uint256(low=100000000000000000000000000000000000, high=0))
+    return ()
 end
 
 func abi_decode{range_check_ptr}(dataEnd : Uint256) -> ():
@@ -598,31 +619,19 @@ func __warp_if_1{
     end
 end
 
-@external
-func fun_ENTRY_POINT{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*) -> (
-        returndata_size : felt, returndata_len : felt, returndata : felt*):
+func __main_meat{
+        exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize,
+        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*, termination_token}() -> (
+        ):
     alloc_locals
-    let termination_token = 0
-    let (__fp__, _) = get_fp_and_pc()
-    let (returndata_ptr : felt*) = alloc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
-    let exec_env = &exec_env_
-    let (memory_dict) = default_dict_new(0)
-    let memory_dict_start = memory_dict
-    let msize = 0
-    with exec_env, msize, memory_dict, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_2 : Uint256) = calldatasize()
-        let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
-        let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
-        __warp_if_1(__warp_subexpr_0)
-        if termination_token == 1:
-            default_dict_finalize(memory_dict_start, memory_dict, 0)
-            return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
-        end
-        assert 0 = 1
-        jmp rel 0
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_2 : Uint256) = calldatasize()
+    let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
+    let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
+    __warp_if_1(__warp_subexpr_0)
+    if termination_token == 1:
+        return ()
     end
+    assert 0 = 1
+    jmp rel 0
 end

--- a/tests/yul/address.cairo
+++ b/tests/yul/address.cairo
@@ -6,7 +6,6 @@ from evm.exec_env import ExecutionEnvironment
 from evm.memory import uint256_mstore
 from evm.uint256 import is_eq, is_lt, is_zero, slt, u256_add, u256_shr
 from evm.yul_api import address, warp_return
-from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin, HashBuiltin
 from starkware.cairo.common.default_dict import default_dict_finalize, default_dict_new
 from starkware.cairo.common.dict_access import DictAccess
@@ -18,27 +17,46 @@ func __warp_constant_0() -> (res : Uint256):
 end
 
 @constructor
-func constructor{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*):
+func constructor{range_check_ptr}(calldata_size, calldata_len, calldata : felt*):
     alloc_locals
-    let termination_token = 0
-    let (returndata_ptr : felt*) = alloc()
+    let (memory_dict) = default_dict_new(0)
+    let memory_dict_start = memory_dict
+    let msize = 0
+    with memory_dict, msize:
+        __constructor_meat()
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return ()
+end
+
+@external
+func __main{range_check_ptr, syscall_ptr : felt*}(
+        calldata_size, calldata_len, calldata : felt*) -> (
+        returndata_size, returndata_len, returndata : felt*):
+    alloc_locals
     let (__fp__, _) = get_fp_and_pc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
+    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=cast(0, felt*), to_returndata_size=0, to_returndata_len=0, to_returndata=cast(0, felt*))
     let exec_env : ExecutionEnvironment* = &exec_env_
     let (memory_dict) = default_dict_new(0)
     let memory_dict_start = memory_dict
     let msize = 0
-    with memory_dict, msize, exec_env, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
-        if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-            assert 0 = 1
-            jmp rel 0
-        else:
-            return ()
-        end
+    let termination_token = 0
+    with exec_env, memory_dict, msize, termination_token:
+        __main_meat()
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
+end
+
+func __constructor_meat{memory_dict : DictAccess*, msize, range_check_ptr}() -> ():
+    alloc_locals
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
+    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    else:
+        return ()
     end
 end
 
@@ -96,31 +114,18 @@ func __warp_if_0{
     end
 end
 
-@external
-func fun_ENTRY_POINT{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*) -> (
-        returndata_size : felt, returndata_len : felt, returndata : felt*):
+func __main_meat{
+        exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize, range_check_ptr,
+        syscall_ptr : felt*, termination_token}() -> ():
     alloc_locals
-    let termination_token = 0
-    let (__fp__, _) = get_fp_and_pc()
-    let (returndata_ptr : felt*) = alloc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
-    let exec_env = &exec_env_
-    let (memory_dict) = default_dict_new(0)
-    let memory_dict_start = memory_dict
-    let msize = 0
-    with exec_env, msize, memory_dict, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_2 : Uint256) = calldatasize()
-        let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
-        let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
-        __warp_if_0(__warp_subexpr_0)
-        if termination_token == 1:
-            default_dict_finalize(memory_dict_start, memory_dict, 0)
-            return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
-        end
-        assert 0 = 1
-        jmp rel 0
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_2 : Uint256) = calldatasize()
+    let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
+    let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
+    __warp_if_0(__warp_subexpr_0)
+    if termination_token == 1:
+        return ()
     end
+    assert 0 = 1
+    jmp rel 0
 end

--- a/tests/yul/arrays.cairo
+++ b/tests/yul/arrays.cairo
@@ -7,7 +7,6 @@ from evm.hashing import uint256_pedersen
 from evm.memory import uint256_mload, uint256_mstore
 from evm.uint256 import is_eq, is_lt, is_zero, slt, u256_add, u256_shl, u256_shr
 from evm.yul_api import warp_return
-from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin, HashBuiltin
 from starkware.cairo.common.default_dict import default_dict_finalize, default_dict_new
 from starkware.cairo.common.dict_access import DictAccess
@@ -35,27 +34,46 @@ func evm_storage(arg0_low, arg0_high) -> (res : Uint256):
 end
 
 @constructor
-func constructor{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*):
+func constructor{range_check_ptr}(calldata_size, calldata_len, calldata : felt*):
     alloc_locals
-    let termination_token = 0
-    let (returndata_ptr : felt*) = alloc()
+    let (memory_dict) = default_dict_new(0)
+    let memory_dict_start = memory_dict
+    let msize = 0
+    with memory_dict, msize:
+        __constructor_meat()
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return ()
+end
+
+@external
+func __main{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
+        calldata_size, calldata_len, calldata : felt*) -> (
+        returndata_size, returndata_len, returndata : felt*):
+    alloc_locals
     let (__fp__, _) = get_fp_and_pc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
+    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=cast(0, felt*), to_returndata_size=0, to_returndata_len=0, to_returndata=cast(0, felt*))
     let exec_env : ExecutionEnvironment* = &exec_env_
     let (memory_dict) = default_dict_new(0)
     let memory_dict_start = memory_dict
     let msize = 0
-    with memory_dict, msize, exec_env, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
-        if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-            assert 0 = 1
-            jmp rel 0
-        else:
-            return ()
-        end
+    let termination_token = 0
+    with exec_env, memory_dict, msize, termination_token:
+        __main_meat()
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
+end
+
+func __constructor_meat{memory_dict : DictAccess*, msize, range_check_ptr}() -> ():
+    alloc_locals
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
+    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    else:
+        return ()
     end
 end
 
@@ -239,31 +257,19 @@ func __warp_if_0{
     end
 end
 
-@external
-func fun_ENTRY_POINT{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*) -> (
-        returndata_size : felt, returndata_len : felt, returndata : felt*):
+func __main_meat{
+        exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize,
+        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*, termination_token}() -> (
+        ):
     alloc_locals
-    let termination_token = 0
-    let (__fp__, _) = get_fp_and_pc()
-    let (returndata_ptr : felt*) = alloc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
-    let exec_env = &exec_env_
-    let (memory_dict) = default_dict_new(0)
-    let memory_dict_start = memory_dict
-    let msize = 0
-    with exec_env, msize, memory_dict, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_2 : Uint256) = calldatasize()
-        let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
-        let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
-        __warp_if_0(__warp_subexpr_0)
-        if termination_token == 1:
-            default_dict_finalize(memory_dict_start, memory_dict, 0)
-            return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
-        end
-        assert 0 = 1
-        jmp rel 0
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_2 : Uint256) = calldatasize()
+    let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
+    let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
+    __warp_if_0(__warp_subexpr_0)
+    if termination_token == 1:
+        return ()
     end
+    assert 0 = 1
+    jmp rel 0
 end

--- a/tests/yul/c2c.cairo
+++ b/tests/yul/c2c.cairo
@@ -6,7 +6,6 @@ from evm.exec_env import ExecutionEnvironment
 from evm.memory import uint256_mload, uint256_mstore
 from evm.uint256 import is_eq, is_gt, is_lt, is_zero, slt, u256_add, u256_shr
 from evm.yul_api import warp_return
-from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin, HashBuiltin
 from starkware.cairo.common.default_dict import default_dict_finalize, default_dict_new
 from starkware.cairo.common.dict_access import DictAccess
@@ -26,27 +25,46 @@ func __warp_constant_10000000000000000000000000000000000000000() -> (res : Uint2
 end
 
 @constructor
-func constructor{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*):
+func constructor{range_check_ptr}(calldata_size, calldata_len, calldata : felt*):
     alloc_locals
-    let termination_token = 0
-    let (returndata_ptr : felt*) = alloc()
+    let (memory_dict) = default_dict_new(0)
+    let memory_dict_start = memory_dict
+    let msize = 0
+    with memory_dict, msize:
+        __constructor_meat()
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return ()
+end
+
+@external
+func __main{range_check_ptr, syscall_ptr : felt*}(
+        calldata_size, calldata_len, calldata : felt*) -> (
+        returndata_size, returndata_len, returndata : felt*):
+    alloc_locals
     let (__fp__, _) = get_fp_and_pc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
+    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=cast(0, felt*), to_returndata_size=0, to_returndata_len=0, to_returndata=cast(0, felt*))
     let exec_env : ExecutionEnvironment* = &exec_env_
     let (memory_dict) = default_dict_new(0)
     let memory_dict_start = memory_dict
     let msize = 0
-    with memory_dict, msize, exec_env, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
-        if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-            assert 0 = 1
-            jmp rel 0
-        else:
-            return ()
-        end
+    let termination_token = 0
+    with exec_env, memory_dict, msize, termination_token:
+        __main_meat()
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
+end
+
+func __constructor_meat{memory_dict : DictAccess*, msize, range_check_ptr}() -> ():
+    alloc_locals
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
+    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    else:
+        return ()
     end
 end
 
@@ -432,31 +450,18 @@ func __warp_if_3{
     end
 end
 
-@external
-func fun_ENTRY_POINT{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*) -> (
-        returndata_size : felt, returndata_len : felt, returndata : felt*):
+func __main_meat{
+        exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize, range_check_ptr,
+        syscall_ptr : felt*, termination_token}() -> ():
     alloc_locals
-    let termination_token = 0
-    let (__fp__, _) = get_fp_and_pc()
-    let (returndata_ptr : felt*) = alloc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
-    let exec_env = &exec_env_
-    let (memory_dict) = default_dict_new(0)
-    let memory_dict_start = memory_dict
-    let msize = 0
-    with exec_env, msize, memory_dict, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_2 : Uint256) = calldatasize()
-        let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
-        let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
-        __warp_if_3(__warp_subexpr_0)
-        if termination_token == 1:
-            default_dict_finalize(memory_dict_start, memory_dict, 0)
-            return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
-        end
-        assert 0 = 1
-        jmp rel 0
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_2 : Uint256) = calldatasize()
+    let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
+    let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
+    __warp_if_3(__warp_subexpr_0)
+    if termination_token == 1:
+        return ()
     end
+    assert 0 = 1
+    jmp rel 0
 end

--- a/tests/yul/calldatacopy.cairo
+++ b/tests/yul/calldatacopy.cairo
@@ -6,7 +6,6 @@ from evm.exec_env import ExecutionEnvironment
 from evm.memory import uint256_mstore
 from evm.uint256 import is_eq, is_lt, is_zero, slt, u256_add, u256_shr
 from evm.yul_api import warp_return
-from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin, HashBuiltin
 from starkware.cairo.common.default_dict import default_dict_finalize, default_dict_new
 from starkware.cairo.common.dict_access import DictAccess
@@ -18,27 +17,45 @@ func __warp_constant_0() -> (res : Uint256):
 end
 
 @constructor
-func constructor{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*):
+func constructor{range_check_ptr}(calldata_size, calldata_len, calldata : felt*):
     alloc_locals
-    let termination_token = 0
-    let (returndata_ptr : felt*) = alloc()
+    let (memory_dict) = default_dict_new(0)
+    let memory_dict_start = memory_dict
+    let msize = 0
+    with memory_dict, msize:
+        __constructor_meat()
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return ()
+end
+
+@external
+func __main{range_check_ptr}(calldata_size, calldata_len, calldata : felt*) -> (
+        returndata_size, returndata_len, returndata : felt*):
+    alloc_locals
     let (__fp__, _) = get_fp_and_pc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
+    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=cast(0, felt*), to_returndata_size=0, to_returndata_len=0, to_returndata=cast(0, felt*))
     let exec_env : ExecutionEnvironment* = &exec_env_
     let (memory_dict) = default_dict_new(0)
     let memory_dict_start = memory_dict
     let msize = 0
-    with memory_dict, msize, exec_env, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
-        if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-            assert 0 = 1
-            jmp rel 0
-        else:
-            return ()
-        end
+    let termination_token = 0
+    with exec_env, memory_dict, msize, termination_token:
+        __main_meat()
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
+end
+
+func __constructor_meat{memory_dict : DictAccess*, msize, range_check_ptr}() -> ():
+    alloc_locals
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
+    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    else:
+        return ()
     end
 end
 
@@ -95,31 +112,18 @@ func __warp_if_0{
     end
 end
 
-@external
-func fun_ENTRY_POINT{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*) -> (
-        returndata_size : felt, returndata_len : felt, returndata : felt*):
+func __main_meat{
+        exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize, range_check_ptr,
+        termination_token}() -> ():
     alloc_locals
-    let termination_token = 0
-    let (__fp__, _) = get_fp_and_pc()
-    let (returndata_ptr : felt*) = alloc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
-    let exec_env = &exec_env_
-    let (memory_dict) = default_dict_new(0)
-    let memory_dict_start = memory_dict
-    let msize = 0
-    with exec_env, msize, memory_dict, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_2 : Uint256) = calldatasize()
-        let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
-        let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
-        __warp_if_0(__warp_subexpr_0)
-        if termination_token == 1:
-            default_dict_finalize(memory_dict_start, memory_dict, 0)
-            return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
-        end
-        assert 0 = 1
-        jmp rel 0
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_2 : Uint256) = calldatasize()
+    let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
+    let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
+    __warp_if_0(__warp_subexpr_0)
+    if termination_token == 1:
+        return ()
     end
+    assert 0 = 1
+    jmp rel 0
 end

--- a/tests/yul/calldataload.cairo
+++ b/tests/yul/calldataload.cairo
@@ -6,7 +6,6 @@ from evm.exec_env import ExecutionEnvironment
 from evm.memory import uint256_mstore
 from evm.uint256 import is_eq, is_lt, is_zero, slt, u256_add, u256_shr
 from evm.yul_api import warp_return
-from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin, HashBuiltin
 from starkware.cairo.common.default_dict import default_dict_finalize, default_dict_new
 from starkware.cairo.common.dict_access import DictAccess
@@ -22,27 +21,45 @@ func returndata_size{exec_env : ExecutionEnvironment*}() -> (res : Uint256):
 end
 
 @constructor
-func constructor{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*):
+func constructor{range_check_ptr}(calldata_size, calldata_len, calldata : felt*):
     alloc_locals
-    let termination_token = 0
-    let (returndata_ptr : felt*) = alloc()
+    let (memory_dict) = default_dict_new(0)
+    let memory_dict_start = memory_dict
+    let msize = 0
+    with memory_dict, msize:
+        __constructor_meat()
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return ()
+end
+
+@external
+func __main{range_check_ptr}(calldata_size, calldata_len, calldata : felt*) -> (
+        returndata_size, returndata_len, returndata : felt*):
+    alloc_locals
     let (__fp__, _) = get_fp_and_pc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
+    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=cast(0, felt*), to_returndata_size=0, to_returndata_len=0, to_returndata=cast(0, felt*))
     let exec_env : ExecutionEnvironment* = &exec_env_
     let (memory_dict) = default_dict_new(0)
     let memory_dict_start = memory_dict
     let msize = 0
-    with memory_dict, msize, exec_env, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
-        if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-            assert 0 = 1
-            jmp rel 0
-        else:
-            return ()
-        end
+    let termination_token = 0
+    with exec_env, memory_dict, msize, termination_token:
+        __main_meat()
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
+end
+
+func __constructor_meat{memory_dict : DictAccess*, msize, range_check_ptr}() -> ():
+    alloc_locals
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
+    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    else:
+        return ()
     end
 end
 
@@ -104,31 +121,18 @@ func __warp_if_0{
     end
 end
 
-@external
-func fun_ENTRY_POINT{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*) -> (
-        returndata_size : felt, returndata_len : felt, returndata : felt*):
+func __main_meat{
+        exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize, range_check_ptr,
+        termination_token}() -> ():
     alloc_locals
-    let termination_token = 0
-    let (__fp__, _) = get_fp_and_pc()
-    let (returndata_ptr : felt*) = alloc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
-    let exec_env = &exec_env_
-    let (memory_dict) = default_dict_new(0)
-    let memory_dict_start = memory_dict
-    let msize = 0
-    with exec_env, msize, memory_dict, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_2 : Uint256) = calldatasize()
-        let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
-        let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
-        __warp_if_0(__warp_subexpr_0)
-        if termination_token == 1:
-            default_dict_finalize(memory_dict_start, memory_dict, 0)
-            return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
-        end
-        assert 0 = 1
-        jmp rel 0
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_2 : Uint256) = calldatasize()
+    let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
+    let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
+    __warp_if_0(__warp_subexpr_0)
+    if termination_token == 1:
+        return ()
     end
+    assert 0 = 1
+    jmp rel 0
 end

--- a/tests/yul/calldatasize.cairo
+++ b/tests/yul/calldatasize.cairo
@@ -6,7 +6,6 @@ from evm.exec_env import ExecutionEnvironment
 from evm.memory import uint256_mstore
 from evm.uint256 import is_eq, is_lt, is_zero, slt, u256_add, u256_shr
 from evm.yul_api import warp_return
-from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin, HashBuiltin
 from starkware.cairo.common.default_dict import default_dict_finalize, default_dict_new
 from starkware.cairo.common.dict_access import DictAccess
@@ -18,27 +17,45 @@ func __warp_constant_0() -> (res : Uint256):
 end
 
 @constructor
-func constructor{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*):
+func constructor{range_check_ptr}(calldata_size, calldata_len, calldata : felt*):
     alloc_locals
-    let termination_token = 0
-    let (returndata_ptr : felt*) = alloc()
+    let (memory_dict) = default_dict_new(0)
+    let memory_dict_start = memory_dict
+    let msize = 0
+    with memory_dict, msize:
+        __constructor_meat()
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return ()
+end
+
+@external
+func __main{range_check_ptr}(calldata_size, calldata_len, calldata : felt*) -> (
+        returndata_size, returndata_len, returndata : felt*):
+    alloc_locals
     let (__fp__, _) = get_fp_and_pc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
+    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=cast(0, felt*), to_returndata_size=0, to_returndata_len=0, to_returndata=cast(0, felt*))
     let exec_env : ExecutionEnvironment* = &exec_env_
     let (memory_dict) = default_dict_new(0)
     let memory_dict_start = memory_dict
     let msize = 0
-    with memory_dict, msize, exec_env, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
-        if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-            assert 0 = 1
-            jmp rel 0
-        else:
-            return ()
-        end
+    let termination_token = 0
+    with exec_env, memory_dict, msize, termination_token:
+        __main_meat()
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
+end
+
+func __constructor_meat{memory_dict : DictAccess*, msize, range_check_ptr}() -> ():
+    alloc_locals
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
+    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    else:
+        return ()
     end
 end
 
@@ -100,31 +117,18 @@ func __warp_if_0{
     end
 end
 
-@external
-func fun_ENTRY_POINT{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*) -> (
-        returndata_size : felt, returndata_len : felt, returndata : felt*):
+func __main_meat{
+        exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize, range_check_ptr,
+        termination_token}() -> ():
     alloc_locals
-    let termination_token = 0
-    let (__fp__, _) = get_fp_and_pc()
-    let (returndata_ptr : felt*) = alloc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
-    let exec_env = &exec_env_
-    let (memory_dict) = default_dict_new(0)
-    let memory_dict_start = memory_dict
-    let msize = 0
-    with exec_env, msize, memory_dict, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_2 : Uint256) = calldatasize()
-        let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
-        let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
-        __warp_if_0(__warp_subexpr_0)
-        if termination_token == 1:
-            default_dict_finalize(memory_dict_start, memory_dict, 0)
-            return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
-        end
-        assert 0 = 1
-        jmp rel 0
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_2 : Uint256) = calldatasize()
+    let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
+    let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
+    __warp_if_0(__warp_subexpr_0)
+    if termination_token == 1:
+        return ()
     end
+    assert 0 = 1
+    jmp rel 0
 end

--- a/tests/yul/constructors_dyn.cairo
+++ b/tests/yul/constructors_dyn.cairo
@@ -6,7 +6,6 @@ from evm.exec_env import ExecutionEnvironment
 from evm.memory import uint256_mload, uint256_mstore
 from evm.uint256 import is_eq, is_lt, is_zero, slt, u256_add, u256_shr
 from evm.yul_api import warp_return
-from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin, HashBuiltin
 from starkware.cairo.common.default_dict import default_dict_finalize, default_dict_new
 from starkware.cairo.common.dict_access import DictAccess
@@ -34,52 +33,77 @@ func evm_storage(arg0_low, arg0_high) -> (res : Uint256):
 end
 
 @constructor
-func constructor{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*):
+func constructor{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
+        calldata_size, calldata_len, calldata : felt*):
     alloc_locals
-    let termination_token = 0
-    let (returndata_ptr : felt*) = alloc()
     let (__fp__, _) = get_fp_and_pc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
+    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=cast(0, felt*), to_returndata_size=0, to_returndata_len=0, to_returndata=cast(0, felt*))
     let exec_env : ExecutionEnvironment* = &exec_env_
     let (memory_dict) = default_dict_new(0)
     let memory_dict_start = memory_dict
     let msize = 0
-    with memory_dict, msize, exec_env, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
-        if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-            assert 0 = 1
-            jmp rel 0
-        end
-        let (__warp_subexpr_2 : Uint256) = calldatasize()
-        let (__warp_subexpr_1 : Uint256) = slt(__warp_subexpr_2, Uint256(low=128, high=0))
-        if __warp_subexpr_1.low + __warp_subexpr_1.high != 0:
-            assert 0 = 1
-            jmp rel 0
-        end
-        let (__warp_subexpr_5 : Uint256) = calldatasize()
-        let (__warp_subexpr_4 : Uint256) = u256_add(
-            __warp_subexpr_5,
-            Uint256(low=340282366920938463463374607431768211424, high=340282366920938463463374607431768211455))
-        let (__warp_subexpr_3 : Uint256) = slt(__warp_subexpr_4, Uint256(low=64, high=0))
-        if __warp_subexpr_3.low + __warp_subexpr_3.high != 0:
-            assert 0 = 1
-            jmp rel 0
-        end
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=192, high=0))
-        let (_1 : Uint256) = calldataload(Uint256(low=32, high=0))
-        uint256_mstore(offset=Uint256(low=128, high=0), value=_1)
-        let (__warp_subexpr_6 : Uint256) = calldataload(Uint256(low=64, high=0))
-        uint256_mstore(offset=Uint256(low=160, high=0), value=__warp_subexpr_6)
-        let (__warp_subexpr_7 : Uint256) = calldataload(Uint256(low=0, high=0))
-        sstore(key=Uint256(low=0, high=0), value=__warp_subexpr_7)
-        sstore(key=Uint256(low=1, high=0), value=_1)
-        let (__warp_subexpr_8 : Uint256) = calldataload(Uint256(low=96, high=0))
-        sstore(key=Uint256(low=2, high=0), value=__warp_subexpr_8)
-        return ()
+    with exec_env, memory_dict, msize:
+        __constructor_meat()
     end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return ()
+end
+
+@external
+func __main{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
+        calldata_size, calldata_len, calldata : felt*) -> (
+        returndata_size, returndata_len, returndata : felt*):
+    alloc_locals
+    let (__fp__, _) = get_fp_and_pc()
+    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=cast(0, felt*), to_returndata_size=0, to_returndata_len=0, to_returndata=cast(0, felt*))
+    let exec_env : ExecutionEnvironment* = &exec_env_
+    let (memory_dict) = default_dict_new(0)
+    let memory_dict_start = memory_dict
+    let msize = 0
+    let termination_token = 0
+    with exec_env, memory_dict, msize, termination_token:
+        __main_meat()
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
+end
+
+func __constructor_meat{
+        exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize,
+        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}() -> ():
+    alloc_locals
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
+    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
+    let (__warp_subexpr_2 : Uint256) = calldatasize()
+    let (__warp_subexpr_1 : Uint256) = slt(__warp_subexpr_2, Uint256(low=128, high=0))
+    if __warp_subexpr_1.low + __warp_subexpr_1.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
+    let (__warp_subexpr_5 : Uint256) = calldatasize()
+    let (__warp_subexpr_4 : Uint256) = u256_add(
+        __warp_subexpr_5,
+        Uint256(low=340282366920938463463374607431768211424, high=340282366920938463463374607431768211455))
+    let (__warp_subexpr_3 : Uint256) = slt(__warp_subexpr_4, Uint256(low=64, high=0))
+    if __warp_subexpr_3.low + __warp_subexpr_3.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=192, high=0))
+    let (_1 : Uint256) = calldataload(Uint256(low=32, high=0))
+    uint256_mstore(offset=Uint256(low=128, high=0), value=_1)
+    let (__warp_subexpr_6 : Uint256) = calldataload(Uint256(low=64, high=0))
+    uint256_mstore(offset=Uint256(low=160, high=0), value=__warp_subexpr_6)
+    let (__warp_subexpr_7 : Uint256) = calldataload(Uint256(low=0, high=0))
+    sstore(key=Uint256(low=0, high=0), value=__warp_subexpr_7)
+    sstore(key=Uint256(low=1, high=0), value=_1)
+    let (__warp_subexpr_8 : Uint256) = calldataload(Uint256(low=96, high=0))
+    sstore(key=Uint256(low=2, high=0), value=__warp_subexpr_8)
+    return ()
 end
 
 func abi_decode_addresst_struct_Person_calldatat_uint256{
@@ -377,31 +401,19 @@ func __warp_if_2{
     end
 end
 
-@external
-func fun_ENTRY_POINT{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*) -> (
-        returndata_size : felt, returndata_len : felt, returndata : felt*):
+func __main_meat{
+        exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize,
+        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*, termination_token}() -> (
+        ):
     alloc_locals
-    let termination_token = 0
-    let (__fp__, _) = get_fp_and_pc()
-    let (returndata_ptr : felt*) = alloc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
-    let exec_env = &exec_env_
-    let (memory_dict) = default_dict_new(0)
-    let memory_dict_start = memory_dict
-    let msize = 0
-    with exec_env, msize, memory_dict, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_2 : Uint256) = calldatasize()
-        let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
-        let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
-        __warp_if_2(__warp_subexpr_0)
-        if termination_token == 1:
-            default_dict_finalize(memory_dict_start, memory_dict, 0)
-            return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
-        end
-        assert 0 = 1
-        jmp rel 0
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_2 : Uint256) = calldatasize()
+    let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
+    let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
+    __warp_if_2(__warp_subexpr_0)
+    if termination_token == 1:
+        return ()
     end
+    assert 0 = 1
+    jmp rel 0
 end

--- a/tests/yul/constructors_nonDyn.cairo
+++ b/tests/yul/constructors_nonDyn.cairo
@@ -6,7 +6,6 @@ from evm.exec_env import ExecutionEnvironment
 from evm.memory import uint256_mload, uint256_mstore
 from evm.uint256 import is_eq, is_lt, is_zero, slt, u256_add, u256_shr
 from evm.yul_api import warp_return
-from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin, HashBuiltin
 from starkware.cairo.common.default_dict import default_dict_finalize, default_dict_new
 from starkware.cairo.common.dict_access import DictAccess
@@ -34,39 +33,64 @@ func evm_storage(arg0_low, arg0_high) -> (res : Uint256):
 end
 
 @constructor
-func constructor{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*):
+func constructor{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
+        calldata_size, calldata_len, calldata : felt*):
     alloc_locals
-    let termination_token = 0
-    let (returndata_ptr : felt*) = alloc()
     let (__fp__, _) = get_fp_and_pc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
+    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=cast(0, felt*), to_returndata_size=0, to_returndata_len=0, to_returndata=cast(0, felt*))
     let exec_env : ExecutionEnvironment* = &exec_env_
     let (memory_dict) = default_dict_new(0)
     let memory_dict_start = memory_dict
     let msize = 0
-    with memory_dict, msize, exec_env, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
-        if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-            assert 0 = 1
-            jmp rel 0
-        end
-        let (__warp_subexpr_2 : Uint256) = calldatasize()
-        let (__warp_subexpr_1 : Uint256) = slt(__warp_subexpr_2, Uint256(low=96, high=0))
-        if __warp_subexpr_1.low + __warp_subexpr_1.high != 0:
-            assert 0 = 1
-            jmp rel 0
-        end
-        let (__warp_subexpr_3 : Uint256) = calldataload(Uint256(low=0, high=0))
-        sstore(key=Uint256(low=0, high=0), value=__warp_subexpr_3)
-        let (__warp_subexpr_4 : Uint256) = calldataload(Uint256(low=32, high=0))
-        sstore(key=Uint256(low=1, high=0), value=__warp_subexpr_4)
-        let (__warp_subexpr_5 : Uint256) = calldataload(Uint256(low=64, high=0))
-        sstore(key=Uint256(low=2, high=0), value=__warp_subexpr_5)
-        return ()
+    with exec_env, memory_dict, msize:
+        __constructor_meat()
     end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return ()
+end
+
+@external
+func __main{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
+        calldata_size, calldata_len, calldata : felt*) -> (
+        returndata_size, returndata_len, returndata : felt*):
+    alloc_locals
+    let (__fp__, _) = get_fp_and_pc()
+    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=cast(0, felt*), to_returndata_size=0, to_returndata_len=0, to_returndata=cast(0, felt*))
+    let exec_env : ExecutionEnvironment* = &exec_env_
+    let (memory_dict) = default_dict_new(0)
+    let memory_dict_start = memory_dict
+    let msize = 0
+    let termination_token = 0
+    with exec_env, memory_dict, msize, termination_token:
+        __main_meat()
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
+end
+
+func __constructor_meat{
+        exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize,
+        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}() -> ():
+    alloc_locals
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
+    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
+    let (__warp_subexpr_2 : Uint256) = calldatasize()
+    let (__warp_subexpr_1 : Uint256) = slt(__warp_subexpr_2, Uint256(low=96, high=0))
+    if __warp_subexpr_1.low + __warp_subexpr_1.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    end
+    let (__warp_subexpr_3 : Uint256) = calldataload(Uint256(low=0, high=0))
+    sstore(key=Uint256(low=0, high=0), value=__warp_subexpr_3)
+    let (__warp_subexpr_4 : Uint256) = calldataload(Uint256(low=32, high=0))
+    sstore(key=Uint256(low=1, high=0), value=__warp_subexpr_4)
+    let (__warp_subexpr_5 : Uint256) = calldataload(Uint256(low=64, high=0))
+    sstore(key=Uint256(low=2, high=0), value=__warp_subexpr_5)
+    return ()
 end
 
 func abi_decode{range_check_ptr}(dataEnd : Uint256) -> ():
@@ -358,31 +382,19 @@ func __warp_if_2{
     end
 end
 
-@external
-func fun_ENTRY_POINT{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*) -> (
-        returndata_size : felt, returndata_len : felt, returndata : felt*):
+func __main_meat{
+        exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize,
+        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*, termination_token}() -> (
+        ):
     alloc_locals
-    let termination_token = 0
-    let (__fp__, _) = get_fp_and_pc()
-    let (returndata_ptr : felt*) = alloc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
-    let exec_env = &exec_env_
-    let (memory_dict) = default_dict_new(0)
-    let memory_dict_start = memory_dict
-    let msize = 0
-    with exec_env, msize, memory_dict, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_2 : Uint256) = calldatasize()
-        let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
-        let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
-        __warp_if_2(__warp_subexpr_0)
-        if termination_token == 1:
-            default_dict_finalize(memory_dict_start, memory_dict, 0)
-            return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
-        end
-        assert 0 = 1
-        jmp rel 0
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_2 : Uint256) = calldatasize()
+    let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
+    let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
+    __warp_if_2(__warp_subexpr_0)
+    if termination_token == 1:
+        return ()
     end
+    assert 0 = 1
+    jmp rel 0
 end

--- a/tests/yul/ctor-check.sol
+++ b/tests/yul/ctor-check.sol
@@ -1,0 +1,23 @@
+pragma solidity ^0.8.3;
+
+contract Lib {
+    address public owner;
+
+    function pwn() public {
+        owner = msg.sender;
+    }
+}
+
+contract WARP {
+    address public owner;
+    Lib public lib;
+
+    constructor(Lib _lib) {
+        owner = msg.sender;
+        lib = Lib(_lib);
+    }
+
+    fallback() external payable {
+        address(lib).call(msg.data);
+    }
+}

--- a/tests/yul/for-loop-with-break.cairo
+++ b/tests/yul/for-loop-with-break.cairo
@@ -6,7 +6,6 @@ from evm.exec_env import ExecutionEnvironment
 from evm.memory import uint256_mload, uint256_mstore
 from evm.uint256 import is_eq, is_gt, is_lt, is_zero, slt, u256_add, u256_shr
 from evm.yul_api import warp_return
-from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin, HashBuiltin
 from starkware.cairo.common.default_dict import default_dict_finalize, default_dict_new
 from starkware.cairo.common.dict_access import DictAccess
@@ -18,27 +17,45 @@ func __warp_constant_0() -> (res : Uint256):
 end
 
 @constructor
-func constructor{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*):
+func constructor{range_check_ptr}(calldata_size, calldata_len, calldata : felt*):
     alloc_locals
-    let termination_token = 0
-    let (returndata_ptr : felt*) = alloc()
+    let (memory_dict) = default_dict_new(0)
+    let memory_dict_start = memory_dict
+    let msize = 0
+    with memory_dict, msize:
+        __constructor_meat()
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return ()
+end
+
+@external
+func __main{range_check_ptr}(calldata_size, calldata_len, calldata : felt*) -> (
+        returndata_size, returndata_len, returndata : felt*):
+    alloc_locals
     let (__fp__, _) = get_fp_and_pc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
+    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=cast(0, felt*), to_returndata_size=0, to_returndata_len=0, to_returndata=cast(0, felt*))
     let exec_env : ExecutionEnvironment* = &exec_env_
     let (memory_dict) = default_dict_new(0)
     let memory_dict_start = memory_dict
     let msize = 0
-    with memory_dict, msize, exec_env, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
-        if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-            assert 0 = 1
-            jmp rel 0
-        else:
-            return ()
-        end
+    let termination_token = 0
+    with exec_env, memory_dict, msize, termination_token:
+        __main_meat()
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
+end
+
+func __constructor_meat{memory_dict : DictAccess*, msize, range_check_ptr}() -> ():
+    alloc_locals
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
+    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    else:
+        return ()
     end
 end
 
@@ -150,31 +167,18 @@ func __warp_if_0{
     end
 end
 
-@external
-func fun_ENTRY_POINT{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*) -> (
-        returndata_size : felt, returndata_len : felt, returndata : felt*):
+func __main_meat{
+        exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize, range_check_ptr,
+        termination_token}() -> ():
     alloc_locals
-    let termination_token = 0
-    let (__fp__, _) = get_fp_and_pc()
-    let (returndata_ptr : felt*) = alloc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
-    let exec_env = &exec_env_
-    let (memory_dict) = default_dict_new(0)
-    let memory_dict_start = memory_dict
-    let msize = 0
-    with exec_env, msize, memory_dict, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_2 : Uint256) = calldatasize()
-        let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
-        let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
-        __warp_if_0(__warp_subexpr_0)
-        if termination_token == 1:
-            default_dict_finalize(memory_dict_start, memory_dict, 0)
-            return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
-        end
-        assert 0 = 1
-        jmp rel 0
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_2 : Uint256) = calldatasize()
+    let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
+    let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
+    __warp_if_0(__warp_subexpr_0)
+    if termination_token == 1:
+        return ()
     end
+    assert 0 = 1
+    jmp rel 0
 end

--- a/tests/yul/for-loop-with-continue.cairo
+++ b/tests/yul/for-loop-with-continue.cairo
@@ -6,7 +6,6 @@ from evm.exec_env import ExecutionEnvironment
 from evm.memory import uint256_mload, uint256_mstore
 from evm.uint256 import is_eq, is_gt, is_lt, is_zero, slt, u256_add, u256_shr
 from evm.yul_api import warp_return
-from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin, HashBuiltin
 from starkware.cairo.common.default_dict import default_dict_finalize, default_dict_new
 from starkware.cairo.common.dict_access import DictAccess
@@ -18,27 +17,45 @@ func __warp_constant_0() -> (res : Uint256):
 end
 
 @constructor
-func constructor{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*):
+func constructor{range_check_ptr}(calldata_size, calldata_len, calldata : felt*):
     alloc_locals
-    let termination_token = 0
-    let (returndata_ptr : felt*) = alloc()
+    let (memory_dict) = default_dict_new(0)
+    let memory_dict_start = memory_dict
+    let msize = 0
+    with memory_dict, msize:
+        __constructor_meat()
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return ()
+end
+
+@external
+func __main{range_check_ptr}(calldata_size, calldata_len, calldata : felt*) -> (
+        returndata_size, returndata_len, returndata : felt*):
+    alloc_locals
     let (__fp__, _) = get_fp_and_pc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
+    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=cast(0, felt*), to_returndata_size=0, to_returndata_len=0, to_returndata=cast(0, felt*))
     let exec_env : ExecutionEnvironment* = &exec_env_
     let (memory_dict) = default_dict_new(0)
     let memory_dict_start = memory_dict
     let msize = 0
-    with memory_dict, msize, exec_env, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
-        if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-            assert 0 = 1
-            jmp rel 0
-        else:
-            return ()
-        end
+    let termination_token = 0
+    with exec_env, memory_dict, msize, termination_token:
+        __main_meat()
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
+end
+
+func __constructor_meat{memory_dict : DictAccess*, msize, range_check_ptr}() -> ():
+    alloc_locals
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
+    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    else:
+        return ()
     end
 end
 
@@ -147,31 +164,18 @@ func __warp_if_0{
     end
 end
 
-@external
-func fun_ENTRY_POINT{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*) -> (
-        returndata_size : felt, returndata_len : felt, returndata : felt*):
+func __main_meat{
+        exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize, range_check_ptr,
+        termination_token}() -> ():
     alloc_locals
-    let termination_token = 0
-    let (__fp__, _) = get_fp_and_pc()
-    let (returndata_ptr : felt*) = alloc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
-    let exec_env = &exec_env_
-    let (memory_dict) = default_dict_new(0)
-    let memory_dict_start = memory_dict
-    let msize = 0
-    with exec_env, msize, memory_dict, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_2 : Uint256) = calldatasize()
-        let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
-        let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
-        __warp_if_0(__warp_subexpr_0)
-        if termination_token == 1:
-            default_dict_finalize(memory_dict_start, memory_dict, 0)
-            return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
-        end
-        assert 0 = 1
-        jmp rel 0
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_2 : Uint256) = calldatasize()
+    let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
+    let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
+    __warp_if_0(__warp_subexpr_0)
+    if termination_token == 1:
+        return ()
     end
+    assert 0 = 1
+    jmp rel 0
 end

--- a/tests/yul/for-loop-with-nested-return.cairo
+++ b/tests/yul/for-loop-with-nested-return.cairo
@@ -6,7 +6,6 @@ from evm.exec_env import ExecutionEnvironment
 from evm.memory import uint256_mload, uint256_mstore
 from evm.uint256 import is_eq, is_gt, is_lt, is_zero, slt, u256_add, u256_shr
 from evm.yul_api import warp_return
-from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin, HashBuiltin
 from starkware.cairo.common.default_dict import default_dict_finalize, default_dict_new
 from starkware.cairo.common.dict_access import DictAccess
@@ -18,27 +17,45 @@ func __warp_constant_0() -> (res : Uint256):
 end
 
 @constructor
-func constructor{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*):
+func constructor{range_check_ptr}(calldata_size, calldata_len, calldata : felt*):
     alloc_locals
-    let termination_token = 0
-    let (returndata_ptr : felt*) = alloc()
+    let (memory_dict) = default_dict_new(0)
+    let memory_dict_start = memory_dict
+    let msize = 0
+    with memory_dict, msize:
+        __constructor_meat()
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return ()
+end
+
+@external
+func __main{range_check_ptr}(calldata_size, calldata_len, calldata : felt*) -> (
+        returndata_size, returndata_len, returndata : felt*):
+    alloc_locals
     let (__fp__, _) = get_fp_and_pc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
+    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=cast(0, felt*), to_returndata_size=0, to_returndata_len=0, to_returndata=cast(0, felt*))
     let exec_env : ExecutionEnvironment* = &exec_env_
     let (memory_dict) = default_dict_new(0)
     let memory_dict_start = memory_dict
     let msize = 0
-    with memory_dict, msize, exec_env, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
-        if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-            assert 0 = 1
-            jmp rel 0
-        else:
-            return ()
-        end
+    let termination_token = 0
+    with exec_env, memory_dict, msize, termination_token:
+        __main_meat()
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
+end
+
+func __constructor_meat{memory_dict : DictAccess*, msize, range_check_ptr}() -> ():
+    alloc_locals
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
+    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    else:
+        return ()
     end
 end
 
@@ -164,31 +181,18 @@ func __warp_if_0{
     end
 end
 
-@external
-func fun_ENTRY_POINT{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*) -> (
-        returndata_size : felt, returndata_len : felt, returndata : felt*):
+func __main_meat{
+        exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize, range_check_ptr,
+        termination_token}() -> ():
     alloc_locals
-    let termination_token = 0
-    let (__fp__, _) = get_fp_and_pc()
-    let (returndata_ptr : felt*) = alloc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
-    let exec_env = &exec_env_
-    let (memory_dict) = default_dict_new(0)
-    let memory_dict_start = memory_dict
-    let msize = 0
-    with exec_env, msize, memory_dict, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_2 : Uint256) = calldatasize()
-        let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
-        let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
-        __warp_if_0(__warp_subexpr_0)
-        if termination_token == 1:
-            default_dict_finalize(memory_dict_start, memory_dict, 0)
-            return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
-        end
-        assert 0 = 1
-        jmp rel 0
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_2 : Uint256) = calldatasize()
+    let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
+    let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
+    __warp_if_0(__warp_subexpr_0)
+    if termination_token == 1:
+        return ()
     end
+    assert 0 = 1
+    jmp rel 0
 end

--- a/tests/yul/function-with-nested-return.cairo
+++ b/tests/yul/function-with-nested-return.cairo
@@ -6,7 +6,6 @@ from evm.exec_env import ExecutionEnvironment
 from evm.memory import uint256_mstore
 from evm.uint256 import is_eq, is_lt, is_zero, slt, u256_add, u256_shr
 from evm.yul_api import warp_return
-from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin, HashBuiltin
 from starkware.cairo.common.default_dict import default_dict_finalize, default_dict_new
 from starkware.cairo.common.dict_access import DictAccess
@@ -18,27 +17,45 @@ func __warp_constant_0() -> (res : Uint256):
 end
 
 @constructor
-func constructor{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*):
+func constructor{range_check_ptr}(calldata_size, calldata_len, calldata : felt*):
     alloc_locals
-    let termination_token = 0
-    let (returndata_ptr : felt*) = alloc()
+    let (memory_dict) = default_dict_new(0)
+    let memory_dict_start = memory_dict
+    let msize = 0
+    with memory_dict, msize:
+        __constructor_meat()
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return ()
+end
+
+@external
+func __main{range_check_ptr}(calldata_size, calldata_len, calldata : felt*) -> (
+        returndata_size, returndata_len, returndata : felt*):
+    alloc_locals
     let (__fp__, _) = get_fp_and_pc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
+    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=cast(0, felt*), to_returndata_size=0, to_returndata_len=0, to_returndata=cast(0, felt*))
     let exec_env : ExecutionEnvironment* = &exec_env_
     let (memory_dict) = default_dict_new(0)
     let memory_dict_start = memory_dict
     let msize = 0
-    with memory_dict, msize, exec_env, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
-        if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-            assert 0 = 1
-            jmp rel 0
-        else:
-            return ()
-        end
+    let termination_token = 0
+    with exec_env, memory_dict, msize, termination_token:
+        __main_meat()
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
+end
+
+func __constructor_meat{memory_dict : DictAccess*, msize, range_check_ptr}() -> ():
+    alloc_locals
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
+    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    else:
+        return ()
     end
 end
 
@@ -111,31 +128,18 @@ func __warp_if_0{
     end
 end
 
-@external
-func fun_ENTRY_POINT{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*) -> (
-        returndata_size : felt, returndata_len : felt, returndata : felt*):
+func __main_meat{
+        exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize, range_check_ptr,
+        termination_token}() -> ():
     alloc_locals
-    let termination_token = 0
-    let (__fp__, _) = get_fp_and_pc()
-    let (returndata_ptr : felt*) = alloc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
-    let exec_env = &exec_env_
-    let (memory_dict) = default_dict_new(0)
-    let memory_dict_start = memory_dict
-    let msize = 0
-    with exec_env, msize, memory_dict, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_2 : Uint256) = calldatasize()
-        let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
-        let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
-        __warp_if_0(__warp_subexpr_0)
-        if termination_token == 1:
-            default_dict_finalize(memory_dict_start, memory_dict, 0)
-            return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
-        end
-        assert 0 = 1
-        jmp rel 0
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_2 : Uint256) = calldatasize()
+    let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
+    let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
+    __warp_if_0(__warp_subexpr_0)
+    if termination_token == 1:
+        return ()
     end
+    assert 0 = 1
+    jmp rel 0
 end

--- a/tests/yul/if-flattening.cairo
+++ b/tests/yul/if-flattening.cairo
@@ -7,7 +7,6 @@ from evm.hashing import uint256_pedersen
 from evm.memory import uint256_mload, uint256_mstore
 from evm.uint256 import is_eq, is_lt, is_zero, slt, u256_add, u256_shr
 from evm.yul_api import warp_return
-from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin, HashBuiltin
 from starkware.cairo.common.default_dict import default_dict_finalize, default_dict_new
 from starkware.cairo.common.dict_access import DictAccess
@@ -35,27 +34,46 @@ func evm_storage(arg0_low, arg0_high) -> (res : Uint256):
 end
 
 @constructor
-func constructor{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*):
+func constructor{range_check_ptr}(calldata_size, calldata_len, calldata : felt*):
     alloc_locals
-    let termination_token = 0
-    let (returndata_ptr : felt*) = alloc()
+    let (memory_dict) = default_dict_new(0)
+    let memory_dict_start = memory_dict
+    let msize = 0
+    with memory_dict, msize:
+        __constructor_meat()
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return ()
+end
+
+@external
+func __main{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
+        calldata_size, calldata_len, calldata : felt*) -> (
+        returndata_size, returndata_len, returndata : felt*):
+    alloc_locals
     let (__fp__, _) = get_fp_and_pc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
+    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=cast(0, felt*), to_returndata_size=0, to_returndata_len=0, to_returndata=cast(0, felt*))
     let exec_env : ExecutionEnvironment* = &exec_env_
     let (memory_dict) = default_dict_new(0)
     let memory_dict_start = memory_dict
     let msize = 0
-    with memory_dict, msize, exec_env, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
-        if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-            assert 0 = 1
-            jmp rel 0
-        else:
-            return ()
-        end
+    let termination_token = 0
+    with exec_env, memory_dict, msize, termination_token:
+        __main_meat()
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
+end
+
+func __constructor_meat{memory_dict : DictAccess*, msize, range_check_ptr}() -> ():
+    alloc_locals
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
+    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    else:
+        return ()
     end
 end
 
@@ -262,31 +280,19 @@ func __warp_if_1{
     end
 end
 
-@external
-func fun_ENTRY_POINT{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*) -> (
-        returndata_size : felt, returndata_len : felt, returndata : felt*):
+func __main_meat{
+        exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize,
+        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*, termination_token}() -> (
+        ):
     alloc_locals
-    let termination_token = 0
-    let (__fp__, _) = get_fp_and_pc()
-    let (returndata_ptr : felt*) = alloc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
-    let exec_env = &exec_env_
-    let (memory_dict) = default_dict_new(0)
-    let memory_dict_start = memory_dict
-    let msize = 0
-    with exec_env, msize, memory_dict, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_2 : Uint256) = calldatasize()
-        let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
-        let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
-        __warp_if_1(__warp_subexpr_0)
-        if termination_token == 1:
-            default_dict_finalize(memory_dict_start, memory_dict, 0)
-            return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
-        end
-        assert 0 = 1
-        jmp rel 0
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_2 : Uint256) = calldatasize()
+    let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
+    let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
+    __warp_if_1(__warp_subexpr_0)
+    if termination_token == 1:
+        return ()
     end
+    assert 0 = 1
+    jmp rel 0
 end

--- a/tests/yul/payable-function.cairo
+++ b/tests/yul/payable-function.cairo
@@ -6,7 +6,6 @@ from evm.exec_env import ExecutionEnvironment
 from evm.memory import uint256_mstore
 from evm.uint256 import is_eq, is_lt, is_zero, slt, u256_add, u256_shr
 from evm.yul_api import warp_return
-from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin, HashBuiltin
 from starkware.cairo.common.default_dict import default_dict_finalize, default_dict_new
 from starkware.cairo.common.dict_access import DictAccess
@@ -18,27 +17,45 @@ func __warp_constant_0() -> (res : Uint256):
 end
 
 @constructor
-func constructor{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*):
+func constructor{range_check_ptr}(calldata_size, calldata_len, calldata : felt*):
     alloc_locals
-    let termination_token = 0
-    let (returndata_ptr : felt*) = alloc()
+    let (memory_dict) = default_dict_new(0)
+    let memory_dict_start = memory_dict
+    let msize = 0
+    with memory_dict, msize:
+        __constructor_meat()
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return ()
+end
+
+@external
+func __main{range_check_ptr}(calldata_size, calldata_len, calldata : felt*) -> (
+        returndata_size, returndata_len, returndata : felt*):
+    alloc_locals
     let (__fp__, _) = get_fp_and_pc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
+    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=cast(0, felt*), to_returndata_size=0, to_returndata_len=0, to_returndata=cast(0, felt*))
     let exec_env : ExecutionEnvironment* = &exec_env_
     let (memory_dict) = default_dict_new(0)
     let memory_dict_start = memory_dict
     let msize = 0
-    with memory_dict, msize, exec_env, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
-        if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-            assert 0 = 1
-            jmp rel 0
-        else:
-            return ()
-        end
+    let termination_token = 0
+    with exec_env, memory_dict, msize, termination_token:
+        __main_meat()
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
+end
+
+func __constructor_meat{memory_dict : DictAccess*, msize, range_check_ptr}() -> ():
+    alloc_locals
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
+    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    else:
+        return ()
     end
 end
 
@@ -131,31 +148,18 @@ func __warp_if_0{
     end
 end
 
-@external
-func fun_ENTRY_POINT{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*) -> (
-        returndata_size : felt, returndata_len : felt, returndata : felt*):
+func __main_meat{
+        exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize, range_check_ptr,
+        termination_token}() -> ():
     alloc_locals
-    let termination_token = 0
-    let (__fp__, _) = get_fp_and_pc()
-    let (returndata_ptr : felt*) = alloc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
-    let exec_env = &exec_env_
-    let (memory_dict) = default_dict_new(0)
-    let memory_dict_start = memory_dict
-    let msize = 0
-    with exec_env, msize, memory_dict, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_2 : Uint256) = calldatasize()
-        let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
-        let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
-        __warp_if_0(__warp_subexpr_0)
-        if termination_token == 1:
-            default_dict_finalize(memory_dict_start, memory_dict, 0)
-            return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
-        end
-        assert 0 = 1
-        jmp rel 0
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_2 : Uint256) = calldatasize()
+    let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
+    let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
+    __warp_if_0(__warp_subexpr_0)
+    if termination_token == 1:
+        return ()
     end
+    assert 0 = 1
+    jmp rel 0
 end

--- a/tests/yul/pure-function.cairo
+++ b/tests/yul/pure-function.cairo
@@ -6,7 +6,6 @@ from evm.exec_env import ExecutionEnvironment
 from evm.memory import uint256_mstore
 from evm.uint256 import is_eq, is_lt, is_zero, slt, u256_add, u256_shr
 from evm.yul_api import warp_return
-from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin, HashBuiltin
 from starkware.cairo.common.default_dict import default_dict_finalize, default_dict_new
 from starkware.cairo.common.dict_access import DictAccess
@@ -18,27 +17,45 @@ func __warp_constant_0() -> (res : Uint256):
 end
 
 @constructor
-func constructor{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*):
+func constructor{range_check_ptr}(calldata_size, calldata_len, calldata : felt*):
     alloc_locals
-    let termination_token = 0
-    let (returndata_ptr : felt*) = alloc()
+    let (memory_dict) = default_dict_new(0)
+    let memory_dict_start = memory_dict
+    let msize = 0
+    with memory_dict, msize:
+        __constructor_meat()
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return ()
+end
+
+@external
+func __main{range_check_ptr}(calldata_size, calldata_len, calldata : felt*) -> (
+        returndata_size, returndata_len, returndata : felt*):
+    alloc_locals
     let (__fp__, _) = get_fp_and_pc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
+    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=cast(0, felt*), to_returndata_size=0, to_returndata_len=0, to_returndata=cast(0, felt*))
     let exec_env : ExecutionEnvironment* = &exec_env_
     let (memory_dict) = default_dict_new(0)
     let memory_dict_start = memory_dict
     let msize = 0
-    with memory_dict, msize, exec_env, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
-        if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-            assert 0 = 1
-            jmp rel 0
-        else:
-            return ()
-        end
+    let termination_token = 0
+    with exec_env, memory_dict, msize, termination_token:
+        __main_meat()
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
+end
+
+func __constructor_meat{memory_dict : DictAccess*, msize, range_check_ptr}() -> ():
+    alloc_locals
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
+    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    else:
+        return ()
     end
 end
 
@@ -131,31 +148,18 @@ func __warp_if_0{
     end
 end
 
-@external
-func fun_ENTRY_POINT{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*) -> (
-        returndata_size : felt, returndata_len : felt, returndata : felt*):
+func __main_meat{
+        exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize, range_check_ptr,
+        termination_token}() -> ():
     alloc_locals
-    let termination_token = 0
-    let (__fp__, _) = get_fp_and_pc()
-    let (returndata_ptr : felt*) = alloc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
-    let exec_env = &exec_env_
-    let (memory_dict) = default_dict_new(0)
-    let memory_dict_start = memory_dict
-    let msize = 0
-    with exec_env, msize, memory_dict, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_2 : Uint256) = calldatasize()
-        let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
-        let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
-        __warp_if_0(__warp_subexpr_0)
-        if termination_token == 1:
-            default_dict_finalize(memory_dict_start, memory_dict, 0)
-            return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
-        end
-        assert 0 = 1
-        jmp rel 0
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_2 : Uint256) = calldatasize()
+    let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
+    let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
+    __warp_if_0(__warp_subexpr_0)
+    if termination_token == 1:
+        return ()
     end
+    assert 0 = 1
+    jmp rel 0
 end

--- a/tests/yul/return-var-capturing.cairo
+++ b/tests/yul/return-var-capturing.cairo
@@ -6,7 +6,6 @@ from evm.exec_env import ExecutionEnvironment
 from evm.memory import uint256_mload, uint256_mstore
 from evm.uint256 import is_eq, is_gt, is_lt, is_zero, slt, u256_add, u256_shr
 from evm.yul_api import warp_return
-from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin, HashBuiltin
 from starkware.cairo.common.default_dict import default_dict_finalize, default_dict_new
 from starkware.cairo.common.dict_access import DictAccess
@@ -18,27 +17,45 @@ func __warp_constant_0() -> (res : Uint256):
 end
 
 @constructor
-func constructor{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*):
+func constructor{range_check_ptr}(calldata_size, calldata_len, calldata : felt*):
     alloc_locals
-    let termination_token = 0
-    let (returndata_ptr : felt*) = alloc()
+    let (memory_dict) = default_dict_new(0)
+    let memory_dict_start = memory_dict
+    let msize = 0
+    with memory_dict, msize:
+        __constructor_meat()
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return ()
+end
+
+@external
+func __main{range_check_ptr}(calldata_size, calldata_len, calldata : felt*) -> (
+        returndata_size, returndata_len, returndata : felt*):
+    alloc_locals
     let (__fp__, _) = get_fp_and_pc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
+    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=cast(0, felt*), to_returndata_size=0, to_returndata_len=0, to_returndata=cast(0, felt*))
     let exec_env : ExecutionEnvironment* = &exec_env_
     let (memory_dict) = default_dict_new(0)
     let memory_dict_start = memory_dict
     let msize = 0
-    with memory_dict, msize, exec_env, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
-        if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-            assert 0 = 1
-            jmp rel 0
-        else:
-            return ()
-        end
+    let termination_token = 0
+    with exec_env, memory_dict, msize, termination_token:
+        __main_meat()
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
+end
+
+func __constructor_meat{memory_dict : DictAccess*, msize, range_check_ptr}() -> ():
+    alloc_locals
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
+    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    else:
+        return ()
     end
 end
 
@@ -186,31 +203,18 @@ func __warp_if_0{
     end
 end
 
-@external
-func fun_ENTRY_POINT{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*) -> (
-        returndata_size : felt, returndata_len : felt, returndata : felt*):
+func __main_meat{
+        exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize, range_check_ptr,
+        termination_token}() -> ():
     alloc_locals
-    let termination_token = 0
-    let (__fp__, _) = get_fp_and_pc()
-    let (returndata_ptr : felt*) = alloc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
-    let exec_env = &exec_env_
-    let (memory_dict) = default_dict_new(0)
-    let memory_dict_start = memory_dict
-    let msize = 0
-    with exec_env, msize, memory_dict, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_2 : Uint256) = calldatasize()
-        let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
-        let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
-        __warp_if_0(__warp_subexpr_0)
-        if termination_token == 1:
-            default_dict_finalize(memory_dict_start, memory_dict, 0)
-            return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
-        end
-        assert 0 = 1
-        jmp rel 0
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_2 : Uint256) = calldatasize()
+    let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
+    let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
+    __warp_if_0(__warp_subexpr_0)
+    if termination_token == 1:
+        return ()
     end
+    assert 0 = 1
+    jmp rel 0
 end

--- a/tests/yul/returndatasize.cairo
+++ b/tests/yul/returndatasize.cairo
@@ -6,7 +6,6 @@ from evm.exec_env import ExecutionEnvironment
 from evm.memory import uint256_mstore
 from evm.uint256 import is_eq, is_lt, is_zero, slt, u256_add, u256_shr
 from evm.yul_api import warp_return
-from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin, HashBuiltin
 from starkware.cairo.common.default_dict import default_dict_finalize, default_dict_new
 from starkware.cairo.common.dict_access import DictAccess
@@ -22,27 +21,45 @@ func returndata_size{exec_env : ExecutionEnvironment*}() -> (res : Uint256):
 end
 
 @constructor
-func constructor{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*):
+func constructor{range_check_ptr}(calldata_size, calldata_len, calldata : felt*):
     alloc_locals
-    let termination_token = 0
-    let (returndata_ptr : felt*) = alloc()
+    let (memory_dict) = default_dict_new(0)
+    let memory_dict_start = memory_dict
+    let msize = 0
+    with memory_dict, msize:
+        __constructor_meat()
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return ()
+end
+
+@external
+func __main{range_check_ptr}(calldata_size, calldata_len, calldata : felt*) -> (
+        returndata_size, returndata_len, returndata : felt*):
+    alloc_locals
     let (__fp__, _) = get_fp_and_pc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
+    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=cast(0, felt*), to_returndata_size=0, to_returndata_len=0, to_returndata=cast(0, felt*))
     let exec_env : ExecutionEnvironment* = &exec_env_
     let (memory_dict) = default_dict_new(0)
     let memory_dict_start = memory_dict
     let msize = 0
-    with memory_dict, msize, exec_env, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
-        if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-            assert 0 = 1
-            jmp rel 0
-        else:
-            return ()
-        end
+    let termination_token = 0
+    with exec_env, memory_dict, msize, termination_token:
+        __main_meat()
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
+end
+
+func __constructor_meat{memory_dict : DictAccess*, msize, range_check_ptr}() -> ():
+    alloc_locals
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
+    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    else:
+        return ()
     end
 end
 
@@ -104,31 +121,18 @@ func __warp_if_0{
     end
 end
 
-@external
-func fun_ENTRY_POINT{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*) -> (
-        returndata_size : felt, returndata_len : felt, returndata : felt*):
+func __main_meat{
+        exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize, range_check_ptr,
+        termination_token}() -> ():
     alloc_locals
-    let termination_token = 0
-    let (__fp__, _) = get_fp_and_pc()
-    let (returndata_ptr : felt*) = alloc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
-    let exec_env = &exec_env_
-    let (memory_dict) = default_dict_new(0)
-    let memory_dict_start = memory_dict
-    let msize = 0
-    with exec_env, msize, memory_dict, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_2 : Uint256) = calldatasize()
-        let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
-        let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
-        __warp_if_0(__warp_subexpr_0)
-        if termination_token == 1:
-            default_dict_finalize(memory_dict_start, memory_dict, 0)
-            return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
-        end
-        assert 0 = 1
-        jmp rel 0
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_2 : Uint256) = calldatasize()
+    let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
+    let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
+    __warp_if_0(__warp_subexpr_0)
+    if termination_token == 1:
+        return ()
     end
+    assert 0 = 1
+    jmp rel 0
 end

--- a/tests/yul/short_string.cairo
+++ b/tests/yul/short_string.cairo
@@ -6,7 +6,6 @@ from evm.exec_env import ExecutionEnvironment
 from evm.memory import uint256_mload, uint256_mstore, uint256_mstore8
 from evm.uint256 import is_eq, is_gt, is_lt, is_zero, slt, u256_add, u256_shr
 from evm.yul_api import warp_return
-from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin, HashBuiltin
 from starkware.cairo.common.default_dict import default_dict_finalize, default_dict_new
 from starkware.cairo.common.dict_access import DictAccess
@@ -18,27 +17,45 @@ func __warp_constant_0() -> (res : Uint256):
 end
 
 @constructor
-func constructor{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*):
+func constructor{range_check_ptr}(calldata_size, calldata_len, calldata : felt*):
     alloc_locals
-    let termination_token = 0
-    let (returndata_ptr : felt*) = alloc()
+    let (memory_dict) = default_dict_new(0)
+    let memory_dict_start = memory_dict
+    let msize = 0
+    with memory_dict, msize:
+        __constructor_meat()
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return ()
+end
+
+@external
+func __main{range_check_ptr}(calldata_size, calldata_len, calldata : felt*) -> (
+        returndata_size, returndata_len, returndata : felt*):
+    alloc_locals
     let (__fp__, _) = get_fp_and_pc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
+    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=cast(0, felt*), to_returndata_size=0, to_returndata_len=0, to_returndata=cast(0, felt*))
     let exec_env : ExecutionEnvironment* = &exec_env_
     let (memory_dict) = default_dict_new(0)
     let memory_dict_start = memory_dict
     let msize = 0
-    with memory_dict, msize, exec_env, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
-        if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-            assert 0 = 1
-            jmp rel 0
-        else:
-            return ()
-        end
+    let termination_token = 0
+    with exec_env, memory_dict, msize, termination_token:
+        __main_meat()
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
+end
+
+func __constructor_meat{memory_dict : DictAccess*, msize, range_check_ptr}() -> ():
+    alloc_locals
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
+    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    else:
+        return ()
     end
 end
 
@@ -341,31 +358,18 @@ func __warp_if_2{
     end
 end
 
-@external
-func fun_ENTRY_POINT{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*) -> (
-        returndata_size : felt, returndata_len : felt, returndata : felt*):
+func __main_meat{
+        exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize, range_check_ptr,
+        termination_token}() -> ():
     alloc_locals
-    let termination_token = 0
-    let (__fp__, _) = get_fp_and_pc()
-    let (returndata_ptr : felt*) = alloc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
-    let exec_env = &exec_env_
-    let (memory_dict) = default_dict_new(0)
-    let memory_dict_start = memory_dict
-    let msize = 0
-    with exec_env, msize, memory_dict, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_2 : Uint256) = calldatasize()
-        let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
-        let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
-        __warp_if_2(__warp_subexpr_0)
-        if termination_token == 1:
-            default_dict_finalize(memory_dict_start, memory_dict, 0)
-            return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
-        end
-        assert 0 = 1
-        jmp rel 0
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_2 : Uint256) = calldatasize()
+    let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
+    let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
+    __warp_if_2(__warp_subexpr_0)
+    if termination_token == 1:
+        return ()
     end
+    assert 0 = 1
+    jmp rel 0
 end

--- a/tests/yul/sstore-sload.cairo
+++ b/tests/yul/sstore-sload.cairo
@@ -6,7 +6,6 @@ from evm.exec_env import ExecutionEnvironment
 from evm.memory import uint256_mstore
 from evm.uint256 import is_eq, is_lt, is_zero, slt, u256_add, u256_shr
 from evm.yul_api import warp_return
-from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin, HashBuiltin
 from starkware.cairo.common.default_dict import default_dict_finalize, default_dict_new
 from starkware.cairo.common.dict_access import DictAccess
@@ -34,27 +33,46 @@ func evm_storage(arg0_low, arg0_high) -> (res : Uint256):
 end
 
 @constructor
-func constructor{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*):
+func constructor{range_check_ptr}(calldata_size, calldata_len, calldata : felt*):
     alloc_locals
-    let termination_token = 0
-    let (returndata_ptr : felt*) = alloc()
+    let (memory_dict) = default_dict_new(0)
+    let memory_dict_start = memory_dict
+    let msize = 0
+    with memory_dict, msize:
+        __constructor_meat()
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return ()
+end
+
+@external
+func __main{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
+        calldata_size, calldata_len, calldata : felt*) -> (
+        returndata_size, returndata_len, returndata : felt*):
+    alloc_locals
     let (__fp__, _) = get_fp_and_pc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
+    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=cast(0, felt*), to_returndata_size=0, to_returndata_len=0, to_returndata=cast(0, felt*))
     let exec_env : ExecutionEnvironment* = &exec_env_
     let (memory_dict) = default_dict_new(0)
     let memory_dict_start = memory_dict
     let msize = 0
-    with memory_dict, msize, exec_env, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
-        if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-            assert 0 = 1
-            jmp rel 0
-        else:
-            return ()
-        end
+    let termination_token = 0
+    with exec_env, memory_dict, msize, termination_token:
+        __main_meat()
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
+end
+
+func __constructor_meat{memory_dict : DictAccess*, msize, range_check_ptr}() -> ():
+    alloc_locals
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
+    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    else:
+        return ()
     end
 end
 
@@ -117,31 +135,19 @@ func __warp_if_0{
     end
 end
 
-@external
-func fun_ENTRY_POINT{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*) -> (
-        returndata_size : felt, returndata_len : felt, returndata : felt*):
+func __main_meat{
+        exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize,
+        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*, termination_token}() -> (
+        ):
     alloc_locals
-    let termination_token = 0
-    let (__fp__, _) = get_fp_and_pc()
-    let (returndata_ptr : felt*) = alloc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
-    let exec_env = &exec_env_
-    let (memory_dict) = default_dict_new(0)
-    let memory_dict_start = memory_dict
-    let msize = 0
-    with exec_env, msize, memory_dict, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_2 : Uint256) = calldatasize()
-        let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
-        let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
-        __warp_if_0(__warp_subexpr_0)
-        if termination_token == 1:
-            default_dict_finalize(memory_dict_start, memory_dict, 0)
-            return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
-        end
-        assert 0 = 1
-        jmp rel 0
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_2 : Uint256) = calldatasize()
+    let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
+    let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
+    __warp_if_0(__warp_subexpr_0)
+    if termination_token == 1:
+        return ()
     end
+    assert 0 = 1
+    jmp rel 0
 end

--- a/tests/yul/view-function.cairo
+++ b/tests/yul/view-function.cairo
@@ -6,7 +6,6 @@ from evm.exec_env import ExecutionEnvironment
 from evm.memory import uint256_mstore
 from evm.uint256 import is_eq, is_lt, is_zero, slt, u256_add, u256_shr
 from evm.yul_api import warp_return
-from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin, HashBuiltin
 from starkware.cairo.common.default_dict import default_dict_finalize, default_dict_new
 from starkware.cairo.common.dict_access import DictAccess
@@ -18,27 +17,45 @@ func __warp_constant_0() -> (res : Uint256):
 end
 
 @constructor
-func constructor{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*):
+func constructor{range_check_ptr}(calldata_size, calldata_len, calldata : felt*):
     alloc_locals
-    let termination_token = 0
-    let (returndata_ptr : felt*) = alloc()
+    let (memory_dict) = default_dict_new(0)
+    let memory_dict_start = memory_dict
+    let msize = 0
+    with memory_dict, msize:
+        __constructor_meat()
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return ()
+end
+
+@external
+func __main{range_check_ptr}(calldata_size, calldata_len, calldata : felt*) -> (
+        returndata_size, returndata_len, returndata : felt*):
+    alloc_locals
     let (__fp__, _) = get_fp_and_pc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
+    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=cast(0, felt*), to_returndata_size=0, to_returndata_len=0, to_returndata=cast(0, felt*))
     let exec_env : ExecutionEnvironment* = &exec_env_
     let (memory_dict) = default_dict_new(0)
     let memory_dict_start = memory_dict
     let msize = 0
-    with memory_dict, msize, exec_env, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
-        if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
-            assert 0 = 1
-            jmp rel 0
-        else:
-            return ()
-        end
+    let termination_token = 0
+    with exec_env, memory_dict, msize, termination_token:
+        __main_meat()
+    end
+    default_dict_finalize(memory_dict_start, memory_dict, 0)
+    return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
+end
+
+func __constructor_meat{memory_dict : DictAccess*, msize, range_check_ptr}() -> ():
+    alloc_locals
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_0 : Uint256) = __warp_constant_0()
+    if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
+        assert 0 = 1
+        jmp rel 0
+    else:
+        return ()
     end
 end
 
@@ -131,31 +148,18 @@ func __warp_if_0{
     end
 end
 
-@external
-func fun_ENTRY_POINT{
-        pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*,
-        bitwise_ptr : BitwiseBuiltin*}(calldata_size, calldata_len, calldata : felt*) -> (
-        returndata_size : felt, returndata_len : felt, returndata : felt*):
+func __main_meat{
+        exec_env : ExecutionEnvironment*, memory_dict : DictAccess*, msize, range_check_ptr,
+        termination_token}() -> ():
     alloc_locals
-    let termination_token = 0
-    let (__fp__, _) = get_fp_and_pc()
-    let (returndata_ptr : felt*) = alloc()
-    local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata, returndata_size=0, returndata_len=0, returndata=returndata_ptr, to_returndata_size=0, to_returndata_len=0, to_returndata=returndata_ptr)
-    let exec_env = &exec_env_
-    let (memory_dict) = default_dict_new(0)
-    let memory_dict_start = memory_dict
-    let msize = 0
-    with exec_env, msize, memory_dict, termination_token:
-        uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
-        let (__warp_subexpr_2 : Uint256) = calldatasize()
-        let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
-        let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
-        __warp_if_0(__warp_subexpr_0)
-        if termination_token == 1:
-            default_dict_finalize(memory_dict_start, memory_dict, 0)
-            return (exec_env.to_returndata_size, exec_env.to_returndata_len, exec_env.to_returndata)
-        end
-        assert 0 = 1
-        jmp rel 0
+    uint256_mstore(offset=Uint256(low=64, high=0), value=Uint256(low=128, high=0))
+    let (__warp_subexpr_2 : Uint256) = calldatasize()
+    let (__warp_subexpr_1 : Uint256) = is_lt(__warp_subexpr_2, Uint256(low=4, high=0))
+    let (__warp_subexpr_0 : Uint256) = is_zero(__warp_subexpr_1)
+    __warp_if_0(__warp_subexpr_0)
+    if termination_token == 1:
+        return ()
     end
+    assert 0 = 1
+    jmp rel 0
 end

--- a/warp/cairo-src/evm/calls.cairo
+++ b/warp/cairo-src/evm/calls.cairo
@@ -54,7 +54,7 @@ end
 
 @contract_interface
 namespace GenericCallInterface:
-    func fun_ENTRY_POINT(calldata_size : felt, calldata_len : felt, calldata : felt*) -> (
+    func __main(calldata_size : felt, calldata_len : felt, calldata : felt*) -> (
             returndata_size : felt, returndata_len : felt, returndata : felt*):
     end
 end
@@ -79,7 +79,7 @@ func warp_call{
         memory_dict=memory_dict, range_check_ptr=range_check_ptr}(in.low, insize.low)
     let (calldata_len) = calculate_data_len(insize.low)
     let (address_felt : felt) = uint256_to_address_felt(address)
-    let (returndata_size, returndata_len, returndata) = GenericCallInterface.fun_ENTRY_POINT(
+    let (returndata_size, returndata_len, returndata) = GenericCallInterface.__main(
         address_felt, insize.low, calldata_len, mem)
     array_copy_to_memory(returndata_size, returndata, 0, out.low, outsize.low)
     local exec_env_ : ExecutionEnvironment = ExecutionEnvironment(

--- a/warp/cli/commands.py
+++ b/warp/cli/commands.py
@@ -45,7 +45,7 @@ def starknet_invoke(
             f"starknet invoke "
             f"--address {address} "
             f"--abi {abi} "
-            f"--function fun_ENTRY_POINT "
+            f"--function __main "
             f"--inputs {inputs} "
             f"--network {network} "
         ).read()

--- a/warp/yul/FunctionPruner.py
+++ b/warp/yul/FunctionPruner.py
@@ -17,7 +17,7 @@ class FunctionPruner(AstMapper):
 
         self.callgraph = build_callgraph(node)
         for function in self.callgraph:
-            if function.name in ("fun_ENTRY_POINT", "constructor"):
+            if function.name in ("__main_meat", "__constructor_meat"):
                 self._dfs(function)
 
         return self.visit(node, *args, **kwargs)
@@ -43,7 +43,7 @@ class FunctionPruner(AstMapper):
         return (
             isinstance(node, ast.FunctionDefinition)
             and node.name not in self.visited_functions
-            and node.name != "constructor"
+            and node.name != "__constructor_meat"
             and "setter" not in node.name
             and "getter" not in node.name
         )

--- a/warp/yul/implicits.py
+++ b/warp/yul/implicits.py
@@ -11,6 +11,10 @@ IMPLICITS = {
 
 IMPLICITS_SET = set(IMPLICITS.keys())
 
+# Implicits that we create manually, they are not built into Cairo
+MANUAL_IMPLICITS = {"memory_dict", "msize", "exec_env", "termination_token"}
+assert MANUAL_IMPLICITS.issubset(IMPLICITS_SET)
+
 
 def print_implicit(name):
     type_ = IMPLICITS.get(name, None)
@@ -22,3 +26,34 @@ def print_implicit(name):
 
 def copy_implicit(name):
     return f"local {print_implicit(name)} = {name}"
+
+
+def initialize_manual_implicit(name):
+    assert name in MANUAL_IMPLICITS
+    if name == "memory_dict":
+        return (
+            f"let (memory_dict) = default_dict_new(0)\n"
+            f"let memory_dict_start = memory_dict\n"
+        )
+    elif name == "msize":
+        return "let msize = 0\n"
+    elif name == "exec_env":
+        return (
+            f"let (__fp__, _) = get_fp_and_pc()\n"
+            f"local exec_env_ : ExecutionEnvironment = ExecutionEnvironment("
+            f"calldata_size=calldata_size, calldata_len=calldata_len, calldata=calldata,"
+            f"returndata_size=0, returndata_len=0, returndata=cast(0, felt*),"
+            f"to_returndata_size=0, to_returndata_len=0, to_returndata=cast(0, felt*))\n"
+            f"let exec_env : ExecutionEnvironment* = &exec_env_\n"
+        )
+    elif name == "termination_token":
+        return "let termination_token = 0\n"
+    assert False, f"Unhandled manual implicit: '{name}'"
+
+
+def finalize_manual_implicit(name):
+    assert name in MANUAL_IMPLICITS
+    if name == "memory_dict":
+        return "default_dict_finalize(memory_dict_start, memory_dict, 0)\n"
+    else:
+        return ""

--- a/warp/yul/parse_object.py
+++ b/warp/yul/parse_object.py
@@ -18,17 +18,16 @@ def parse_to_normalized_ast(codes) -> ast.Node:
 def combine_deployment_and_runtime(
     deployment_code: ast.Block, runtime_code: ast.Block
 ) -> ast.Block:
-
     ctor_block, deployment_functions = extract_top_level_code(deployment_code)
-    entry_point_block, runtime_functions = extract_top_level_code(runtime_code)
+    main_block, runtime_functions = extract_top_level_code(runtime_code)
     ctor = ast.FunctionDefinition(
-        name="constructor", parameters=[], return_variables=[], body=ctor_block
+        name="__constructor_meat", parameters=[], return_variables=[], body=ctor_block
     )
-    entry_point = ast.FunctionDefinition(
-        name="fun_ENTRY_POINT",
+    main_ = ast.FunctionDefinition(
+        name="__main_meat",
         parameters=[],
         return_variables=[],
-        body=entry_point_block,
+        body=main_block,
     )
 
     deployment_names = {
@@ -42,7 +41,7 @@ def combine_deployment_and_runtime(
     renamed_deployment_functions = renamer.visit_list(deployment_functions)
     renamed_ctor = renamer.visit(ctor)
     return ast.Block(
-        (renamed_ctor, *renamed_deployment_functions, entry_point, *runtime_functions)
+        (renamed_ctor, *renamed_deployment_functions, main_, *runtime_functions)
     )
 
 

--- a/warp/yul/starknet_utils.py
+++ b/warp/yul/starknet_utils.py
@@ -13,7 +13,7 @@ async def invoke_method(
     cairo_calldata = get_cairo_calldata(evm_calldata)
     return await starknet.invoke_raw(
         contract_address=address,
-        selector="fun_ENTRY_POINT",
+        selector="__main",
         calldata=cairo_calldata,
         caller_address=0,
     )


### PR DESCRIPTION
Problem: we replace returns with empty strings in the main
     function. The reason is that we change the signature of the main
     function, add return variables, so the returns are not
     valid. However, it might change semantics and it leads to
     non-compiling code for the new contract 'ctor-check.sol'.

     Another issue is that sometimes we don't finalize certain
    implicits on early returns

Solution: transpile the main and constructor function as is, without
     any changes. Add wrappers that initialize and finalize implicits
     and perform the outermost returning. The semantics are unchanged
     and finalization is guaranteed.

Also now we add only necessary implicits to the constructor and main
     functions.