### PR TITLE
Fix fixed length array encoding for semantic tests

### DIFF
--- a/tests/behaviour/expectations/semantic.ts
+++ b/tests/behaviour/expectations/semantic.ts
@@ -234,10 +234,14 @@ export function encodeValue(tp: TypeNode, value: SolValue, compilerVersion: stri
     if (!(value instanceof Array)) {
       throw new Error(`Can't encode ${value} as arrayType`);
     }
-    return [
-      value.length.toString(),
-      ...value.flatMap((v) => encodeValue(tp.elementT, v, compilerVersion)),
-    ];
+    if (tp.size === undefined) {
+      return [
+        value.length.toString(),
+        ...value.flatMap((v) => encodeValue(tp.elementT, v, compilerVersion)),
+      ];
+    } else {
+      return value.flatMap((v) => encodeValue(tp.elementT, v, compilerVersion));
+    }
   } else if (tp instanceof BoolType) {
     if (typeof value !== 'boolean') {
       throw new Error(`Can't encode ${value} as boolType`);


### PR DESCRIPTION
Fixed length arrays are encoded as tuples, not as ptr,len pairs, so the prepended length is not needed