### PR TITLE
Remove .gitattributes in favor of official GitHub highlighting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.cairo linguist-language=python


### PR DESCRIPTION
I originally committed this, but since official support landed, figure I'd come clean up after myself :)