### PR TITLE
Fix memoryToCalldata not reading nested complex types properly

### DIFF
--- a/src/cairoUtilFuncGen/memory/memoryToCalldata.ts
+++ b/src/cairoUtilFuncGen/memory/memoryToCalldata.ts
@@ -157,7 +157,10 @@ export class MemoryToCallDataGen extends StringIndexedFuncGen {
             elementT instanceof ArrayType
           ) {
             const memberGetter = this.getOrCreate(elementT);
-            return `let (member${index}) = ${memberGetter}(${add('mem_loc', offset++)})`;
+            return [
+              `let (read${index}) = dict_read{dict_ptr=warp_memory}(${add('mem_loc', offset++)})`,
+              `let (member${index}) = ${memberGetter}(read${index})`,
+            ].join('\n');
           } else {
             const memberCairoType = CairoType.fromSol(elementT, this.ast);
             if (memberCairoType.width === 1) {

--- a/tests/behaviour/contracts/memory/nestedIndexAccessWrite.sol
+++ b/tests/behaviour/contracts/memory/nestedIndexAccessWrite.sol
@@ -1,0 +1,15 @@
+pragma solidity ^0.8.14;
+// SPDX-License-Identifier: MIT
+
+contract WARP {
+    function set(uint24[3][4] memory x) public {
+        x[2][2] = 1;
+        x[3][2] = 7;
+    }
+
+    function passDataToInnerFunction() public returns (uint24[3][4] memory) {
+        uint24[3][4] memory data;
+        set(data);
+        return data;
+    }
+}

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -1767,6 +1767,14 @@ export const expectations = flatten(
               ['7', '8', '9', '10', '11'],
             ),
           ]),
+          File.Simple('nestedIndexAccessWrite', [
+            Expect.Simple(
+              'passDataToInnerFunction',
+              [],
+              [...['0', '0', '0'], ...['0', '0', '0'], ...['0', '0', '1'], ...['0', '0', '7']],
+              '0',
+            ),
+          ]),
           File.Simple('staticArrays', [
             Expect.Simple('uint8default', [], ['0', '0']),
             Expect.Simple('uint8write', ['5'], ['0', '5']),


### PR DESCRIPTION
Nested complex types are stored as 'pointers' in memory and need to be read before being passed to nested copy functions