### PR TITLE
TupleFlattener and TupleFiller

### DIFF
--- a/src/passes/index.ts
+++ b/src/passes/index.ts
@@ -30,6 +30,7 @@ export * from './ReturnVariableInitializer';
 export * from './sourceUnitSplitter';
 export * from './staticArrayIndexer';
 export * from './storageAllocator';
+export * from './tupleFixes';
 export * from './references';
 export * from './tupleAssignmentSplitter';
 export * from './typeStringsChecker';

--- a/src/passes/tupleFixes/index.ts
+++ b/src/passes/tupleFixes/index.ts
@@ -1,0 +1,12 @@
+import { AST } from '../../ast/ast';
+import { ASTMapper } from '../../ast/mapper';
+import { TupleFiller } from './tupleFiller';
+import { TupleFlattener } from './tupleFlattener';
+
+export class TupleFixes extends ASTMapper {
+  static map(ast: AST): AST {
+    TupleFlattener.map(ast);
+    TupleFiller.map(ast);
+    return ast;
+  }
+}

--- a/src/passes/tupleFixes/tupleFiller.ts
+++ b/src/passes/tupleFixes/tupleFiller.ts
@@ -1,0 +1,113 @@
+import assert from 'assert';
+import {
+  Assignment,
+  DataLocation,
+  Expression,
+  FunctionDefinition,
+  generalizeType,
+  getNodeType,
+  ModifierDefinition,
+  Mutability,
+  StateVariableVisibility,
+  TupleExpression,
+  TupleType,
+  VariableDeclaration,
+} from 'solc-typed-ast';
+import { AST } from '../../ast/ast';
+import { ASTMapper } from '../../ast/mapper';
+import { printNode, printTypeNode } from '../../utils/astPrinter';
+import { getDefaultValue } from '../../utils/defaultValueNodes';
+import { createIdentifier, createVariableDeclarationStatement } from '../../utils/nodeTemplates';
+import { notNull } from '../../utils/typeConstructs';
+import { expressionHasSideEffects, typeNameFromTypeNode } from '../../utils/utils';
+
+export class TupleFiller extends ASTMapper {
+  counter = 0;
+  visitAssignment(node: Assignment, ast: AST): void {
+    if (
+      !(node.vLeftHandSide instanceof TupleExpression) ||
+      node.vLeftHandSide.vOriginalComponents.every(notNull)
+    ) {
+      return this.visitExpression(node, ast);
+    }
+
+    const scope = node.getClosestParentBySelector(
+      (p) => p instanceof FunctionDefinition || p instanceof ModifierDefinition,
+    )?.id;
+    assert(scope !== undefined, `Unable to find scope for tuple assignment. ${printNode(node)}`);
+
+    // We are now looking at a tuple with empty slots on the left hand side of the assignment
+    // There is a known bug with getNodeType when passed such tuples, so we must fill them
+    // or remove the slot if the rhs has no side effects
+    const lhs: TupleExpression = node.vLeftHandSide;
+
+    lhs.vOriginalComponents
+      .map((value, index) => (value === null ? index : null))
+      .filter(notNull)
+      .forEach((emptyIndex) => {
+        if (shouldRemove(node.vRightHandSide, emptyIndex)) return;
+        const tupleType = getNodeType(node.vRightHandSide, ast.compilerVersion);
+        assert(
+          tupleType instanceof TupleType,
+          `Expected rhs of tuple assignment to be tuple type, got ${printTypeNode(
+            tupleType,
+          )} at ${printNode(node)}`,
+        );
+        const elementType = tupleType.elements[emptyIndex];
+        const [generalisedType, loc] = generalizeType(elementType);
+        const typeName = typeNameFromTypeNode(elementType, ast);
+        const declaration = new VariableDeclaration(
+          ast.reserveId(),
+          '',
+          false,
+          false,
+          `__warp_tf${this.counter++}`,
+          scope,
+          false,
+          loc ?? DataLocation.Default,
+          StateVariableVisibility.Default,
+          Mutability.Mutable,
+          generalisedType.pp(),
+          undefined,
+          typeName,
+        );
+        ast.insertStatementBefore(
+          node,
+          createVariableDeclarationStatement(
+            [declaration],
+            getDefaultValue(elementType, declaration, ast),
+            ast,
+          ),
+        );
+        const child = createIdentifier(declaration, ast);
+        lhs.vOriginalComponents[emptyIndex] = child;
+        ast.registerChild(child, lhs);
+      });
+
+    if (node.vRightHandSide instanceof TupleExpression) {
+      const toRemove = lhs.vOriginalComponents
+        .map((value, index) => (value === null ? index : null))
+        .filter(notNull);
+      lhs.vOriginalComponents = lhs.vOriginalComponents.filter(
+        (_value, index) => !toRemove.includes(index),
+      );
+      node.vRightHandSide.vOriginalComponents = node.vRightHandSide.vOriginalComponents.filter(
+        (_value, index) => !toRemove.includes(index),
+      );
+      updateTypeString(node.vRightHandSide);
+    }
+
+    updateTypeString(node.vLeftHandSide);
+  }
+}
+
+function shouldRemove(rhs: Expression, index: number): boolean {
+  if (!(rhs instanceof TupleExpression)) return false;
+  const elem = rhs.vOriginalComponents[index];
+
+  return elem === null || !expressionHasSideEffects(elem);
+}
+
+function updateTypeString(node: TupleExpression): void {
+  node.typeString = `tuple(${node.vComponents.map((value) => value.typeString)})`;
+}

