### PR TITLE
Implement pipelining order for optimizing visitors

### DIFF
--- a/tests/golden/ctor-check.cairo
+++ b/tests/golden/ctor-check.cairo
@@ -230,22 +230,23 @@ func __warp_block_8{
         msize, range_check_ptr}() -> ():
     alloc_locals
     let (_6 : Uint256) = returndata_size()
-    let _7 : Uint256 = Uint256(low=18446744073709551615, high=0)
-    let (__warp_subexpr_0 : Uint256) = is_gt(_6, _7)
+    let (__warp_subexpr_0 : Uint256) = is_gt(_6, Uint256(low=18446744073709551615, high=0))
     if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
         assert 0 = 1
         jmp rel 0
     end
-    let _8 : Uint256 = Uint256(
-        low=340282366920938463463374607431768211424, high=340282366920938463463374607431768211455)
     let (memPtr : Uint256) = uint256_mload(Uint256(low=64, high=0))
     let (__warp_subexpr_4 : Uint256) = u256_add(_6, Uint256(low=31, high=0))
-    let (__warp_subexpr_3 : Uint256) = uint256_and(__warp_subexpr_4, _8)
+    let (__warp_subexpr_3 : Uint256) = uint256_and(
+        __warp_subexpr_4,
+        Uint256(low=340282366920938463463374607431768211424, high=340282366920938463463374607431768211455))
     let (__warp_subexpr_2 : Uint256) = u256_add(__warp_subexpr_3, Uint256(low=63, high=0))
-    let (__warp_subexpr_1 : Uint256) = uint256_and(__warp_subexpr_2, _8)
+    let (__warp_subexpr_1 : Uint256) = uint256_and(
+        __warp_subexpr_2,
+        Uint256(low=340282366920938463463374607431768211424, high=340282366920938463463374607431768211455))
     let (newFreePtr : Uint256) = u256_add(memPtr, __warp_subexpr_1)
     let (__warp_subexpr_7 : Uint256) = is_lt(newFreePtr, memPtr)
-    let (__warp_subexpr_6 : Uint256) = is_gt(newFreePtr, _7)
+    let (__warp_subexpr_6 : Uint256) = is_gt(newFreePtr, Uint256(low=18446744073709551615, high=0))
     let (__warp_subexpr_5 : Uint256) = uint256_or(__warp_subexpr_6, __warp_subexpr_7)
     if __warp_subexpr_5.low + __warp_subexpr_5.high != 0:
         assert 0 = 1
@@ -324,4 +325,3 @@ func __main_meat{
     warp_return(Uint256(low=0, high=0), Uint256(low=0, high=0))
     return ()
 end
-

--- a/tests/golden/delegatecall.cairo
+++ b/tests/golden/delegatecall.cairo
@@ -230,22 +230,23 @@ func __warp_block_8{
         msize, range_check_ptr}() -> ():
     alloc_locals
     let (_6 : Uint256) = returndata_size()
-    let _7 : Uint256 = Uint256(low=18446744073709551615, high=0)
-    let (__warp_subexpr_0 : Uint256) = is_gt(_6, _7)
+    let (__warp_subexpr_0 : Uint256) = is_gt(_6, Uint256(low=18446744073709551615, high=0))
     if __warp_subexpr_0.low + __warp_subexpr_0.high != 0:
         assert 0 = 1
         jmp rel 0
     end
-    let _8 : Uint256 = Uint256(
-        low=340282366920938463463374607431768211424, high=340282366920938463463374607431768211455)
     let (memPtr : Uint256) = uint256_mload(Uint256(low=64, high=0))
     let (__warp_subexpr_4 : Uint256) = u256_add(_6, Uint256(low=31, high=0))
-    let (__warp_subexpr_3 : Uint256) = uint256_and(__warp_subexpr_4, _8)
+    let (__warp_subexpr_3 : Uint256) = uint256_and(
+        __warp_subexpr_4,
+        Uint256(low=340282366920938463463374607431768211424, high=340282366920938463463374607431768211455))
     let (__warp_subexpr_2 : Uint256) = u256_add(__warp_subexpr_3, Uint256(low=63, high=0))
-    let (__warp_subexpr_1 : Uint256) = uint256_and(__warp_subexpr_2, _8)
+    let (__warp_subexpr_1 : Uint256) = uint256_and(
+        __warp_subexpr_2,
+        Uint256(low=340282366920938463463374607431768211424, high=340282366920938463463374607431768211455))
     let (newFreePtr : Uint256) = u256_add(memPtr, __warp_subexpr_1)
     let (__warp_subexpr_7 : Uint256) = is_lt(newFreePtr, memPtr)
-    let (__warp_subexpr_6 : Uint256) = is_gt(newFreePtr, _7)
+    let (__warp_subexpr_6 : Uint256) = is_gt(newFreePtr, Uint256(low=18446744073709551615, high=0))
     let (__warp_subexpr_5 : Uint256) = uint256_or(__warp_subexpr_6, __warp_subexpr_7)
     if __warp_subexpr_5.low + __warp_subexpr_5.high != 0:
         assert 0 = 1
@@ -318,4 +319,3 @@ func __main_meat{
     warp_return(Uint256(low=0, high=0), Uint256(low=0, high=0))
     return ()
 end
-

--- a/warp/cli/warp_cli.py
+++ b/warp/cli/warp_cli.py
@@ -32,7 +32,11 @@ def warp(ctx, network):
 @click.argument("file_path", type=click.Path(exists=True))
 @click.argument("contract_name")
 @click.option("--cairo-output", is_flag=True)
-def transpile(file_path, contract_name, cairo_output):
+@click.option(
+    "--yul-optimizations",
+    help="A string input for setting the sequence of optimizer steps",
+)
+def transpile(file_path, contract_name, cairo_output, yul_optimizations):
     """
     FILE_PATH: Path to your solidity contract\n
     CONTRACT_NAME: Name of the primary contract (non-interface, non-library, non-abstract contract) that you wish to transpile
@@ -42,7 +46,12 @@ def transpile(file_path, contract_name, cairo_output):
     from yul.main import transpile_from_solidity
 
     path = click.format_filename(file_path)
-    output = transpile_from_solidity(file_path, contract_name)
+
+    if isinstance(yul_optimizations, str):
+        output = transpile_from_solidity(file_path, contract_name, yul_optimizations)
+    else:
+        output = transpile_from_solidity(file_path, contract_name)
+
     if cairo_output:
         cairo_code = output["cairo_code"]
         with open(f"{file_path[:-4]}.cairo", "w") as cairo_file:


### PR DESCRIPTION
Implements a second parameter in `transpile_from_yul`. This is a string which allows one to change the order of the Optimizing Visitors according to the following map:

```
function_map = {
        "v": VariableInliner,
        "c": ConstantFolder,
        "o": FoldIf,
        "l": LeaveNormalizer,
        "r": RevertNormalizer,
        "f": FunctionPruner,
        "d": DeadcodeEliminator,
}
```

I tested these changes against the tests we have defined in our make file. All of these tests pass apart from a few unit tests in 
`python -m pytest scripts/yul/compilation_test.py -v --tb=short --workers=auto`

I'm working on fixing these failues. After that, I'll implement a command line parameter which will take a string of letters which will act as keys according to the above dictionary. Marking this PR as a draft until then.