### PR TITLE
Fix enum literal replacement

### DIFF
--- a/tests/behaviour/contracts/enums/singleEnum.sol
+++ b/tests/behaviour/contracts/enums/singleEnum.sol
@@ -19,6 +19,10 @@ contract WARP {
     _status = Status.Z5;
   }
 
+  function setWithContractName() public {
+    _status = WARP.Status.A1;
+  }
+
   Status public _status;
 
   enum Status {

--- a/tests/behaviour/contracts/enums/singleEnum7.sol
+++ b/tests/behaviour/contracts/enums/singleEnum7.sol
@@ -48,4 +48,8 @@ contract WARP {
   function cancel() public {
     _status = Status.Z9;
   }
+
+  function setWithContractName() public {
+    _status = WARP.Status.A1;
+  }
 }

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -765,6 +765,10 @@ export const expectations = flatten(
               ['cancel', [], [], '0'],
               ['get', [], ['255'], '0'],
             ]),
+            new Expect('setWithContractName', [
+              ['setWithContractName', [], [], '0'],
+              ['get', [], ['1'], '0'],
+            ]),
           ]),
           File.Simple('singleEnum7', [
             Expect.Simple('get', [], ['0']),
@@ -779,6 +783,10 @@ export const expectations = flatten(
             new Expect('cancel', [
               ['cancel', [], [], '0'],
               ['get', [], ['259'], '0'],
+            ]),
+            new Expect('setWithContractName', [
+              ['setWithContractName', [], [], '0'],
+              ['get', [], ['1'], '0'],
             ]),
           ]),
           File.Simple('doubleEnum', [


### PR DESCRIPTION
The old method for replacing enum literals didn't handle nested member accesses properly, such as `ContractName.EnumName.Value`. The new approach starts as soon as it finds a member access and replaces as soon as it can instead of always recursing all the way in