### PR TITLE
Calldata assignment after tuple split solved.

### DIFF
--- a/src/passes/tupleAssignmentSplitter.ts
+++ b/src/passes/tupleAssignmentSplitter.ts
@@ -121,21 +121,23 @@ export class TupleAssignmentSplitter extends ASTMapper {
       node.vRightHandSide,
     );
 
-    const assignments = [...tempVars.entries()].map(
-      ([target, tempVar]) =>
-        new ExpressionStatement(
-          ast.reserveId(),
-          node.src,
-          new Assignment(
+    const assignments = [...tempVars.entries()]
+      .filter(([_, tempVar]) => tempVar.storageLocation !== DataLocation.CallData)
+      .map(
+        ([target, tempVar]) =>
+          new ExpressionStatement(
             ast.reserveId(),
             node.src,
-            target.typeString,
-            '=',
-            target,
-            createIdentifier(tempVar, ast),
+            new Assignment(
+              ast.reserveId(),
+              node.src,
+              target.typeString,
+              '=',
+              target,
+              createIdentifier(tempVar, ast),
+            ),
           ),
-        ),
-    );
+      );
 
     block.appendChild(tempTupleDeclaration);
     assignments.forEach((n) => block.appendChild(n));


### PR DESCRIPTION
Calldata assignment error in semantic test "array_multiple_local_vars" is fixed. Calldata assignment after tuple split is filtered. Return is not filtered since the new temp variables are declared, hence causes no problem even if they are declared as calldata. "array_multiple_local_vars" semantic test still contains the "Array length not implemented" error.