### PR TITLE
Formatting fix in benchmark markdown

### DIFF
--- a/starknet-testnet/generateMarkdown.py
+++ b/starknet-testnet/generateMarkdown.py
@@ -100,7 +100,7 @@ def create_markdown():
             md_file.write("| ----------- | ----------- |\n")
 
             for metric, value in sorted(data.items()):
-                if metric == "builtin_instances":
+                if metric in ["builtin_instances", "function_steps"]:
                     continue
                 md_file.write(f"| {metric} | {value} |\n")
             md_file.write(f"\n")


### PR DESCRIPTION
A quite small fix which removes the function_steps being added where it shouldn't be in the markdown file.