### PR TITLE
modify external contract method call

### DIFF
--- a/example_contracts/external_function.sol
+++ b/example_contracts/external_function.sol
@@ -1,0 +1,24 @@
+
+pragma solidity ^0.8.10;
+
+//SPDX-License-Identifier: MIT
+
+contract A{
+    uint a;
+	function f() public {
+        a = 2;
+    }
+}
+contract B{
+	A public b;
+    struct AA{
+        uint x;
+        uint y;
+    }
+}
+contract C{
+	B public a;
+	function foo() public{
+		a.b().f();
+	}
+}

--- a/src/cairoWriter.ts
+++ b/src/cairoWriter.ts
@@ -31,6 +31,7 @@ import {
   FunctionStateMutability,
   FunctionTypeName,
   FunctionVisibility,
+  getNodeType,
   Identifier,
   IdentifierPath,
   IfStatement,
@@ -63,12 +64,12 @@ import {
   TupleExpression,
   UnaryOperation,
   UncheckedBlock,
+  UserDefinedType,
   UserDefinedTypeName,
   UsingForDirective,
   VariableDeclaration,
   VariableDeclarationStatement,
   WhileStatement,
-  getNodeType,
 } from 'solc-typed-ast';
 import { CairoAssert, CairoContract, CairoFunctionDefinition } from './ast/cairoNodes';
 import { writeImplicits } from './utils/implicits';
@@ -444,17 +445,40 @@ class IdentifierWriter extends CairoASTNodeWriter {
 
 class FunctionCallWriter extends CairoASTNodeWriter {
   writeInner(node: FunctionCall, writer: ASTWriter): SrcDesc {
+    const args = node.vArguments.map((v) => writer.write(v)).join(', ');
+    const func = writer.write(node.vExpression);
     switch (node.kind) {
-      case FunctionCallKind.FunctionCall:
+      case FunctionCallKind.FunctionCall: {
+        if (node.vExpression instanceof MemberAccess) {
+          // check if node.vExpression.vExpression.typeString includes "contract"
+          const nodeType = getNodeType(node.vExpression.vExpression, writer.targetCompilerVersion);
+          if (
+            nodeType instanceof UserDefinedType &&
+            nodeType.definition instanceof ContractDefinition
+          ) {
+            const contractType = nodeType.definition.name;
+            const memberName = node.vExpression.memberName;
+            const contract = writer.write(node.vExpression.vExpression);
+            return [`${contractType}.${memberName}(${contract}${args ? ', ' : ''}${args})`];
+          }
+        }
+        return [`${func}(${args})`];
+      }
+
       case FunctionCallKind.TypeConversion: {
-        const args = node.vArguments.map((v) => writer.write(v)).join(', ');
-        const func = writer.write(node.vExpression);
         const arg = node.vArguments[0];
         if (node.vFunctionName === 'address' && arg instanceof Literal) {
           const val: BigInt = BigInt(arg.value);
           // Make sure literal < 2**251
           assert(val < BigInt('0x800000000000000000000000000000000000000000000000000000000000000'));
           return [`${args[0]}`];
+        }
+        const nodeType = getNodeType(node.vExpression, writer.targetCompilerVersion);
+        if (
+          nodeType instanceof UserDefinedType &&
+          nodeType.definition instanceof ContractDefinition
+        ) {
+          return [`${args}`];
         }
         return [`${func}(${args})`];
       }

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -46,6 +46,7 @@ const expectedResults = new Map<string, ResultType>([
   ['example_contracts/errorHandling/require', 'Success'],
   ['example_contracts/errorHandling/revert', 'Success'],
   ['example_contracts/events', 'Success'],
+  ['example_contracts/external_function', 'NotSupportedYet'],
   ['example_contracts/freeFunction', 'Success'],
   ['example_contracts/function-with-nested-return', 'Success'],
   ['example_contracts/functionArgumentConversions', 'Success'],

--- a/src/utils/cairoTypeSystem.ts
+++ b/src/utils/cairoTypeSystem.ts
@@ -4,6 +4,7 @@ import {
   ArrayType,
   BoolType,
   BytesType,
+  ContractDefinition,
   StringType,
   AddressType,
   BuiltinType,
@@ -95,6 +96,8 @@ export abstract class CairoType {
             ),
           );
         }
+      } else if (tp.definition instanceof ContractDefinition) {
+        return new CairoFelt();
       }
       throw new NotSupportedYetError(
         `Serialising ${tp.definition.type} UserDefinedType not supported yet. Found at ${printNode(


### PR DESCRIPTION
modify cairoWriter such that calls to methods on contracts get changed to the form the cairo expects. E.g. `a.f(arg1)` in solidity becomes `ContractType.f(a, arg1)`