### PR TITLE
Skip test fix

### DIFF
--- a/tests/behaviour/behaviour.test.ts
+++ b/tests/behaviour/behaviour.test.ts
@@ -62,7 +62,7 @@ describe('Transpiled contracts are valid cairo', function () {
   for (let i = 0; i < expectations.length; ++i) {
     it(expectations[i].name, async function () {
       const res = await compileResults[i];
-      if (res === null) {
+      if (res.result === null) {
         this.skip();
       } else {
         expect(res.result, `starknet-compile printed errors: ${res.result}`).to.include({

--- a/tests/util.ts
+++ b/tests/util.ts
@@ -18,7 +18,10 @@ export function transpile(contractPath: string): Promise<{ stdout: string; stder
   return sh(`bin/warp transpile ${contractPath} --strict`);
 }
 
-export function starknetCompile(cairoPath: string, jsonOutputPath: string) {
+export function starknetCompile(
+  cairoPath: string,
+  jsonOutputPath: string,
+): Promise<{ stdout: string; stderr: string }> {
   return sh(`starknet-compile --cairo_path warp_output ${cairoPath} --output ${jsonOutputPath}`);
 }
 


### PR DESCRIPTION
The test suite changes to prevent unlimited multithreading also broke the skipping of the compile stage if the transpile stage fails. This fixes it