### PR TITLE
Enable python-based syntax highlightling for .cairo files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.cairo linguist-language=python


### PR DESCRIPTION
Was browsing the repo on GH and thought it might benefit from the `.gitattributes` trend that's been popping up in [other projects](https://github.com/OpenZeppelin/cairo-contracts/blob/main/.gitattributes) to enable basic coloring for cairo code.

Feel free to close if not interested or just wanna wait for official GH support :)

![screenshot-github com-2022 01 25-06_54_10](https://user-images.githubusercontent.com/1211977/150991526-116a0774-4f04-42a2-a88d-7c298b379f01.png)
