### PR TITLE
Remove 'global' from using for

### DIFF
--- a/example_contracts/using_for/imports/user_defined.sol
+++ b/example_contracts/using_for/imports/user_defined.sol
@@ -25,7 +25,7 @@ library Nums {
   }
 }
 
-using Nums for uint256 global;
+using Nums for uint256;
 
 struct BB {
     uint256 b;


### PR DESCRIPTION
`using Nums for uint256 global` causes a compiler error in the new solc version (0.8.14), but did not in 0.8.13. This removes it from the test it was breaking