### PR TITLE
Implement TypeStringsChecker pass

### DIFF
--- a/src/passes/index.ts
+++ b/src/passes/index.ts
@@ -31,6 +31,7 @@ export * from './sourceUnitSplitter';
 export * from './storageAllocator';
 export * from './references';
 export * from './tupleAssignmentSplitter';
+export * from './typeStringsChecker';
 export * from './unloadingAssignment';
 export * from './unreachableStatementPruner';
 export * from './userDefinedTypesConverter';

--- a/src/passes/typeStringsChecker.ts
+++ b/src/passes/typeStringsChecker.ts
@@ -1,0 +1,32 @@
+import assert from 'assert';
+import { ElementaryTypeName, TypeName, typeNameToTypeNode } from 'solc-typed-ast';
+import { AST } from '../ast/ast';
+import { ASTMapper } from '../ast/mapper';
+
+class AssertTypeStrings extends ASTMapper {
+  visitTypeName(node: TypeName, ast: AST): void {
+    this.commonVisit(node, ast);
+    assert(node.typeString !== undefined, 'Undefined typestring found for TypeName');
+  }
+}
+
+export class TypeStringsChecker extends ASTMapper {
+  visitElementaryTypeName(node: ElementaryTypeName, _ast: AST): void {
+    if (node.typeString === undefined) {
+      node.typeString = typeNameToTypeNode(node).pp();
+    }
+  }
+
+  static map(ast: AST): AST {
+    ast.roots.forEach((root) => {
+      const mapper = new this();
+      mapper.dispatchVisit(root, ast);
+    });
+
+    ast.roots.forEach((root) => {
+      const mapper = new AssertTypeStrings();
+      mapper.dispatchVisit(root, ast);
+    });
+    return ast;
+  }
+}

--- a/src/transpiler.ts
+++ b/src/transpiler.ts
@@ -37,6 +37,7 @@ import {
   SourceUnitSplitter,
   StorageAllocator,
   TupleAssignmentSplitter,
+  TypeStringsChecker,
   UnloadingAssignment,
   UnreachableStatementPruner,
   UserDefinedTypesConverter,
@@ -80,6 +81,7 @@ export function transform(ast: AST, options: TranspilationOptions & PrintOptions
 function applyPasses(ast: AST, options: TranspilationOptions & PrintOptions): AST {
   const passes: Map<string, typeof ASTMapper> = createPassMap([
     ['Ss', SourceUnitSplitter],
+    ['Ct', TypeStringsChecker],
     ['Idi', ImportDirectiveIdentifier],
     ['Ru', RejectUnsupportedFeatures],
     ['L', LiteralExpressionEvaluator],


### PR DESCRIPTION
Some `ElementaryTypeName` nodes were noticed to have undefined typestrings in the input AST. This PR adds a new pass that ensures these typestrings are filled in, and then checks the AST to assert that all `TypeName` nodes have a defined typestring.