### PR TITLE
Return index access bug

### DIFF
--- a/src/cairoWriter.ts
+++ b/src/cairoWriter.ts
@@ -685,7 +685,8 @@ class IdentifierWriter extends CairoASTNodeWriter {
       isDynamicCallDataArray(getNodeType(node, this.ast.compilerVersion)) &&
       ((node.getClosestParentByType(Return) !== undefined &&
         node.getClosestParentByType(FunctionDefinition)?.visibility ===
-          FunctionVisibility.External) ||
+          FunctionVisibility.External &&
+        node.getClosestParentByType(IndexAccess) === undefined) ||
         (node.parent instanceof FunctionCall &&
           node.parent.vReferencedDeclaration instanceof FunctionDefinition &&
           node.parent.vReferencedDeclaration.visibility === FunctionVisibility.External))

--- a/src/passes/tupleAssignmentSplitter.ts
+++ b/src/passes/tupleAssignmentSplitter.ts
@@ -121,21 +121,23 @@ export class TupleAssignmentSplitter extends ASTMapper {
       node.vRightHandSide,
     );
 
-    const assignments = [...tempVars.entries()].map(
-      ([target, tempVar]) =>
-        new ExpressionStatement(
-          ast.reserveId(),
-          node.src,
-          new Assignment(
+    const assignments = [...tempVars.entries()]
+      .filter(([_, tempVar]) => tempVar.storageLocation !== DataLocation.CallData)
+      .map(
+        ([target, tempVar]) =>
+          new ExpressionStatement(
             ast.reserveId(),
             node.src,
-            target.typeString,
-            '=',
-            target,
-            createIdentifier(tempVar, ast),
+            new Assignment(
+              ast.reserveId(),
+              node.src,
+              target.typeString,
+              '=',
+              target,
+              createIdentifier(tempVar, ast),
+            ),
           ),
-        ),
-    );
+      );
 
     block.appendChild(tempTupleDeclaration);
     assignments.forEach((n) => block.appendChild(n));

--- a/tests/behaviour/contracts/calldata/passingDynArrayInternally.sol
+++ b/tests/behaviour/contracts/calldata/passingDynArrayInternally.sol
@@ -20,6 +20,8 @@ contract WARP {
     function returnDArray(uint8[] calldata x) pure internal returns (uint8[] calldata){
         return (x);
     }
-
- 
+    
+    function returnFirstIndex(uint8[] calldata x) pure public returns (uint8) {
+        return x[0];
+    }
 }

--- a/tests/behaviour/contracts/tuples/calldata_tuple.sol
+++ b/tests/behaviour/contracts/tuples/calldata_tuple.sol
@@ -1,0 +1,15 @@
+pragma solidity ^0.8.10;
+//SPDX-License-Identifier: MIT
+
+contract WARP {
+ 
+  function createTuple(uint128[] calldata arr, uint128 num) private pure returns (uint128[] calldata, uint128) {
+    return (arr, num);
+  }
+
+  function tupleSplit(uint128[] calldata arr, uint128 num) public pure returns (uint128) {
+      (arr, num) = createTuple(arr, num);
+      return num;
+  }
+}
+

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -2186,6 +2186,11 @@ export const expectations = flatten(
             ),
           ]),
         ]),
+        new Dir('tuples', [
+          File.Simple('calldata_tuple', [
+            Expect.Simple('tupleSplit', ['3', '1', '2', '3', '5'], ['5']),
+          ]),
+        ]),
         new Dir('type_information', [
           File.Simple('informationEnum', [
             Expect.Simple('dMin', [], ['0']),

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -131,6 +131,7 @@ export const expectations = flatten(
                 ],
               ],
             ),
+            Expect.Simple('returnFirstIndex', ['2', ...['1', '2']], ['1']),
           ]),
         ]),
         new Dir('conditionals', [


### PR DESCRIPTION
While returning an index of an array `return arr[0];`, both length and value (with a wrong syntax) were returned previously, while it should have been only the value.