### PR TITLE
Source unit

### DIFF
--- a/src/passes/functionModifierHandler/functionModifierHandler.ts
+++ b/src/passes/functionModifierHandler/functionModifierHandler.ts
@@ -4,9 +4,6 @@ import {
   FunctionKind,
   FunctionVisibility,
   ModifierDefinition,
-  Return,
-  SourceUnit,
-  Statement,
   VariableDeclaration,
 } from 'solc-typed-ast';
 import { AST } from '../../ast/ast';
@@ -91,76 +88,62 @@ export class FunctionModifierHandler extends ASTMapper {
     functionToCall: FunctionDefinition,
     ast: AST,
   ): FunctionDefinition {
-    const scope = node.vScope;
-    const functionName = `__warp_${modifier.name}_${this.count++}`;
-    const funcId = ast.reserveId();
+    // First clone the modifier as a whole so all referencedDeclarations are rebound
+    const modifierClone = cloneASTNode(modifier, ast);
 
     const functionParams = functionToCall.vParameters.vParameters.map((v) =>
-      this.createParameter(v, funcId, ast),
+      this.createInputParameter(v, ast),
     );
-    const modParams = modifier.vParameters.vParameters.map((v) => {
-      const variable = cloneASTNode(v, ast);
-      variable.scope = funcId;
-      return variable;
-    });
-    const params = [...modParams, ...functionParams];
 
     const retParams = node.vReturnParameters.vParameters.map((v) =>
-      this.getNamedParam(v, funcId, ast),
+      this.createReturnParameter(v, ast),
     );
-    const retParamList = createParameterList(retParams, ast);
+    const retParamList = createParameterList(retParams, ast, modifierClone.id);
 
-    let statements: Statement[] = [];
+    ast.context.unregister(modifierClone);
 
-    // Add body of modifier
-    if (modifier.vBody !== undefined) {
-      const modBody = cloneASTNode(modifier.vBody, ast);
-      new FunctionModifierInliner(functionToCall, functionParams, retParamList).dispatchVisit(
-        modBody,
-        ast,
-      );
-      statements = statements.concat(modBody.vStatements);
-    }
-
-    // Add return statement
-    if (retParams.length > 0 && !(statements[statements.length - 1] instanceof Return))
-      statements.push(createReturn(retParams, retParamList.id, ast));
-
-    // Create Function Definition Node
-    const funcDef = new FunctionDefinition(
-      funcId,
-      '',
-      scope.id,
-      scope instanceof SourceUnit ? FunctionKind.Free : FunctionKind.Function,
-      functionName,
+    const modifierAsFunction = new FunctionDefinition(
+      modifierClone.id,
+      modifierClone.src,
+      node.scope,
+      FunctionKind.Function,
+      `__warp_${modifier.name}_${this.count++}`,
       node.virtual,
       FunctionVisibility.Internal,
       node.stateMutability,
-      false,
-      createParameterList(params, ast),
+      node.isConstructor,
+      createParameterList(
+        [...modifierClone.vParameters.vParameters, ...functionParams],
+        ast,
+        modifierClone.id,
+      ),
       retParamList,
       [],
       undefined,
-      createBlock(statements, ast),
+      modifierClone.vBody,
     );
 
-    // Insert node into ast
-    scope.insertAtBeginning(funcDef);
-    ast.registerChild(funcDef, scope);
-    return funcDef;
+    if (modifierAsFunction.vBody) {
+      new FunctionModifierInliner(functionToCall, functionParams, retParamList).dispatchVisit(
+        modifierAsFunction.vBody,
+        ast,
+      );
+    }
+
+    node.vScope.insertAtBeginning(modifierAsFunction);
+    ast.registerChild(modifierAsFunction, node.vScope);
+    return modifierAsFunction;
   }
 
-  createParameter(v: VariableDeclaration, scope: number, ast: AST): VariableDeclaration {
+  createInputParameter(v: VariableDeclaration, ast: AST): VariableDeclaration {
     const variable = cloneASTNode(v, ast);
     variable.name = `__warp_parameter${this.count++}`;
-    variable.scope = scope;
     return variable;
   }
 
-  getNamedParam(v: VariableDeclaration, scope: number, ast: AST): VariableDeclaration {
+  createReturnParameter(v: VariableDeclaration, ast: AST): VariableDeclaration {
     const param = cloneASTNode(v, ast);
     param.name = `__warp_ret_parameter${this.count++}`;
-    param.scope = scope;
     return param;
   }
 }

--- a/src/passes/identifierMangler.ts
+++ b/src/passes/identifierMangler.ts
@@ -51,7 +51,7 @@ export class IdentifierMangler extends ASTMapper {
     this.commonVisit(node, ast);
   }
 
-  visitImportDirective(node: ImportDirective, ast: AST): void {
+  visitImportDirective(_node: ImportDirective, _ast: AST): void {
     return;
   }
 

--- a/src/passes/identifierMangler.ts
+++ b/src/passes/identifierMangler.ts
@@ -51,12 +51,15 @@ export class IdentifierMangler extends ASTMapper {
     this.commonVisit(node, ast);
   }
 
+  visitImportDirective(node: ImportDirective, ast: AST): void {
+    return;
+  }
+
   visitIdentifier(node: Identifier, _ast: AST): void {
     if (
       node.vIdentifierType === ExternalReferenceType.UserDefined &&
       (node.vReferencedDeclaration instanceof VariableDeclaration ||
-        (node.vReferencedDeclaration instanceof FunctionDefinition &&
-          !(node.parent instanceof ImportDirective)))
+        node.vReferencedDeclaration instanceof FunctionDefinition)
     ) {
       node.name = node.vReferencedDeclaration.name;
     }

--- a/src/passes/sourceUnitSplitter.ts
+++ b/src/passes/sourceUnitSplitter.ts
@@ -44,7 +44,7 @@ function splitSourceUnit(sourceUnit: SourceUnit, ast: AST): SourceUnit[] {
     '',
     0,
     mangleFreeFilePath(filePathRoot) + '.sol',
-    new Map(),
+    sourceUnit.exportedSymbols,
     freeSourceChildren,
   );
 
@@ -56,7 +56,7 @@ function splitSourceUnit(sourceUnit: SourceUnit, ast: AST): SourceUnit[] {
       '',
       0,
       mangleContractFilePath(filePathRoot, contract.name) + '.sol',
-      new Map(),
+      sourceUnit.exportedSymbols,
       [
         ...sourceUnit.vImportDirectives.map((iD) => cloneASTNode(iD, ast)),
         ...updateScope([contract], contractSourceUnitId),
@@ -87,6 +87,10 @@ function splitSourceUnit(sourceUnit: SourceUnit, ast: AST): SourceUnit[] {
         );
         su.insertAtBeginning(iDir);
         ast.registerChild(iDir, su);
+        //ImportDirective scope should point to current SourceUnit
+        importSu.getChildrenByType(ImportDirective).forEach((IDNode) => {
+          IDNode.scope = importSu.id;
+        });
       }),
   );
 

--- a/src/utils/astChecking.ts
+++ b/src/utils/astChecking.ts
@@ -757,7 +757,7 @@ class IdChekcer extends ASTMapper {
             node instanceof VariableDeclaration) &&
           node.scope >= 0
         ) {
-          console.log(node.type, node.id);
+          console.log(printNode(node));
           assert(Ids.has(node.scope));
         } else if (
           (node instanceof Identifier ||
@@ -766,7 +766,7 @@ class IdChekcer extends ASTMapper {
             node instanceof UserDefinedTypeName) &&
           node.referencedDeclaration >= 0
         ) {
-          console.log(node.type, node.id);
+          console.log(printNode(node));
           assert(Ids.has(node.referencedDeclaration));
         } else if (
           // node instanceof  ||

--- a/src/utils/astChecking.ts
+++ b/src/utils/astChecking.ts
@@ -738,6 +738,10 @@ class ParameterScopeChecker extends ASTMapper {
   }
 }
 
+/* The pass asserts that all id based references refer 
+   to nodes that are children of the roots of the AST.
+*/
+
 class IdChecker extends ASTMapper {
   static Ids = new Set();
 

--- a/src/utils/astChecking.ts
+++ b/src/utils/astChecking.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import {
   ArrayTypeName,
   Assignment,
@@ -691,6 +692,7 @@ function checkIdNonNegative(node: ASTNode) {
 export function isSane(ast: AST): boolean {
   NodeTypeResolutionChecker.map(ast);
   ParameterScopeChecker.map(ast);
+  IdChekcer.map(ast);
 
   return ast.roots.every((root) => {
     try {
@@ -733,5 +735,94 @@ class ParameterScopeChecker extends ASTMapper {
         );
       }
     });
+  }
+}
+
+class IdChekcer extends ASTMapper {
+  static map(ast: AST): AST {
+    const Ids = new Set();
+    ast.roots.forEach((root) => {
+      root.getChildren(true).forEach((node) => {
+        Ids.add(node.id);
+      });
+    });
+
+    ast.roots.forEach((root) => {
+      root.walkChildren((node) => {
+        if (
+          (node instanceof ContractDefinition ||
+            node instanceof FunctionDefinition ||
+            node instanceof ImportDirective ||
+            node instanceof StructDefinition ||
+            node instanceof VariableDeclaration) &&
+          node.scope >= 0
+        ) {
+          console.log(node.type, node.id);
+          assert(Ids.has(node.scope));
+        } else if (
+          (node instanceof Identifier ||
+            node instanceof IdentifierPath ||
+            //node instanceof MemberAccess ||
+            node instanceof UserDefinedTypeName) &&
+          node.referencedDeclaration >= 0
+        ) {
+          console.log(node.type, node.id);
+          assert(Ids.has(node.referencedDeclaration));
+        } else if (
+          // node instanceof  ||
+          node instanceof ArrayTypeName ||
+          node instanceof Assignment ||
+          node instanceof BinaryOperation ||
+          node instanceof Block ||
+          node instanceof Break ||
+          node instanceof Continue ||
+          node instanceof DoWhileStatement ||
+          node instanceof ElementaryTypeName ||
+          node instanceof EmitStatement ||
+          node instanceof EnumDefinition ||
+          node instanceof EnumValue ||
+          node instanceof EventDefinition ||
+          node instanceof Expression ||
+          node instanceof ExpressionStatement ||
+          node instanceof ForStatement ||
+          node instanceof IfStatement ||
+          node instanceof InheritanceSpecifier ||
+          node instanceof InlineAssembly ||
+          node instanceof Literal ||
+          node instanceof Mapping ||
+          node instanceof ModifierDefinition ||
+          node instanceof ModifierInvocation ||
+          node instanceof OverrideSpecifier ||
+          node instanceof ParameterList ||
+          node instanceof PlaceholderStatement ||
+          node instanceof PragmaDirective ||
+          node instanceof Return ||
+          node instanceof RevertStatement ||
+          node instanceof StructuredDocumentation ||
+          node instanceof Throw ||
+          node instanceof TupleExpression ||
+          node instanceof UncheckedBlock ||
+          node instanceof UsingForDirective ||
+          node instanceof VariableDeclarationStatement ||
+          node instanceof WhileStatement
+        ) {
+          /**
+           * These nodes do not ID references or scope.
+           * There is nothing to check, so just skip them.
+           */
+        } else {
+          throw new Error(
+            `Id properties for node ${pp(node)} is not reachable through the current AST`,
+          );
+        }
+      });
+    });
+    // root.getChildren(true).forEach((node) =>{
+    //   if (node instanceof (Identifier || MemberAccess)){
+    //     //console.log(node.referencedDeclaration)
+    //     assert(Ids.has(node.referencedDeclaration))
+    //   }
+    // })
+    return ast;
   }
 }

--- a/src/utils/nodeTemplates.ts
+++ b/src/utils/nodeTemplates.ts
@@ -83,9 +83,13 @@ export function createNumberLiteral(value: bigint, typeString: string, ast: AST)
 export function createParameterList(
   params: Iterable<VariableDeclaration>,
   ast: AST,
+  scope?: number,
 ): ParameterList {
   const paramList = new ParameterList(ast.reserveId(), '', params);
   ast.setContextRecursive(paramList);
+  if (scope !== undefined) {
+    [...params].forEach((decl) => (decl.scope = scope));
+  }
   return paramList;
 }
 


### PR DESCRIPTION
- [x] Added a pass to astChecking.ts that asserts that all id based references refer to nodes that are children of the roots of the AST
- [x] Bug fix for ImportDirectives to refer to the current source unit
- [x] Bug fix for empty ExportedSymbols after souce unit splitting.