### PR TITLE
Inheritance removal

### DIFF
--- a/src/passes/inheritanceInliner/utils.ts
+++ b/src/passes/inheritanceInliner/utils.ts
@@ -47,7 +47,6 @@ export function updateReferencedDeclarations(
 }
 
 export function removeBaseContractDependence(node: ContractDefinition): void {
-  node.linearizedBaseContracts = [];
   const toRemove = node.children.filter(
     (child): child is InheritanceSpecifier => child instanceof InheritanceSpecifier,
   );

--- a/src/passes/inheritanceInliner/utils.ts
+++ b/src/passes/inheritanceInliner/utils.ts
@@ -4,6 +4,7 @@ import {
   FunctionDefinition,
   Identifier,
   IdentifierPath,
+  InheritanceSpecifier,
   MemberAccess,
   ModifierDefinition,
   VariableDeclaration,
@@ -43,4 +44,12 @@ export function updateReferencedDeclarations(
       }
     }
   });
+}
+
+export function removeBaseContractDependence(node: ContractDefinition): void {
+  node.linearizedBaseContracts = [];
+  const toRemove = node.children.filter(
+    (child): child is InheritanceSpecifier => child instanceof InheritanceSpecifier,
+  );
+  toRemove.forEach((inheritanceSpecifier) => node.removeChild(inheritanceSpecifier));
 }


### PR DESCRIPTION
InheritanceSpecifiers can contain function calls, which causes issues with later passes which can try to extract those calls into statements because there's nowhere for the statements to go. As InheritanceInliner copies these calls into the constructor, they InheritanceSpecifiers can be safely removed once InheritanceInliner has run