### PR TITLE
change expected loc of contract state_var

### DIFF
--- a/src/passes/references/expectedLocationAnalyser.ts
+++ b/src/passes/references/expectedLocationAnalyser.ts
@@ -11,15 +11,13 @@ import {
   FunctionVisibility,
   generalizeType,
   getNodeType,
-  Identifier,
   IndexAccess,
   MemberAccess,
   PointerType,
   Return,
   TupleExpression,
   UnaryOperation,
-  UserDefinedTypeName,
-  VariableDeclaration,
+  UserDefinedType,
   VariableDeclarationStatement,
 } from 'solc-typed-ast';
 import { AST } from '../../ast/ast';
@@ -159,14 +157,11 @@ export class ExpectedLocationAnalyser extends ASTMapper {
 
   visitMemberAccess(node: MemberAccess, ast: AST): void {
     const baseLoc = this.actualLocations.get(node.vExpression);
+    const baseNodeType = getNodeType(node.vExpression, ast.compilerVersion);
     assert(baseLoc !== undefined);
     if (
-      node.vExpression instanceof Identifier &&
-      node.vExpression.vReferencedDeclaration instanceof VariableDeclaration &&
-      node.vExpression.vReferencedDeclaration.stateVariable &&
-      node.vExpression.vReferencedDeclaration.vType instanceof UserDefinedTypeName &&
-      node.vExpression.vReferencedDeclaration.vType.vReferencedDeclaration instanceof
-        ContractDefinition
+      baseNodeType instanceof UserDefinedType &&
+      baseNodeType.definition instanceof ContractDefinition
     ) {
       this.expectedLocations.set(node.vExpression, DataLocation.Default);
     } else this.expectedLocations.set(node.vExpression, baseLoc);

--- a/tests/behaviour/contracts/cross_contract_calls/this_methods_call.sol
+++ b/tests/behaviour/contracts/cross_contract_calls/this_methods_call.sol
@@ -17,6 +17,6 @@ contract A {
   }
 
   function execute_add(int a, int b) view public returns (int) {
-    return this.add(a, b) + this.add(b,a) + this.c() + returnThis().d()/* + curr_contract.c()*/;
+    return this.add(a, b) + this.add(b,a) + this.c() + returnThis().d() + curr_contract.c();
   }
 }

--- a/tests/behaviour/contracts/cross_contract_calls/this_methods_call.sol
+++ b/tests/behaviour/contracts/cross_contract_calls/this_methods_call.sol
@@ -15,8 +15,12 @@ contract A {
   function returnThis() view public returns (A) {
     return this;
   }
+  
+  function return_curr_contract() view public returns (A) {
+    return curr_contract;
+  }
 
   function execute_add(int a, int b) view public returns (int) {
-    return this.add(a, b) + this.add(b,a) + this.c() + returnThis().d() + curr_contract.c();
+    return this.add(a, b) + this.c() + curr_contract.d() + returnThis().d() + return_curr_contract().c();
   }
 }

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -579,7 +579,7 @@ export const expectations = flatten(
         new Dir('cross_contract_calls', [
           File.Simple(
             'this_methods_call',
-            [Expect.Simple('execute_add', ['2', '0', '35', '0'], ['708', '0'])],
+            [Expect.Simple('execute_add', ['2', '0', '35', '0'], ['637', '0'])],
             'A',
           ),
           File.Simple('simple', [Expect.Simple('f', [], ['69', '0'])], 'A'),

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -579,7 +579,7 @@ export const expectations = flatten(
         new Dir('cross_contract_calls', [
           File.Simple(
             'this_methods_call',
-            [Expect.Simple('execute_add', ['2', '0', '35', '0'], ['374', '0'])],
+            [Expect.Simple('execute_add', ['2', '0', '35', '0'], ['708', '0'])],
             'A',
           ),
           File.Simple('simple', [Expect.Simple('f', [], ['69', '0'])], 'A'),


### PR DESCRIPTION
Initially contract type state variables has DataLocation as `strorage` which were creating problems when we access the variable, now the DataLocation is `default` and it is working as expected. 