### PR TITLE
Fix Actual Outcome of testing.ts

### DIFF
--- a/src/testing.ts
+++ b/src/testing.ts
@@ -234,7 +234,20 @@ function printResults(results: Map<string, ResultType>, unexpectedResults: strin
     unexpectedResults.map((o) => {
       console.log(`\nTest: ${o}.sol`);
       console.log(`Expected outcome: ${expectedResults.get(o)}`);
-      console.log(`Actual outcome: ${results.get(o)}`);
+      console.log(`Actual outcome:`);
+      const Actual = new Map<string, ResultType>();
+      results.forEach((value, key) => {
+        if (key.includes(o)) {
+          Actual.set(key, value);
+        }
+      });
+      Actual.forEach((value, key) => {
+        if (key.includes('WARP')) {
+          console.log(key + '.cairo' + ' : ' + value);
+        } else {
+          console.log(key + '.sol' + ' : ' + value);
+        }
+      });
     });
     console.log('\n');
   }


### PR DESCRIPTION
Fixes bug for status `CairoCompileFailed` (`bin/warp test`)
The Actual Outcome will print status for `.sol` and `.cairo` files separately 
Eg:
```
Test: example_contracts/loops/for-loop-with-nested-return
Expected outcome: Success
Actual outcome:
example_contracts/loops/for-loop-with-nested-return.sol : Success
example_contracts/loops/for-loop-with-nested-return__WARP_CONTRACT__WARP.cairo : CairoCompileFailed
```
