### PR TITLE
Update UserDefinedTypesConverter pass

### DIFF
--- a/example_contracts/userDefinedFunctionCalls.sol
+++ b/example_contracts/userDefinedFunctionCalls.sol
@@ -1,0 +1,11 @@
+pragma solidity ^0.8.10;
+//SPDX-License-Identifier: MIT
+contract WARP {
+  type A is uint256;
+  function f(A a) pure internal returns (A) {
+    return a;
+  }
+  function g(A a) pure internal returns (A) {
+    return f(a);
+  }
+}

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -160,6 +160,7 @@ const expectedResults = new Map<string, ResultType>([
   ['example_contracts/using_for/library', 'Success'],
   ['example_contracts/using_for/simple', 'Success'],
   ['example_contracts/usingReturnValues', 'Success'],
+  ['example_contracts/userDefinedFunctionCalls', 'Success'],
   ['example_contracts/userdefinedtypes', 'Success'],
   ['example_contracts/userdefinedidentifier', 'Success'],
   ['example_contracts/variable-declarations', 'Success'],

--- a/src/utils/getTypeString.ts
+++ b/src/utils/getTypeString.ts
@@ -30,7 +30,6 @@ import {
   TypeNode,
   UserDefinedType,
   UserDefinedTypeName,
-  UserDefinedValueTypeDefinition,
   VariableDeclarationStatement,
 } from 'solc-typed-ast';
 import { RationalLiteral } from '../passes/literalExpressionEvaluator/rationalLiteral';
@@ -169,7 +168,8 @@ function instanceOfNonRecursivePP(type: TypeNode): boolean {
     type instanceof ModuleType ||
     type instanceof RationalLiteral ||
     type instanceof StringLiteralType ||
-    type instanceof StringType
+    type instanceof StringType ||
+    type instanceof UserDefinedType
   );
 }
 
@@ -195,9 +195,6 @@ export function generateExpressionTypeString(type: TypeNode): string {
     return `function ${
       type.name !== undefined ? type.name : ''
     }(${argStr})${mutStr}${visStr}${retStr}`;
-  } else if (type instanceof UserDefinedType) {
-    if (!(type.definition instanceof UserDefinedValueTypeDefinition)) return type.pp();
-    return type.definition.underlyingType.typeString;
   } else if (type instanceof ArrayType) {
     return `${generateExpressionTypeString(type.elementT)}[${
       type.size !== undefined ? type.size : ''


### PR DESCRIPTION
This PR updates the UserDefinedTypesConverter pass to handle typestrings better. Introduces changes that ensure uniformity in how the three type replacement passes update the typestrings for Expressions and VariableDeclarations. 