### PR TITLE
Exclude WARP FREE from compilation

### DIFF
--- a/src/testing.ts
+++ b/src/testing.ts
@@ -289,6 +289,7 @@ function runCairoFileTest(
   onlyResults: boolean,
   throwError = false,
 ): void {
+  if (file.endsWith('WARP_FREE__.cairo')) return;
   if (!onlyResults) console.log(`Compiling ${file}`);
   if (compileCairo(file).success) {
     results.set(removeExtension(file), 'Success');

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -191,7 +191,7 @@ const expectedResults = new Map<string, ResultType>([
   // uses modulo (%)
   ['example_contracts/unsupportedFunctions/shadowAddmod', 'Success'],
   // Uses WARP_STORAGE in a free function
-  ['example_contracts/using_for/imports/user_defined', 'CairoCompileFailed'],
+  ['example_contracts/using_for/imports/user_defined', 'Success'],
   // global_directive.sol cannot resolve struct when file imported as identifier
   ['example_contracts/using_for/imports/global_directive', 'CairoCompileFailed'],
   ['example_contracts/using_for/function', 'WillNotSupport'],


### PR DESCRIPTION
Excludes the WARP FREE functions from compilations.
Updates the testing.ts expected outcomes.