### PR TITLE
Install older marshmallow-dataclass version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask >= 2.0.2
 flask-cors >= 3.0.10
 flask[async]
 cairo-lang == 0.8.1
+marshmallow-dataclass == 8.5.3


### PR DESCRIPTION
Marshmallow 8.5.4 was released yesterday and causes starknet-compile to crash, this specifies that 8.5.3 should be installed