### PR TITLE
remove old code for extracting storage var getters

### DIFF
--- a/tests/golden/ERC20.cairo
+++ b/tests/golden/ERC20.cairo
@@ -31,10 +31,6 @@ func sload{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(ke
 end
 
 @storage_var
-func balances(arg0_low, arg0_high) -> (res : Uint256):
-end
-
-@storage_var
 func evm_storage(arg0_low, arg0_high) -> (res : Uint256):
 end
 
@@ -249,10 +245,15 @@ func abi_decode_address{exec_env : ExecutionEnvironment*, range_check_ptr}(dataE
     return (value0)
 end
 
-func getter_fun_balances{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
-        key : Uint256) -> (ret__warp_mangled : Uint256):
+func getter_fun_balances{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        syscall_ptr : felt*}(key : Uint256) -> (ret__warp_mangled : Uint256):
     alloc_locals
-    let (ret__warp_mangled) = balances.read(key.low, key.high)
+    uint256_mstore(offset=Uint256(low=0, high=0), value=key)
+    uint256_mstore(offset=Uint256(low=32, high=0), value=Uint256(low=0, high=0))
+    let (__warp_subexpr_0 : Uint256) = uint256_pedersen(
+        Uint256(low=0, high=0), Uint256(low=64, high=0))
+    let (ret__warp_mangled : Uint256) = sload(__warp_subexpr_0)
     return (ret__warp_mangled)
 end
 

--- a/tests/golden/ERC20_storage.cairo
+++ b/tests/golden/ERC20_storage.cairo
@@ -31,10 +31,6 @@ func sstore{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
 end
 
 @storage_var
-func balanceOf(arg0_low, arg0_high) -> (res : Uint256):
-end
-
-@storage_var
 func evm_storage(arg0_low, arg0_high) -> (res : Uint256):
 end
 
@@ -310,10 +306,15 @@ func abi_encode_bool{memory_dict : DictAccess*, msize, range_check_ptr}(
     return (tail)
 end
 
-func getter_fun_balanceOf{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
-        key : Uint256) -> (ret__warp_mangled : Uint256):
+func getter_fun_balanceOf{
+        memory_dict : DictAccess*, msize, pedersen_ptr : HashBuiltin*, range_check_ptr,
+        syscall_ptr : felt*}(key : Uint256) -> (ret__warp_mangled : Uint256):
     alloc_locals
-    let (ret__warp_mangled) = balanceOf.read(key.low, key.high)
+    uint256_mstore(offset=Uint256(low=0, high=0), value=key)
+    uint256_mstore(offset=Uint256(low=32, high=0), value=Uint256(low=2, high=0))
+    let (__warp_subexpr_0 : Uint256) = uint256_pedersen(
+        Uint256(low=0, high=0), Uint256(low=64, high=0))
+    let (ret__warp_mangled : Uint256) = sload(__warp_subexpr_0)
     return (ret__warp_mangled)
 end
 

--- a/warp/yul/RevertNormalizer.py
+++ b/warp/yul/RevertNormalizer.py
@@ -7,7 +7,6 @@ from typing import Mapping, Optional
 import yul.yul_ast as ast
 from yul.AstMapper import AstMapper
 from yul.BuiltinHandler import BuiltinHandler
-from yul.storage_access import extract_var_from_getter, extract_var_from_setter
 from yul.top_sort import top_sort_ast
 
 REVERT = ast.FunctionCall(

--- a/warp/yul/storage_access.py
+++ b/warp/yul/storage_access.py
@@ -1,27 +1,9 @@
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass
-from typing import Iterable, Optional
+from typing import Iterable
 
 from yul.WarpException import warp_assert
-
-GETTER_PATTERN = re.compile(r"getter_fun_(\S*)(_(\d+))?")
-SETTER_PATTERN = re.compile(r"setter_fun_(\S*)(_(\d+))?")
-
-
-def extract_var_from_getter(getter: str) -> Optional[str]:
-    match = re.fullmatch(GETTER_PATTERN, getter)
-    if not match:
-        return None
-    return match.group(1)
-
-
-def extract_var_from_setter(setter: str) -> Optional[str]:
-    match = re.fullmatch(SETTER_PATTERN, setter)
-    if not match:
-        return None
-    return match.group(1)
 
 
 @dataclass(frozen=True, order=True)


### PR DESCRIPTION
We decided to move away from creating separate storage vars based on
     function names. It's fragile and unreliable. However, some code
     for it was still left in warp, it's time to clean it up.