### PR TITLE
Extern import cleaned up

### DIFF
--- a/src/passes/externImporter.ts
+++ b/src/passes/externImporter.ts
@@ -1,21 +1,15 @@
 import assert from 'assert';
 import {
   ContractDefinition,
-  ErrorDefinition,
   FunctionDefinition,
   Identifier,
-  ImportDirective,
   SourceUnit,
   StructDefinition,
-  UserDefinedValueTypeDefinition,
-  VariableDeclaration,
   UserDefinedTypeName,
   ASTNode,
 } from 'solc-typed-ast';
 import { AST } from '../ast/ast';
 import { ASTMapper } from '../ast/mapper';
-import { printNode } from '../utils/astPrinter';
-import { NotSupportedYetError } from '../utils/errors';
 import * as pathLib from 'path';
 
 export class ExternImporter extends ASTMapper {
@@ -43,7 +37,6 @@ export class ExternImporter extends ASTMapper {
 
   visitIdentifier(node: Identifier, ast: AST): void {
     const declaration = node.vReferencedDeclaration;
-
     if (declaration === undefined) return;
 
     const declarationSourceUnit = declaration.getClosestParentByType(SourceUnit);
@@ -57,14 +50,6 @@ export class ExternImporter extends ASTMapper {
       (declaration instanceof StructDefinition && isFree(declaration))
     ) {
       ast.registerImport(node, formatPath(declarationSourceUnit.absolutePath), declaration.name);
-    }
-    if (
-      declaration instanceof ErrorDefinition ||
-      declaration instanceof UserDefinedValueTypeDefinition ||
-      declaration instanceof VariableDeclaration ||
-      declaration instanceof ImportDirective
-    ) {
-      throw new NotSupportedYetError(`Importing ${printNode(declaration)} not implemented yet`);
     }
   }
 }


### PR DESCRIPTION
VARIABLE DECLARATION: There is no need for any action for importing variable declarations, whether it is a free constant or a contract's member variable.
When a variable is imported from another file or declared and used from the same file as:
- free: the constant variable is taken into the main contract
- inheritance: the inherited contract's member variable is taken into the main contract
- member access: the called member variable is taken into the main contract
NOTE: Even though member access is taken into the contract, it is taken as C.member(), which does not exist in Cairo, hence it is a bug.

IMPORT DIRECTIVE: There is no need for any action for import directives. A imports B, B imports C -> A uses the variables, functions, and structs of the C with no problem, since the functions and structs are currently imported successfully, and variables are copied inside A (with the same logic as above in VARIABLE DECLARATION).

ERROR DEFINITION: There is no need for any action for importing error definitions since user-defined errors are not supported.

USER DEFINED VALUE TYPE DEFINITION: There is no need for any action for importing user-defined value type definitions since user-defined value types are replaced by the actual type.