### PR TITLE
Validate constructor input

### DIFF
--- a/src/passes/externalInputChecker/booleanBoundChecker.ts
+++ b/src/passes/externalInputChecker/booleanBoundChecker.ts
@@ -17,7 +17,11 @@ import { createIdentifier } from '../../utils/nodeTemplates';
 
 export class BooleanBoundChecker extends ASTMapper {
   visitFunctionDefinition(node: FunctionDefinition, ast: AST): void {
-    if (FunctionVisibility.External === node.visibility && node.vBody !== undefined) {
+    if (
+      (FunctionVisibility.External === node.visibility ||
+        FunctionVisibility.Public === node.visibility) &&
+      node.vBody !== undefined
+    ) {
       node.vParameters.vParameters.forEach((parameter) => {
         const typeNode = getNodeType(parameter, ast.compilerVersion);
         if (typeNode instanceof BoolType) {

--- a/src/passes/externalInputChecker/enumBoundChecker.ts
+++ b/src/passes/externalInputChecker/enumBoundChecker.ts
@@ -13,7 +13,11 @@ import { createIdentifier } from '../../utils/nodeTemplates';
 
 export class EnumBoundChecker extends ASTMapper {
   visitFunctionDefinition(node: FunctionDefinition, ast: AST): void {
-    if (FunctionVisibility.External === node.visibility && node.vBody !== undefined) {
+    if (
+      (FunctionVisibility.External === node.visibility ||
+        FunctionVisibility.Public === node.visibility) &&
+      node.vBody !== undefined
+    ) {
       node.vParameters.vParameters.forEach((parameter) => {
         if (parameter.typeString.slice(0, 4) === 'enum' && parameter.name !== undefined) {
           const functionCall = this.generateFunctionCall(node, parameter, ast);

--- a/src/passes/externalInputChecker/intBoundChecker.ts
+++ b/src/passes/externalInputChecker/intBoundChecker.ts
@@ -17,7 +17,11 @@ import { createIdentifier } from '../../utils/nodeTemplates';
 
 export class IntBoundChecker extends ASTMapper {
   visitFunctionDefinition(node: FunctionDefinition, ast: AST): void {
-    if (FunctionVisibility.External === node.visibility && node.vBody !== undefined) {
+    if (
+      (FunctionVisibility.External === node.visibility ||
+        FunctionVisibility.Public === node.visibility) &&
+      node.vBody !== undefined
+    ) {
       node.vParameters.vParameters.forEach((parameter) => {
         const typeNode = getNodeType(parameter, ast.compilerVersion);
         if (typeNode instanceof IntType) {

--- a/tests/behaviour/contracts/constants/simpleImmutable.sol
+++ b/tests/behaviour/contracts/constants/simpleImmutable.sol
@@ -3,16 +3,26 @@ pragma solidity >=0.8.4;
 
 contract WARP {
   uint immutable uintValue;
+  int16 immutable intValue;
 
-  constructor(uint u) {
+  constructor(uint u, int16 i) {
     uintValue = u;
+    intValue = i;
   }
 
   function getUintValue() public view returns (uint) {
     return uintValue;
   }
 
+  function getIntValue() public view returns (int16) {
+    return intValue;
+  }
+
   function addUintValue(uint x) public view returns (uint) {
     return uintValue + x;
+  }
+
+  function addIntValue(int16 a) public view returns (int16) {
+    return intValue + a;
   }
 }

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -82,10 +82,12 @@ export const expectations = flatten(
           new File(
             'simpleImmutable',
             'WARP',
-            ['0', '256'],
+            ['0', '256', '512'],
             [
               Expect.Simple('getUintValue', [], ['0', '256'], '0'),
+              Expect.Simple('getIntValue', [], ['512'], '0'),
               Expect.Simple('addUintValue', ['0', '256'], ['0', '512'], '0'),
+              Expect.Simple('addIntValue', ['256'], ['768'], '0'),
             ],
           ),
         ]),


### PR DESCRIPTION
Validate constructor arguments by adding public functions to the external input checker passes.

This PR also improves the behaviour test for `simpleImmutable`, which spawned this fix and is now found to be associated with an unrelated discrepancy between Starknet CLI and the behaviour/Starknet test suite when providing negative integers as arguments to the deployment of a contract.