--- a/src/passes/tupleFixes/tupleFlattener.ts
+++ b/src/passes/tupleFixes/tupleFlattener.ts
@@ -1,0 +1,20 @@
+import { TupleExpression } from 'solc-typed-ast';
+import { AST } from '../../ast/ast';
+import { ASTMapper } from '../../ast/mapper';
+
+export class TupleFlattener extends ASTMapper {
+  visitTupleExpression(node: TupleExpression, ast: AST): void {
+    if (
+      node.vOriginalComponents.length === 1 &&
+      node.vOriginalComponents[0] !== null &&
+      node.vOriginalComponents[0].typeString === node.typeString &&
+      !node.isInlineArray
+    ) {
+      const parent = node.parent;
+      ast.replaceNode(node, node.vOriginalComponents[0], parent);
+      this.dispatchVisit(node.vOriginalComponents[0], ast);
+    } else {
+      this.visitExpression(node, ast);
+    }
+  }
+}

--- a/src/transpiler.ts
+++ b/src/transpiler.ts
@@ -45,6 +45,7 @@ import {
   VariableDeclarationExpressionSplitter,
   VariableDeclarationInitialiser,
   StaticArrayIndexer,
+  TupleFixes,
 } from './passes';
 import { OrderNestedStructs } from './passes/orderNestedStructs';
 import { CairoToSolASTWriterMapping } from './solWriter';
@@ -81,6 +82,7 @@ export function transform(ast: AST, options: TranspilationOptions & PrintOptions
 
 function applyPasses(ast: AST, options: TranspilationOptions & PrintOptions): AST {
   const passes: Map<string, typeof ASTMapper> = createPassMap([
+    ['Tf', TupleFixes],
     ['Ss', SourceUnitSplitter],
     ['Ct', TypeStringsChecker],
     ['Idi', ImportDirectiveIdentifier],
@@ -130,7 +132,6 @@ function applyPasses(ast: AST, options: TranspilationOptions & PrintOptions): AS
 
   printPassName('Input', options);
   printAST(ast, options);
-  checkAST(ast, options, 'None run');
 
   const finalAst = passesInOrder.reduce((ast, mapper) => {
     printPassName(mapper.getPassName(), options);

--- a/tests/behaviour/behaviour.test.ts
+++ b/tests/behaviour/behaviour.test.ts
@@ -36,7 +36,7 @@ describe('Transpile solidity', function () {
       expect(res.result, `warp-ts printed errors: ${res.result}`).to.include({ stderr: '' });
       expect(
         fs.existsSync(expectations[i].cairo),
-        'Transpilation failed, cannot find output file',
+        `Transpilation failed, cannot find output file. Is the file's contract named WARP or specified in the expectations?`,
       ).to.be.true;
       expect(res.success, `${res.result}`);
     });

--- a/tests/behaviour/contracts/expressions/tupleEdgeCases.sol
+++ b/tests/behaviour/contracts/expressions/tupleEdgeCases.sol
@@ -1,0 +1,15 @@
+pragma solidity ^0.8.10;
+
+//SPDX-License-Identifier: MIT
+
+contract WARP {
+    function f(uint a) public returns (uint) {
+        uint a;
+        uint b;
+        (a,,b,) = ((1,2,3, g()));
+    }
+
+    function g() public returns (uint){
+
+    }
+}

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -886,6 +886,7 @@ export const expectations = flatten(
               ],
             ),
           ]),
+          File.Simple('tupleEdgeCases', [Expect.Simple('f', ['0', '0'], ['0', '0'])]),
         ]),
         new Dir('external_function_inputs', [
           File.Simple('dynamic_array_return_index', [


### PR DESCRIPTION
getNodeType and the TypeNode system as a whole do not handle tuples with empty slots well (getNodeType throws an exception in such cases, and TypeNodes don't have a way of expressing empty tuple slots). As such, this pass runs before any AST checking can and removes or fills empty tuple slots as appropriate, fixing the typestrings. It also flattens single element non-array tuples as they add nothing to the tree, but make processing harder