### PR TITLE
Reference Types in Mapping Values

### DIFF
--- a/src/cairoUtilFuncGen/storage/mappingIndexAccess.ts
+++ b/src/cairoUtilFuncGen/storage/mappingIndexAccess.ts
@@ -10,8 +10,8 @@ import {
 } from 'solc-typed-ast';
 import { CairoType, TypeConversionContext } from '../../utils/cairoTypeSystem';
 import { createCairoFunctionStub, createCallToFunction } from '../../utils/functionGeneration';
-import { isComplexStorageType, typeNameFromTypeNode } from '../../utils/utils';
-import { StringIndexedFuncGen } from '../base';
+import { typeNameFromTypeNode } from '../../utils/utils';
+import { locationIfComplexType, StringIndexedFuncGen } from '../base';
 
 export class MappingIndexAccessGen extends StringIndexedFuncGen {
   gen(node: IndexAccess, nodeInSourceUnit?: ASTNode): FunctionCall {
@@ -39,7 +39,7 @@ export class MappingIndexAccessGen extends StringIndexedFuncGen {
         [
           'res',
           typeNameFromTypeNode(nodeType, this.ast),
-          isComplexStorageType(nodeType) ? DataLocation.Storage : DataLocation.Default,
+          locationIfComplexType(nodeType, DataLocation.Storage),
         ],
       ],
       ['syscall_ptr', 'pedersen_ptr', 'range_check_ptr'],

--- a/src/cairoUtilFuncGen/storage/mappingIndexAccess.ts
+++ b/src/cairoUtilFuncGen/storage/mappingIndexAccess.ts
@@ -10,7 +10,7 @@ import {
 } from 'solc-typed-ast';
 import { CairoType, TypeConversionContext } from '../../utils/cairoTypeSystem';
 import { createCairoFunctionStub, createCallToFunction } from '../../utils/functionGeneration';
-import { typeNameFromTypeNode } from '../../utils/utils';
+import { isComplexStorageType, typeNameFromTypeNode } from '../../utils/utils';
 import { StringIndexedFuncGen } from '../base';
 
 export class MappingIndexAccessGen extends StringIndexedFuncGen {
@@ -35,7 +35,13 @@ export class MappingIndexAccessGen extends StringIndexedFuncGen {
         // TODO check that this is always default
         ['index', typeNameFromTypeNode(baseType.to.keyType, this.ast), DataLocation.Default],
       ],
-      [['res', typeNameFromTypeNode(nodeType, this.ast)]],
+      [
+        [
+          'res',
+          typeNameFromTypeNode(nodeType, this.ast),
+          isComplexStorageType(nodeType) ? DataLocation.Storage : DataLocation.Default,
+        ],
+      ],
       ['syscall_ptr', 'pedersen_ptr', 'range_check_ptr'],
       this.ast,
       nodeInSourceUnit ?? node,

--- a/src/cairoUtilFuncGen/storage/storageDelete.ts
+++ b/src/cairoUtilFuncGen/storage/storageDelete.ts
@@ -15,12 +15,8 @@ import {
 import { AST } from '../../ast/ast';
 import { CairoType, TypeConversionContext } from '../../utils/cairoTypeSystem';
 import { createCairoFunctionStub, createCallToFunction } from '../../utils/functionGeneration';
-import {
-  typeNameFromTypeNode,
-  mapRange,
-  isReferenceType,
-  narrowBigIntSafe,
-} from '../../utils/utils';
+import { isReferenceType } from '../../utils/nodeTypeProcessing';
+import { typeNameFromTypeNode, mapRange, narrowBigIntSafe } from '../../utils/utils';
 import { add, CairoFunction, StringIndexedFuncGen } from '../base';
 import { DynArrayGen } from './dynArray';
 import { StorageReadGen } from './storageRead';

--- a/src/passes/references/storedPointerDereference.ts
+++ b/src/passes/references/storedPointerDereference.ts
@@ -1,22 +1,20 @@
 import assert from 'assert';
 import {
-  ArrayType,
   Assignment,
   DataLocation,
   Expression,
   FunctionCall,
-  generalizeType,
   getNodeType,
   IndexAccess,
-  MappingType,
   MemberAccess,
-  PointerType,
-  StructDefinition,
-  TypeNode,
-  UserDefinedType,
 } from 'solc-typed-ast';
 import { AST } from '../../ast/ast';
-import { typeNameFromTypeNode } from '../../utils/utils';
+import {
+  isComplexMemoryType,
+  isDynamicStorageArray,
+  isMapping,
+  typeNameFromTypeNode,
+} from '../../utils/utils';
 import { ReferenceSubPass } from './referenceSubPass';
 
 export class StoredPointerDereference extends ReferenceSubPass {
@@ -72,27 +70,4 @@ export class StoredPointerDereference extends ReferenceSubPass {
       this.visitExpression(node, ast);
     }
   }
-}
-
-function isDynamicStorageArray(type: TypeNode): boolean {
-  return (
-    type instanceof PointerType &&
-    type.location === DataLocation.Storage &&
-    type.to instanceof ArrayType &&
-    type.to.size === undefined
-  );
-}
-
-function isComplexMemoryType(type: TypeNode): boolean {
-  return (
-    type instanceof PointerType &&
-    type.location === DataLocation.Memory &&
-    (type.to instanceof ArrayType ||
-      (type.to instanceof UserDefinedType && type.to.definition instanceof StructDefinition))
-  );
-}
-
-function isMapping(type: TypeNode): boolean {
-  const [base] = generalizeType(type);
-  return base instanceof MappingType;
 }

--- a/src/passes/references/storedPointerDereference.ts
+++ b/src/passes/references/storedPointerDereference.ts
@@ -13,8 +13,8 @@ import {
   isComplexMemoryType,
   isDynamicStorageArray,
   isMapping,
-  typeNameFromTypeNode,
-} from '../../utils/utils';
+} from '../../utils/nodeTypeProcessing';
+import { typeNameFromTypeNode } from '../../utils/utils';
 import { ReferenceSubPass } from './referenceSubPass';
 
 export class StoredPointerDereference extends ReferenceSubPass {

--- a/src/passes/rejectUnsupportedFeatures.ts
+++ b/src/passes/rejectUnsupportedFeatures.ts
@@ -44,12 +44,6 @@ export class RejectUnsupportedFeatures extends ASTMapper {
     const typeNode = getNodeType(node, ast.compilerVersion);
     if (typeNode instanceof FunctionType)
       throw new WillNotSupportError('Function objects are not supported');
-    if (
-      typeNode instanceof PointerType &&
-      typeNode.to instanceof MappingType &&
-      typeNode.to.valueType instanceof UserDefinedType
-    )
-      throw new NotSupportedYetError('Mappings with structs are not supported yet');
     this.commonVisit(node, ast);
   }
 

--- a/src/passes/rejectUnsupportedFeatures.ts
+++ b/src/passes/rejectUnsupportedFeatures.ts
@@ -4,13 +4,10 @@ import {
   RevertStatement,
   ErrorDefinition,
   Conditional,
-  MappingType,
   MemberAccess,
-  PointerType,
   AddressType,
   FunctionType,
   getNodeType,
-  UserDefinedType,
   VariableDeclaration,
   FunctionCall,
   FunctionCallKind,
@@ -19,7 +16,7 @@ import {
 import { AST } from '../ast/ast';
 import { ASTMapper } from '../ast/mapper';
 import { printNode } from '../utils/astPrinter';
-import { NotSupportedYetError, WillNotSupportError } from '../utils/errors';
+import { WillNotSupportError } from '../utils/errors';
 
 export class RejectUnsupportedFeatures extends ASTMapper {
   visitIndexAccess(node: IndexAccess, ast: AST): void {

--- a/src/utils/nodeTypeProcessing.ts
+++ b/src/utils/nodeTypeProcessing.ts
@@ -5,6 +5,7 @@ import {
   FunctionCall,
   FunctionCallKind,
   FunctionType,
+  generalizeType,
   getNodeType,
   IntType,
   MappingType,
@@ -157,4 +158,49 @@ export function isDynamicCallDataArray(type: TypeNode): boolean {
     type.to instanceof ArrayType &&
     type.to.size === undefined
   );
+}
+
+export function isReferenceType(type: TypeNode): boolean {
+  return (
+    type instanceof ArrayType ||
+    type instanceof MappingType ||
+    (type instanceof UserDefinedType && type.definition instanceof StructDefinition) ||
+    (type instanceof PointerType && isReferenceType(type.to))
+  );
+}
+
+export function isValueType(type: TypeNode): boolean {
+  return !isReferenceType(type);
+}
+
+export function isDynamicStorageArray(type: TypeNode): boolean {
+  return (
+    type instanceof PointerType &&
+    type.location === DataLocation.Storage &&
+    type.to instanceof ArrayType &&
+    type.to.size === undefined
+  );
+}
+
+export function isComplexStorageType(type: TypeNode): boolean {
+  return (
+    type instanceof PointerType &&
+    type.location === DataLocation.Storage &&
+    (type.to instanceof ArrayType ||
+      (type.to instanceof UserDefinedType && type.to.definition instanceof StructDefinition))
+  );
+}
+
+export function isComplexMemoryType(type: TypeNode): boolean {
+  return (
+    type instanceof PointerType &&
+    type.location === DataLocation.Memory &&
+    (type.to instanceof ArrayType ||
+      (type.to instanceof UserDefinedType && type.to.definition instanceof StructDefinition))
+  );
+}
+
+export function isMapping(type: TypeNode): boolean {
+  const [base] = generalizeType(type);
+  return base instanceof MappingType;
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -364,3 +364,35 @@ export function isReferenceType(type: TypeNode): boolean {
 export function isValueType(type: TypeNode): boolean {
   return !isReferenceType(type);
 }
+
+export function isDynamicStorageArray(type: TypeNode): boolean {
+  return (
+    type instanceof PointerType &&
+    type.location === DataLocation.Storage &&
+    type.to instanceof ArrayType &&
+    type.to.size === undefined
+  );
+}
+
+export function isComplexStorageType(type: TypeNode): boolean {
+  return (
+    type instanceof PointerType &&
+    type.location === DataLocation.Storage &&
+    (type.to instanceof ArrayType ||
+      (type.to instanceof UserDefinedType && type.to.definition instanceof StructDefinition))
+  );
+}
+
+export function isComplexMemoryType(type: TypeNode): boolean {
+  return (
+    type instanceof PointerType &&
+    type.location === DataLocation.Memory &&
+    (type.to instanceof ArrayType ||
+      (type.to instanceof UserDefinedType && type.to.definition instanceof StructDefinition))
+  );
+}
+
+export function isMapping(type: TypeNode): boolean {
+  const [base] = generalizeType(type);
+  return base instanceof MappingType;
+}

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -24,7 +24,6 @@ import {
   PointerType,
   StateVariableVisibility,
   StringType,
-  StructDefinition,
   TimeUnit,
   TupleExpression,
   TypeName,
@@ -350,49 +349,4 @@ export function splitDarray(
   );
 
   return [arrayLen, dArrayVarDecl];
-}
-
-export function isReferenceType(type: TypeNode): boolean {
-  return (
-    type instanceof ArrayType ||
-    type instanceof MappingType ||
-    (type instanceof UserDefinedType && type.definition instanceof StructDefinition) ||
-    (type instanceof PointerType && isReferenceType(type.to))
-  );
-}
-
-export function isValueType(type: TypeNode): boolean {
-  return !isReferenceType(type);
-}
-
-export function isDynamicStorageArray(type: TypeNode): boolean {
-  return (
-    type instanceof PointerType &&
-    type.location === DataLocation.Storage &&
-    type.to instanceof ArrayType &&
-    type.to.size === undefined
-  );
-}
-
-export function isComplexStorageType(type: TypeNode): boolean {
-  return (
-    type instanceof PointerType &&
-    type.location === DataLocation.Storage &&
-    (type.to instanceof ArrayType ||
-      (type.to instanceof UserDefinedType && type.to.definition instanceof StructDefinition))
-  );
-}
-
-export function isComplexMemoryType(type: TypeNode): boolean {
-  return (
-    type instanceof PointerType &&
-    type.location === DataLocation.Memory &&
-    (type.to instanceof ArrayType ||
-      (type.to instanceof UserDefinedType && type.to.definition instanceof StructDefinition))
-  );
-}
-
-export function isMapping(type: TypeNode): boolean {
-  const [base] = generalizeType(type);
-  return base instanceof MappingType;
 }

--- a/tests/behaviour/contracts/storage/mappings.sol
+++ b/tests/behaviour/contracts/storage/mappings.sol
@@ -14,10 +14,21 @@ contract WARP {
   }
 
   mapping(uint => uint8) map3;
-
   function nonFeltKey(uint x, uint8 y) public returns (uint8) {
     map3[x] = y;
     map3[x + 1] = y + 1;
     return map3[x];
   }
+
+  struct structDef {
+      uint8 member1;
+      uint member2;
+  }
+  mapping(int8 => structDef) map4;
+  function structValue(uint8 x, uint y) external returns (structDef memory) {
+    map4[1] = structDef(x, y);
+    return map4[1];
+  }
+
+
 }

--- a/tests/behaviour/contracts/storage/mappings.sol
+++ b/tests/behaviour/contracts/storage/mappings.sol
@@ -25,10 +25,26 @@ contract WARP {
       uint member2;
   }
   mapping(int8 => structDef) map4;
-  function structValue(uint8 x, uint y) external returns (structDef memory) {
+  function structValue(uint8 x, uint y) external returns (uint8, uint) {
     map4[1] = structDef(x, y);
-    return map4[1];
+    return (map4[1].member1, map4[1].member2);
+  }
+
+  mapping(int8 => uint[3]) map5;
+  function staticArrayValue(uint x, uint y, uint z) external returns (uint, uint, uint) {
+    map5[1] = [x, y, z];
+
+    return (map5[1][0], map5[1][1], map5[1][2]);
   }
 
 
+  mapping(int8 => uint[]) map6;
+  function dynamicArrayValue(uint x, uint y, uint z) external returns (uint, uint, uint) {
+    map6[1] = new uint[](3);
+    map6[1][0] = x;
+    map6[1][1] = y;
+    map6[1][2] = z;
+
+    return (map6[1][0], map6[1][1], map6[1][2]);
+  }
 }

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -2005,6 +2005,7 @@ export const expectations = flatten(
             Expect.Simple('nestedMappings', ['4'], ['4'], 'stepCheck'),
             Expect.Simple('nonFeltKey', ['3', '4', '5'], ['5']),
             Expect.Simple('nonFeltKey', ['4', '5', '6'], ['6'], 'stepCheck'),
+            Expect.Simple('structValue', ['10', '100', '1000'], ['10', '100', '1000']),
           ]),
           File.Simple('nesting', [Expect.Simple('nesting', [], ['5'])]),
           File.Simple('passingArguments', [

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -2006,6 +2006,16 @@ export const expectations = flatten(
             Expect.Simple('nonFeltKey', ['3', '4', '5'], ['5']),
             Expect.Simple('nonFeltKey', ['4', '5', '6'], ['6'], 'stepCheck'),
             Expect.Simple('structValue', ['10', '100', '1000'], ['10', '100', '1000']),
+            Expect.Simple(
+              'staticArrayValue',
+              ['10', '11', '100', '101', '1000', '1001'],
+              ['10', '11', '100', '101', '1000', '1001'],
+            ),
+            Expect.Simple(
+              'dynamicArrayValue',
+              ['10', '11', '100', '101', '1000', '1001'],
+              ['10', '11', '100', '101', '1000', '1001'],
+            ),
           ]),
           File.Simple('nesting', [Expect.Simple('nesting', [], ['5'])]),
           File.Simple('passingArguments', [


### PR DESCRIPTION
Fixing bug where mapping types pointing to reference types could not be used. This was because datalocation 'default' was in the typestring of the MappingIndexAccess function, which is not possible for reference types and therefore was causing an exception.