### PR TITLE
return error msg in case of OUT_OF_RESOURCE

### DIFF
--- a/starknet-testnet/server.py
+++ b/starknet-testnet/server.py
@@ -105,7 +105,10 @@ async def invoke():
         )
     except StarkException as err:
         print(err)
-        if err.code == StarknetErrorCode.TRANSACTION_FAILED or err.code == StarknetErrorCode.OUT_OF_RESOURCES:
+        if (
+            err.code == StarknetErrorCode.TRANSACTION_FAILED
+            or err.code == StarknetErrorCode.OUT_OF_RESOURCES
+        ):
             return jsonify(
                 {"transaction_info": {"threw": True, "message": err.message}}
             )

--- a/starknet-testnet/server.py
+++ b/starknet-testnet/server.py
@@ -105,7 +105,7 @@ async def invoke():
         )
     except StarkException as err:
         print(err)
-        if err.code == StarknetErrorCode.TRANSACTION_FAILED:
+        if err.code == StarknetErrorCode.TRANSACTION_FAILED or err.code == StarknetErrorCode.OUT_OF_RESOURCES:
             return jsonify(
                 {"transaction_info": {"threw": True, "message": err.message}}
             )


### PR DESCRIPTION
Currently, if transaction executor goes out of resources then it raises an exception, but now it'll return to the sender with an appropriate error message. 