### PR TITLE
Order of evaluation of arguments in constructors

### DIFF
--- a/src/passes/inheritanceInliner/constructorInheritance.ts
+++ b/src/passes/inheritanceInliner/constructorInheritance.ts
@@ -39,12 +39,13 @@ import { updateReferencedDeclarations } from './utils';
   
   A new function will be created and added as a child of the current contract, and this
   function will be the new constructor. It will handle:
-    - Collecting the arguments to call each base constructor. To do that, each time an 
-    argument is passed, a new variable declaration is created cloning the parameter that 
-    corresponds to this argument. The value of the declaration is the expression of the 
-    argument, and references to the parameter will change to reference the new variable 
-    created.
+    - Collecting the arguments to call each base constructor.
     - Calling the functions corresponding to each constructor in the correct order.
+
+  When collecting the arguments, it's important to notice that expressions should be 
+  evaluated in the reverse order the constructors are executed. To do so, each time a
+  contract is entered, the previous constracts in the order of linearization are checked
+  looking for the call to this contract's constructor; and argument references are updated
 
   In the following example:
   

--- a/tests/behaviour/contracts/inheritance/constructors/order_of_eval.sol
+++ b/tests/behaviour/contracts/inheritance/constructors/order_of_eval.sol
@@ -1,0 +1,33 @@
+pragma solidity ^0.8.6;
+
+// SPDX-License-Identifier: MIT
+
+contract A {
+  uint256[] x;
+
+  constructor(uint256) {}
+
+  function f(uint256 _x) internal returns (uint256) {
+    x.push(_x);
+  }
+}
+
+contract B {
+  constructor(uint256) {}
+}
+
+abstract contract C is A {
+  constructor(uint256) {}
+}
+
+abstract contract D is C {
+  constructor(uint256) C(f(2)) {}
+}
+
+contract X is B, D {
+  function g() public view returns (uint256[] memory) {
+    return x;
+  }
+
+  constructor() A(f(1)) B(f(3)) D(f(4)) {}
+}

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -1307,6 +1307,12 @@ export const expectations = flatten(
         new Dir('inheritance', [
           new Dir('constructors', [
             new File(
+              'abstractContract',
+              'C',
+              ['250', '0'],
+              [Expect.Simple('f', ['412', '0'], ['662', '0'])],
+            ),
+            new File(
               'constructors',
               'C',
               [],
@@ -1330,10 +1336,10 @@ export const expectations = flatten(
               [Expect.Simple('a', [], ['0', '0'])],
             ),
             new File(
-              'abstractContract',
-              'C',
-              ['250', '0'],
-              [Expect.Simple('f', ['412', '0'], ['662', '0'])],
+              'order_of_eval',
+              'X',
+              [],
+              [Expect.Simple('g', [], ['4', '4', '0', '2', '0', '1', '0', '3', '0'])],
             ),
           ]),
           new Dir('functions', [


### PR DESCRIPTION
Constructors are executed from the "most base-like" to the "most derived" according to the order of linearization. However, expressions passed as arguments for those constructors are evaluated first (before the execution of constructors) and this is done in the reverse order of execution, or in other words, from the "most derived" to the "most base-like".

This PR addresses the previous issue, so that the arguments are evaluated in the correct order