### PR TITLE
remove splitting of parameters in the storage variable

### DIFF
--- a/tests/golden/ERC20.cairo
+++ b/tests/golden/ERC20.cairo
@@ -20,18 +20,18 @@ end
 
 func sstore{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
         key : Uint256, value : Uint256):
-    evm_storage.write(key.low, key.high, value)
+    evm_storage.write(key, value)
     return ()
 end
 
 func sload{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(key : Uint256) -> (
         value : Uint256):
-    let (value) = evm_storage.read(key.low, key.high)
+    let (value) = evm_storage.read(key)
     return (value)
 end
 
 @storage_var
-func evm_storage(arg0_low, arg0_high) -> (res : Uint256):
+func evm_storage(arg0 : Uint256) -> (res : Uint256):
 end
 
 @constructor

--- a/tests/golden/ERC20_storage.cairo
+++ b/tests/golden/ERC20_storage.cairo
@@ -20,18 +20,18 @@ end
 
 func sload{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(key : Uint256) -> (
         value : Uint256):
-    let (value) = evm_storage.read(key.low, key.high)
+    let (value) = evm_storage.read(key)
     return (value)
 end
 
 func sstore{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
         key : Uint256, value : Uint256):
-    evm_storage.write(key.low, key.high, value)
+    evm_storage.write(key, value)
     return ()
 end
 
 @storage_var
-func evm_storage(arg0_low, arg0_high) -> (res : Uint256):
+func evm_storage(arg0 : Uint256) -> (res : Uint256):
 end
 
 @constructor

--- a/tests/golden/arrays.cairo
+++ b/tests/golden/arrays.cairo
@@ -20,18 +20,18 @@ end
 
 func sload{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(key : Uint256) -> (
         value : Uint256):
-    let (value) = evm_storage.read(key.low, key.high)
+    let (value) = evm_storage.read(key)
     return (value)
 end
 
 func sstore{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
         key : Uint256, value : Uint256):
-    evm_storage.write(key.low, key.high, value)
+    evm_storage.write(key, value)
     return ()
 end
 
 @storage_var
-func evm_storage(arg0_low, arg0_high) -> (res : Uint256):
+func evm_storage(arg0 : Uint256) -> (res : Uint256):
 end
 
 @constructor

--- a/tests/golden/constructors_dyn.cairo
+++ b/tests/golden/constructors_dyn.cairo
@@ -19,18 +19,18 @@ end
 
 func sstore{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
         key : Uint256, value : Uint256):
-    evm_storage.write(key.low, key.high, value)
+    evm_storage.write(key, value)
     return ()
 end
 
 func sload{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(key : Uint256) -> (
         value : Uint256):
-    let (value) = evm_storage.read(key.low, key.high)
+    let (value) = evm_storage.read(key)
     return (value)
 end
 
 @storage_var
-func evm_storage(arg0_low, arg0_high) -> (res : Uint256):
+func evm_storage(arg0 : Uint256) -> (res : Uint256):
 end
 
 @constructor

--- a/tests/golden/constructors_nonDyn.cairo
+++ b/tests/golden/constructors_nonDyn.cairo
@@ -19,18 +19,18 @@ end
 
 func sstore{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
         key : Uint256, value : Uint256):
-    evm_storage.write(key.low, key.high, value)
+    evm_storage.write(key, value)
     return ()
 end
 
 func sload{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(key : Uint256) -> (
         value : Uint256):
-    let (value) = evm_storage.read(key.low, key.high)
+    let (value) = evm_storage.read(key)
     return (value)
 end
 
 @storage_var
-func evm_storage(arg0_low, arg0_high) -> (res : Uint256):
+func evm_storage(arg0 : Uint256) -> (res : Uint256):
 end
 
 @constructor

--- a/tests/golden/ctor-check.cairo
+++ b/tests/golden/ctor-check.cairo
@@ -19,13 +19,13 @@ end
 
 func sstore{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
         key : Uint256, value : Uint256):
-    evm_storage.write(key.low, key.high, value)
+    evm_storage.write(key, value)
     return ()
 end
 
 func sload{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(key : Uint256) -> (
         value : Uint256):
-    let (value) = evm_storage.read(key.low, key.high)
+    let (value) = evm_storage.read(key)
     return (value)
 end
 
@@ -38,7 +38,7 @@ func __warp_constant_10000000000000000000000000000000000000000() -> (res : Uint2
 end
 
 @storage_var
-func evm_storage(arg0_low, arg0_high) -> (res : Uint256):
+func evm_storage(arg0 : Uint256) -> (res : Uint256):
 end
 
 @constructor

--- a/tests/golden/delegatecall.cairo
+++ b/tests/golden/delegatecall.cairo
@@ -19,13 +19,13 @@ end
 
 func sstore{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
         key : Uint256, value : Uint256):
-    evm_storage.write(key.low, key.high, value)
+    evm_storage.write(key, value)
     return ()
 end
 
 func sload{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(key : Uint256) -> (
         value : Uint256):
-    let (value) = evm_storage.read(key.low, key.high)
+    let (value) = evm_storage.read(key)
     return (value)
 end
 
@@ -38,7 +38,7 @@ func __warp_constant_10000000000000000000000000000000000000000() -> (res : Uint2
 end
 
 @storage_var
-func evm_storage(arg0_low, arg0_high) -> (res : Uint256):
+func evm_storage(arg0 : Uint256) -> (res : Uint256):
 end
 
 @constructor

--- a/tests/golden/if-flattening.cairo
+++ b/tests/golden/if-flattening.cairo
@@ -20,18 +20,18 @@ end
 
 func sload{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(key : Uint256) -> (
         value : Uint256):
-    let (value) = evm_storage.read(key.low, key.high)
+    let (value) = evm_storage.read(key)
     return (value)
 end
 
 func sstore{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
         key : Uint256, value : Uint256):
-    evm_storage.write(key.low, key.high, value)
+    evm_storage.write(key, value)
     return ()
 end
 
 @storage_var
-func evm_storage(arg0_low, arg0_high) -> (res : Uint256):
+func evm_storage(arg0 : Uint256) -> (res : Uint256):
 end
 
 @constructor

--- a/tests/golden/simple-storage-var.cairo
+++ b/tests/golden/simple-storage-var.cairo
@@ -19,18 +19,18 @@ end
 
 func sload{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(key : Uint256) -> (
         value : Uint256):
-    let (value) = evm_storage.read(key.low, key.high)
+    let (value) = evm_storage.read(key)
     return (value)
 end
 
 func sstore{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
         key : Uint256, value : Uint256):
-    evm_storage.write(key.low, key.high, value)
+    evm_storage.write(key, value)
     return ()
 end
 
 @storage_var
-func evm_storage(arg0_low, arg0_high) -> (res : Uint256):
+func evm_storage(arg0 : Uint256) -> (res : Uint256):
 end
 
 @constructor

--- a/tests/golden/sstore-sload.cairo
+++ b/tests/golden/sstore-sload.cairo
@@ -19,18 +19,18 @@ end
 
 func sstore{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(
         key : Uint256, value : Uint256):
-    evm_storage.write(key.low, key.high, value)
+    evm_storage.write(key, value)
     return ()
 end
 
 func sload{pedersen_ptr : HashBuiltin*, range_check_ptr, syscall_ptr : felt*}(key : Uint256) -> (
         value : Uint256):
-    let (value) = evm_storage.read(key.low, key.high)
+    let (value) = evm_storage.read(key)
     return (value)
 end
 
 @storage_var
-func evm_storage(arg0_low, arg0_high) -> (res : Uint256):
+func evm_storage(arg0 : Uint256) -> (res : Uint256):
 end
 
 @constructor

--- a/warp/yul/storage_access.py
+++ b/warp/yul/storage_access.py
@@ -16,18 +16,15 @@ class StorageVar:
 def generate_getter_body(
     getter_var: str, args: Iterable[str], return_name: str = "res"
 ) -> str:
-    args_repr = ", ".join(f"{x}.low, {x}.high" for x in args)
+    args_repr = ", ".join(args)
     return (
         f"let ({return_name}) = {getter_var}.read({args_repr})\nreturn ({return_name})"
     )
 
 
 def generate_setter_body(setter_var: str, args: Iterable[str]) -> str:
-    *access_args, value_arg = args
-    args_repr = ", ".join(f"{x}.low, {x}.high" for x in access_args)
-    if access_args:
-        args_repr += ", "
-    return f"{setter_var}.write({args_repr}{value_arg})\nreturn ()"
+    args_repr = ", ".join(args)
+    return f"{setter_var}.write({args_repr})\nreturn ()\n"
 
 
 def generate_storage_var_declaration(var: StorageVar) -> str:
@@ -39,9 +36,7 @@ def generate_storage_var_declaration(var: StorageVar) -> str:
         var.res_type == "Uint256",
         "We don't support storage variables that return types other than Uint256",
     )
-    args_repr = ", ".join(
-        f"arg{i}_low, arg{i}_high" for i, typ in enumerate(var.arg_types)
-    )
+    args_repr = ", ".join(f"arg{i} : {typ}" for i, typ in enumerate(var.arg_types))
     return (
         f"@storage_var\n"
         f"func {var.name}({args_repr}) -> (res: {var.res_type}):\n"


### PR DESCRIPTION
Before 0.6.2 Cairo couldn't handle struct parameters for storage
     variables, so we had to split each Uint256 into its low and high
     part. It's no longer necessary.