### PR TITLE
Modifier inheritance

### DIFF
--- a/src/utils/cloning.ts
+++ b/src/utils/cloning.ts
@@ -20,6 +20,7 @@ import {
   Literal,
   Mapping,
   MemberAccess,
+  ModifierDefinition,
   ModifierInvocation,
   OverrideSpecifier,
   ParameterList,
@@ -332,6 +333,20 @@ function cloneASTNodeImpl<T extends ASTNode>(
       cloneASTNodeImpl(node.vParameters, ast, remappedIds),
       cloneASTNodeImpl(node.vReturnParameters, ast, remappedIds),
       node.vModifiers.map((m) => cloneASTNodeImpl(m, ast, remappedIds)),
+      node.vOverrideSpecifier && cloneASTNodeImpl(node.vOverrideSpecifier, ast, remappedIds),
+      node.vBody && cloneASTNodeImpl(node.vBody, ast, remappedIds),
+      node.documentation,
+      node.nameLocation,
+      node.raw,
+    );
+  } else if (node instanceof ModifierDefinition) {
+    newNode = new ModifierDefinition(
+      replaceId(node.id, ast, remappedIds),
+      node.src,
+      node.name,
+      node.virtual,
+      node.visibility,
+      cloneASTNodeImpl(node.vParameters, ast, remappedIds),
       node.vOverrideSpecifier && cloneASTNodeImpl(node.vOverrideSpecifier, ast, remappedIds),
       node.vBody && cloneASTNodeImpl(node.vBody, ast, remappedIds),
       node.documentation,

--- a/tests/behaviour/contracts/inheritance/modifiers/modifierInheritance.sol
+++ b/tests/behaviour/contracts/inheritance/modifiers/modifierInheritance.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.0;
+
+contract A {
+  bool locked = false;
+
+  modifier unlocked() {
+    require(!locked, 'Can not call this function when locked');
+    locked = true;
+    _;
+    locked = false;
+  }
+
+  function lock() public {
+    locked = true;
+  }
+}
+
+contract B is A {
+  uint256 public balance;
+
+  function clear() public {
+    delete balance;
+    delete locked;
+  }
+}
+
+contract C {
+  modifier costs(uint256 value, uint256 price) {
+    if (value >= price) {
+      _;
+    }
+  }
+}
+
+contract D is C, B {
+  constructor() {
+    balance = 100000;
+  }
+
+  function withdraw(uint256 price) public unlocked costs(balance, price) returns (uint256 result) {
+    balance -= price;
+    return balance;
+  }
+}

--- a/tests/behaviour/contracts/inheritance/modifiers/modifierOverriding.sol
+++ b/tests/behaviour/contracts/inheritance/modifiers/modifierOverriding.sol
@@ -1,0 +1,32 @@
+pragma solidity ^0.8.0;
+
+contract A {
+  uint256 balance = 6000;
+
+  modifier cost(uint256 value) virtual {
+    require(value <= balance, 'Value to withdraw must be smaller than the current balance');
+    _;
+  }
+}
+
+contract B is A {
+  uint256 limit = 200;
+
+  modifier cost(uint256 value) override {
+    require(value <= balance, 'Value to withdraw must be smaller than the current balance');
+    require(value >= limit, 'Value to withdraw must be bigger than the limit');
+    _;
+  }
+}
+
+contract C is B {
+  modifier rest() {
+    _;
+    require(balance >= 1000, 'Balance must be bigger than 1000');
+  }
+
+  function withdraw(uint256 price) public cost(price) rest returns (uint256) {
+    balance -= price;
+    return balance;
+  }
+}

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -660,6 +660,54 @@ export const expectations = flatten(
           new Dir('variables', [
             new File('derived', 'Derived', [], [Expect.Simple('f', [], ['36', '0', '24', '0'])]),
           ]),
+          new Dir('modifiers', [
+            new File(
+              'modifierInheritance',
+              'D',
+              [],
+              [
+                new Expect('modifier', [
+                  ['withdraw', ['5000', '0'], ['95000', '0'], '0'],
+                  ['lock', [], [], '0'],
+                  ['withdraw', ['280', '0'], null, '0', 'Can not call this function when locked'],
+                  ['clear', [], [], '0'],
+                  ['withdraw', ['280', '0'], ['0', '0'], '0'],
+                ]),
+              ],
+            ),
+            new File(
+              'modifierOverriding',
+              'C',
+              [],
+              [
+                new Expect('modifier', [
+                  [
+                    'withdraw',
+                    ['10000', '0'],
+                    null,
+                    '0',
+                    'Value to withdraw must be smaller than the current balance',
+                  ],
+                  [
+                    'withdraw',
+                    ['100', '0'],
+                    null,
+                    '0',
+                    'Value to withdraw must be bigger than the limit',
+                  ],
+                  ['withdraw', ['5500', '0'], null, '0', 'Balance must be bigger than 1000'],
+                  ['withdraw', ['5000', '0'], ['1000', '0'], '0'],
+                  [
+                    'withdraw',
+                    ['100', '0'],
+                    null,
+                    '0',
+                    'Value to withdraw must be bigger than the limit',
+                  ],
+                ]),
+              ],
+            ),
+          ]),
         ]),
         new Dir('libraries', [
           File.Simple('using_for', [


### PR DESCRIPTION
Added functionality to handle modifier inheritance within `inheritanceInliner` pass. It follows the same approach taken by function inheritance.