### PR TITLE
Implement semanticTest exceptions

### DIFF
--- a/tests/behaviour/expectations/index.ts
+++ b/tests/behaviour/expectations/index.ts
@@ -1,6 +1,28 @@
 import { expectations as semantic } from './semantic';
 import { expectations as behaviour } from './behaviour';
-import { AsyncTest, File } from './types';
+import { exceptions } from './semantic_exceptions';
+import { AsyncTest, Expect, File } from './types';
+import { readFileSync } from 'fs-extra';
+
+function getSyncTestFromPath(path: string): File {
+  const text = readFileSync(path + '.sol', 'utf-8');
+
+  const contractNames = [...text.matchAll(/contract (\w+)/g)].map(([_, name]) => name);
+  const lastContract = contractNames[contractNames.length - 1];
+
+  const lines = text.replace(/\s+$/gm, '').split('\n');
+  const testStartIndex = lines.indexOf('// ----');
+  const tests = lines.slice(testStartIndex + 1);
+  const expects = tests.map((test) => {
+    const matches = [...test.matchAll(/\/\/ (\S*)\(.*\): (.*) -> ([^ ,\n]*)/gm)];
+    return Expect.Simple(
+      matches[0][1],
+      matches[0][2].split(','),
+      matches[0][3] === 'FAILURE' ? null : [matches[0][3]],
+    );
+  });
+  return File.Simple(path, expects, lastContract);
+}
 
 // Don't be fooled, process.env.BLAH can be undefined
 function filterTests(
@@ -8,7 +30,13 @@ function filterTests(
   asyncTests: AsyncTest[],
   filter = process.env.FILTER,
 ): AsyncTest[] {
-  const tests = [...syncTests.map(AsyncTest.fromSync), ...asyncTests];
+  // Separate the exceptions from the selected semanticTests
+  // into a different array 'newSyncTests'
+  const newAsyncTests = asyncTests.filter((test) => !exceptions.includes(test.name));
+  const newSyncTests = asyncTests.filter((test) => exceptions.includes(test.name));
+
+  syncTests = [...syncTests, ...newSyncTests.map((test) => getSyncTestFromPath(test.name))];
+  const tests = [...syncTests.map(AsyncTest.fromSync), ...newAsyncTests];
   if (filter === undefined) {
     return tests;
   }

--- a/tests/behaviour/expectations/semantic_exceptions.ts
+++ b/tests/behaviour/expectations/semantic_exceptions.ts
@@ -1,0 +1,4 @@
+export const exceptions: string[] = [
+  //Out of bounds arguments are passed incorrectly
+  'tests/behaviour/solidity/test/libsolidity/semanticTests/arithmetics/checked_add_v2',
+];


### PR DESCRIPTION
**The Issue:**
There are some semantic tests with expected failures where out of bound arguments are passed. For example: 65536 for a uint16 type. Unlike behaviour tests, the semantic test suite uses an `AbiCoder` object that transcodes these values into tests. Hence instead of being read as a string, the out of boud values are wrapped around and get changed unintentionally. This causes the X-fails semantic tests to not pass. 

**The Solution:**
This PR implements a solution where these selected semantic tests with out of bounds values are handled differently than the other semantic tests. This fixes the issue because now the arguments are being passed as strings and hence will not get wrapped around. This is implemented in a way that the internal handling is abstracted from the end user. Like before, the user can uncomment semantic tests from `semantic_whitelist.ts` and run `yarn test:behaviour`. If any of the uncommented tests are listed in `semantic_exceptions.ts`, they will be processed differently before being handed over to the test suite. 

This ensures that both the semanticTests folder or `behaviour.ts` remain unchanged.