### PR TITLE
Cleanup SourceUnit filepath mangling

### DIFF
--- a/src/passes/sourceUnitSplitter.ts
+++ b/src/passes/sourceUnitSplitter.ts
@@ -103,11 +103,11 @@ function updateScope(nodes: readonly Scoped[], newScope: number): readonly Scope
 }
 
 export function mangleFreeFilePath(path: string): string {
-  return `${path}__WARP_FREE__`;
+  return `${path}_`;
 }
 
 export function mangleContractFilePath(path: string, contractName: string): string {
-  return `${path}__WARP_CONTRACT__${contractName}`;
+  return `${path}_${contractName}`;
 }
 
 function getAllSourceUnitDefinitions(sourceUnit: SourceUnit) {


### PR DESCRIPTION
Now that #395 replaces `_` with `__` we can replace our `__WARP_CONTRACT__` with `_` and guarantee uniqueness