### PR TITLE
solved the issue with typestring in Literal#18 node for too long literal

### DIFF
--- a/src/passes/bytesConverter.ts
+++ b/src/passes/bytesConverter.ts
@@ -17,6 +17,7 @@ import {
   TypeName,
   IndexAccess,
   Literal,
+  IntLiteralType,
 } from 'solc-typed-ast';
 import { AST } from '../ast/ast';
 import { ASTMapper } from '../ast/mapper';
@@ -35,8 +36,10 @@ import {
 
 export class BytesConverter extends ASTMapper {
   visitExpression(node: Expression, ast: AST): void {
-    const typeNode = replaceFixedBytesType(getNodeType(node, ast.compilerVersion));
-    node.typeString = generateExpressionTypeString(typeNode);
+    const typeNode = getNodeType(node, ast.compilerVersion);
+    if (!(typeNode instanceof IntLiteralType)) {
+      node.typeString = generateExpressionTypeString(replaceFixedBytesType(typeNode));
+    }
     this.commonVisit(node, ast);
   }
 

--- a/src/passes/userDefinedTypesConverter.ts
+++ b/src/passes/userDefinedTypesConverter.ts
@@ -5,6 +5,7 @@ import {
   FunctionCall,
   FunctionType,
   getNodeType,
+  IntLiteralType,
   MappingType,
   MemberAccess,
   PointerType,
@@ -47,8 +48,11 @@ export class UserDefinedTypesConverter extends ASTMapper {
 
   visitExpression(node: Expression, ast: AST): void {
     this.commonVisit(node, ast);
-    const replacementNode = replaceUserDefinedType(getNodeType(node, ast.compilerVersion));
-    node.typeString = generateExpressionTypeString(replacementNode);
+    const nodeType = getNodeType(node, ast.compilerVersion);
+    if (!(nodeType instanceof IntLiteralType)) {
+      const replacementNode = replaceUserDefinedType(nodeType);
+      node.typeString = generateExpressionTypeString(replacementNode);
+    }
   }
 
   visitUserDefinedTypeName(node: UserDefinedTypeName, ast: AST): void {

--- a/src/utils/getTypeString.ts
+++ b/src/utils/getTypeString.ts
@@ -152,7 +152,7 @@ export function generateLiteralTypeString(
     }
     case LiteralKind.Number: {
       if (value.length > 32) {
-        value = `${value.slice(4)}...(${value.length - 8} digits omitted)...${value.slice(-4)}`;
+        value = `${value.slice(0, 4)}...(${value.length - 8} digits omitted)...${value.slice(-4)}`;
       }
       return `int_const ${value}`;
     }


### PR DESCRIPTION
Problem was having with the typestring in the tree of Literal#18 after LiteralExpressionEvaluator is wrong, and after UserDefinedTypesConverter it's even more . So this PR solves this problem.