### PR TITLE
Handle ineffectual structs

### DIFF
--- a/src/cairoWriter.ts
+++ b/src/cairoWriter.ts
@@ -541,7 +541,8 @@ class ExpressionStatementWriter extends CairoASTNodeWriter {
   writeInner(node: ExpressionStatement, writer: ASTWriter): SrcDesc {
     const documentation = getDocumentation(node.documentation, writer);
     if (
-      node.vExpression instanceof FunctionCall ||
+      (node.vExpression instanceof FunctionCall &&
+        node.vExpression.kind !== FunctionCallKind.StructConstructorCall) ||
       node.vExpression instanceof Assignment ||
       node.vExpression instanceof CairoAssert
     ) {

--- a/src/passes/references/dataAccessFunctionaliser.ts
+++ b/src/passes/references/dataAccessFunctionaliser.ts
@@ -145,10 +145,8 @@ export class DataAccessFunctionaliser extends ReferenceSubPass {
   }
 
   visitFunctionCall(node: FunctionCall, ast: AST): void {
-    // const expectedLoc = this.getLocations(node)[1];
     if (node.kind === FunctionCallKind.StructConstructorCall) {
       // Memory struct constructor calls should have been replaced by memoryAllocations
-      // assert(expectedLoc === DataLocation.Default);
       return this.commonVisit(node, ast);
     } else {
       return this.visitExpression(node, ast);

--- a/tests/behaviour/contracts/expressions/ineffectual.sol
+++ b/tests/behaviour/contracts/expressions/ineffectual.sol
@@ -3,11 +3,15 @@ pragma solidity ^0.8.10;
 //SPDX-License-Identifier: MIT
 
 contract WARP {
+  struct S {
+    uint a;
+  }
   function test(uint8 x) pure public returns (uint8) {
     1;
     1+1;
     x;
     x + 1;
+    S(x);
     return x;
   }
 }


### PR DESCRIPTION
Detects struct constructors that are direct children of expression statements and treats them as a `let`, since a struct constructor call is not a valid cairo statement