### PR TITLE
Array element location

### DIFF
--- a/src/cairoUtilFuncGen/base.ts
+++ b/src/cairoUtilFuncGen/base.ts
@@ -74,7 +74,8 @@ export function locationIfComplexType(type: TypeNode, location: DataLocation): D
   if (
     base instanceof ArrayType ||
     base instanceof MappingType ||
-    (base instanceof UserDefinedType && base.definition instanceof StructDefinition)
+    (base instanceof UserDefinedType && base.definition instanceof StructDefinition) ||
+    base instanceof MappingType
   ) {
     return location;
   } else {

--- a/src/passes/references/expectedLocationAnalyser.ts
+++ b/src/passes/references/expectedLocationAnalyser.ts
@@ -165,7 +165,7 @@ export class ExpectedLocationAnalyser extends ASTMapper {
         // External functions need to read out their returns
         // TODO might need to expand this to be clear that it's a deep read
         const retExpressions =
-          node.vExpression instanceof TupleExpression
+          node.vExpression instanceof TupleExpression && !node.vExpression.isInlineArray
             ? node.vExpression.vOriginalComponents.map((element) => {
                 assert(element !== null, `Cannot return tuple with empty slots`);
                 return element;

--- a/src/passes/references/expectedLocationAnalyser.ts
+++ b/src/passes/references/expectedLocationAnalyser.ts
@@ -216,7 +216,8 @@ export class ExpectedLocationAnalyser extends ASTMapper {
     if (assignedLocation === undefined) return this.visitExpression(node, ast);
 
     node.vOriginalComponents.filter(notNull).forEach((element) => {
-      this.expectedLocations.set(element, assignedLocation);
+      const elementType = getNodeType(element, ast.compilerVersion);
+      this.expectedLocations.set(element, locationIfComplexType(elementType, assignedLocation));
     });
 
     this.visitExpression(node, ast);

--- a/tests/behaviour/contracts/copy_storage_to_memory/static_arrays.sol
+++ b/tests/behaviour/contracts/copy_storage_to_memory/static_arrays.sol
@@ -6,6 +6,7 @@ contract WARP {
   uint8[5] x = [1, 2, 3, 4, 5];
   uint8[15] y;
 
+  uint scalar = 10;
 
   // Throw errors if they are not explicitly cast
   uint256[3] w = [uint256(1), uint256(2), uint256(3)];
@@ -36,6 +37,10 @@ contract WARP {
   function getZ() public view returns (uint256[6] memory) {
     uint256[6] memory zz = z;
     return zz;
+  }
+
+  function scalarInTuple() public view returns (uint[3] memory) {
+    return [1,scalar, x[2]];
   }
 }
 

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -506,6 +506,7 @@ export const expectations = flatten(
             ),
             Expect.Simple('getW', [], ['1', '0', '2', '0', '3', '0']),
             Expect.Simple('getZ', [], ['1', '0', '2', '0', '3', '0', '4', '0', '5', '0', '6', '0']),
+            Expect.Simple('scalarInTuple', [], ['1', '0', '10', '0', '3', '0']),
           ]),
           File.Simple('structs', [
             Expect.Simple('setS', ['2', '3', '5', '7'], []),


### PR DESCRIPTION
Fixes a bug where scalar types in inline arrays were given the expected location of the array, not default