### PR TITLE
Change calldata static arrays to pointers

### DIFF
--- a/src/utils/cairoTypeSystem.ts
+++ b/src/utils/cairoTypeSystem.ts
@@ -60,6 +60,10 @@ export abstract class CairoType {
         return new WarpLocation();
       } else if (context === TypeConversionContext.Ref) {
         return new CairoFelt();
+      } else if (context === TypeConversionContext.CallDataRef) {
+        return new CairoPointer(
+          CairoType.fromSol(tp.elementT, ast, TypeConversionContext.CallDataRef),
+        );
       } else {
         const recursionContext =
           context === TypeConversionContext.MemoryAllocation ? TypeConversionContext.Ref : context;


### PR DESCRIPTION
Calldata static arrays need to be changed to pointer based representation to allow non-literal index accesses