### PR TITLE
Benchmark: Add JSON file size, and group functions by contract

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Test code execution
         run: |
-          yarn testnet-b &
+          yarn testnet:benchmark &
           make test_execution
 
       - name: Setup source hash (pull_request)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,6 +89,7 @@ jobs:
 
       - name: Push benchmarks to another repository
         uses: dmnemec/copy_file_to_another_repo_action@main
+        if: ${{ github.event_name == 'push' }}
         env:
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
         with:

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test:lib": "yarn warplib && npx mocha tests/warplib.test.ts --extension ts --require ts-node/register --exit",
     "test:behaviour": "yarn tsc && npx mocha tests/behaviour/behaviour.test.ts --extension ts --require ts-node/register --exit",
     "testnet": "python3 starknet-testnet/server.py",
-    "testnet-b": "python3 starknet-testnet/server.py benchmark",
+    "testnet:benchmark": "python3 starknet-testnet/server.py benchmark",
     "warplib": "yarn tsc; node ./build/warplib/generateWarplib.js",
     "release": "yarn warplib && npm publish --access public"
   },

--- a/readme.md
+++ b/readme.md
@@ -79,7 +79,7 @@ yarn test
 In order to generate benchmarks locally during development:
 
 ```bash
-yarn testnet-b
+yarn testnet:benchmark
 yarn test
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -76,6 +76,19 @@ then to run the tests:
 yarn test
 ```
 
+In order to generate benchmarks locally during development:
+
+```bash
+yarn testnet-b
+yarn test
+```
+
+```python
+python starknet-testnet/generateMarkdown.py
+```
+
+This saves the benchmarks at `benchmark/stats/data.md`
+
 ## Contribution :hammer_and_pick:
 
 Contributions are welcome but please reach out to the team before attempting

--- a/starknet-testnet/server.py
+++ b/starknet-testnet/server.py
@@ -2,8 +2,10 @@ import os
 import sys
 from generateMarkdown import (
     builtin_instance_count,
+    json_size_count,
     steps_in_function_deploy,
     steps_in_function_invoke,
+    contract_name_map,
 )
 
 from flask import Flask, jsonify, request
@@ -50,6 +52,8 @@ async def deploy():
         if BENCHMARK:
             steps_in_function_deploy(data["compiled_cairo"], execution_info)
             builtin_instance_count(data["compiled_cairo"], execution_info)
+            json_size_count(data["compiled_cairo"])
+            contract_name_map[contract_address] = data["compiled_cairo"]
         return jsonify(
             {
                 "contract_address": hex(contract_address),


### PR DESCRIPTION
This PR adds a new field in the benchmark denoting the size of the JSON file given to the testnet. 
This PR also groups the function names by their contract. Earlier, the invoked functions were being written out individually which was not very readable. 

This PR also changes the CI to push benchmarks only when a commit is merged and not on pull requests. This will clear up clutter on the warp-ts-benchmark branch. 