### PR TITLE
Fail fast on unsuported solidity semantics

### DIFF
--- a/src/warp/yul/BuiltinHandler.py
+++ b/src/warp/yul/BuiltinHandler.py
@@ -7,6 +7,7 @@ from typing import Callable, Mapping, Optional, Sequence
 
 from warp.yul.FunctionGenerator import CairoFunctions, FunctionInfo
 from warp.yul.Imports import Imports
+from warp.yul.source_filter import see
 
 UINT256_MODULE = "starkware.cairo.common.uint256"
 
@@ -151,8 +152,9 @@ class NotImplementedStarkNet(StaticHandler):
 
     def get_function_call(self, _args: Sequence[str]):
         raise RuntimeError(
-            f"WARNING: This contract referenced '{type(self).__name__.lower()}' "
+            f"WARNING: This contract's compile YUL referenced '{type(self).__name__.lower()}' "
             f"which is not yet supported."
+            f"\n\n\t{see}"
         )
 
 

--- a/src/warp/yul/main.py
+++ b/src/warp/yul/main.py
@@ -25,6 +25,7 @@ from warp.yul.parse_object import parse_to_normalized_ast
 from warp.yul.Renamer import MangleNamesVisitor
 from warp.yul.RevertNormalizer import RevertNormalizer
 from warp.yul.ScopeFlattener import ScopeFlattener
+from warp.yul.source_filter import ensure_compilable
 from warp.yul.SwitchToIfVisitor import SwitchToIfVisitor
 from warp.yul.ToCairoVisitor import ToCairoVisitor
 from warp.yul.utils import get_for_contract
@@ -48,6 +49,7 @@ class bcolors:
 def transpile_from_solidity(
     sol_src_path, main_contract, optimizers_order="VFoLRFD"
 ) -> dict:
+    ensure_compilable(sol_src_path)
     sol_src_path_modified = str(sol_src_path)[:-4] + "_marked.sol"
     try:
         with kudu_exe() as exe:
@@ -64,6 +66,7 @@ def transpile_from_solidity(
                 + bcolors.ENDC,
                 file=sys.stderr,
             )
+
     except subprocess.CalledProcessError as e:
         print(
             bcolors.FAIL + bcolors.BOLD + e.stderr.decode("utf-8") + bcolors.ENDC,

--- a/src/warp/yul/source_filter.py
+++ b/src/warp/yul/source_filter.py
@@ -1,0 +1,58 @@
+import dataclasses
+import re
+import sys
+from os.path import exists
+
+
+@dataclasses.dataclass()
+class bcolors:
+    HEADER = "\033[95m"
+    OKBLUE = "\033[94m"
+    OKCYAN = "\033[96m"
+    OKGREEN = "\033[92m"
+    WARNING = "\033[93m"
+    FAIL = "\033[91m"
+    ENDC = "\033[0m"
+    BOLD = "\033[1m"
+    UNDERLINE = "\033[4m"
+
+
+readme_link = (
+    "https://github.com/NethermindEth/warp#solidity-constructs-currently-not-supported"
+)
+see = f"See {readme_link} for more details."
+illegal_patterns = [
+    (r"\bmsg.value\b", "Warp doesn't support msg.value."),
+    (r"\btx.origin\b", "Warp doesn't support tx.origin."),
+    (r"\btx.gasprice\b", "Warp doesn't support tx.gasprice."),
+    (r"\bblock.basefee\b", "Warp doesn't support block.basefee."),
+    (r"\bblock.chainid\b", "Warp doesn't support block.chainid."),
+    (r"\bblock.coinbase\b", "Warp doesn't support block.coinbase."),
+    (r"\bblock.difficulty\b", "Warp doesn't support block.difficulty."),
+    (r"\bblock.gaslimit\b", "Warp doesn't support block.gaslimit."),
+    (r"\bgasleft\b", "Warp doesn't support gasleft."),
+    (r"\bselfdestruct\b", "Warp doesn't support selfdestruct."),
+    (r"\bblockhash\b", "Warp doesn't support blockhash."),
+    (
+        r"\bkeccak256\b",
+        "Warp doesn't support keccak since it's too slow on starknet. Please consider using the pedersen primitive.",
+    ),
+    (
+        r"\btry\b",
+        "Warp doesn't support try/catch.",
+    ),
+]
+
+
+def ensure_compilable(sol_src_path: str):
+    with open(sol_src_path) as f:
+        source = f.read()
+        for (regex, error_msg) in illegal_patterns:
+            if re.compile(regex).search(source):
+                print(
+                    bcolors.FAIL
+                    + bcolors.BOLD
+                    + f"{error_msg}\n\n\t{see}\n"
+                    + bcolors.ENDC,
+                    file=sys.stderr,
+                )


### PR DESCRIPTION
Some of these constructs were being compiled to nonsense cairo. For example we implement `callvalue` for a specific case which resulted in all contracts containing `msg.value` to be compiled.

The solution is to filter for these regexes to make sure we enforce that these won't be compiled.