### PR TITLE
Loop references issues

### DIFF
--- a/src/passes/loopFunctionaliser/continueToLoopCall.ts
+++ b/src/passes/loopFunctionaliser/continueToLoopCall.ts
@@ -27,8 +27,8 @@ export class ContinueToLoopCall extends ASTMapper {
     ast.replaceNode(
       node,
       createReturn(
-        createLoopCall(continueFunction, continueFunction.vParameters.vParameters, ast),
-        continueFunction.vReturnParameters.id,
+        createLoopCall(continueFunction, containingFunction.vParameters.vParameters, ast),
+        containingFunction.vReturnParameters.id,
         ast,
       ),
     );

--- a/src/passes/loopFunctionaliser/whileLoopToFunction.ts
+++ b/src/passes/loopFunctionaliser/whileLoopToFunction.ts
@@ -25,7 +25,7 @@ export class WhileLoopToFunction extends ASTMapper {
       this.loopToContinueFunction,
       ast,
     );
-    // const outerCall = createOuterCall(node, unboundVariables, functionDef, ast);
+
     const outerCall = createOuterCall(
       node,
       [...unboundVariables.keys()],

--- a/tests/behaviour/contracts/loops/loops.sol
+++ b/tests/behaviour/contracts/loops/loops.sol
@@ -74,6 +74,16 @@ contract WARP {
     return x;
   }
 
+  function doWhile_continue_2() public pure returns (uint256 r) {
+    uint256 i = 0;
+    do {
+      if (i > 0) return 0;
+      i++;
+      continue;
+    } while (false);
+    return 42;
+  }
+
   function doWhile_return(uint8 target) public pure returns (uint8) {
     uint8 x = 0;
 

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -1394,6 +1394,7 @@ export const expectations = flatten(
             Expect.Simple('doWhile', ['0', '4'], ['5']),
             Expect.Simple('doWhile', ['7', '6'], ['8']),
             Expect.Simple('doWhile_continue', ['1'], ['1']),
+            Expect.Simple('doWhile_continue_2', [], ['42', '0']),
             Expect.Simple('doWhile_return', ['4'], ['2']),
             Expect.Simple('doWhile_break', ['0', '2'], ['2']),
           ]),


### PR DESCRIPTION
The following problems were addressed: 
- When creating parameters for functions by cloning, the identifiers referencing those parameters kept the old references instead of changing to the cloned ones, which meant that collecting unbound variables in the body of the new function, for example, would result in identifiers pointing to variables that don't even exist in the scope of this function.
> To solve this, a mapping was created to store <old_variable_id, cloned_variable>, and then with a pass through the children of the node, all identifiers reference declaration were changed to point to their corresponding new variable.
- The wrong parameters were being passed to: the method that creates function calls from `continue`s and the method that creates the function call for the loop. This was causing trouble with references as well.