### PR TITLE
Fix mod implicits

### DIFF
--- a/src/warplib/implementations/maths/mod.ts
+++ b/src/warplib/implementations/maths/mod.ts
@@ -1,5 +1,6 @@
 import { BinaryOperation } from 'solc-typed-ast';
 import { AST } from '../../../ast/ast';
+import { Implicits } from '../../../utils/implicits';
 import { mapRange } from '../../../utils/utils';
 import { forAllWidths, generateFile, IntxIntFunction } from '../../utils';
 
@@ -41,5 +42,9 @@ export function mod_signed() {
 }
 
 export function functionaliseMod(node: BinaryOperation, ast: AST): void {
-  IntxIntFunction(node, 'mod', 'signedOrWide', true, false, () => ['range_check_ptr'], ast);
+  const implicits = (width: number, signed: boolean): Implicits[] => {
+    if (width !== 256 && signed) return ['range_check_ptr', 'bitwise_ptr'];
+    return ['range_check_ptr'];
+  };
+  IntxIntFunction(node, 'mod', 'signedOrWide', true, false, implicits, ast);
 }

--- a/tests/behaviour/behaviour.test.ts
+++ b/tests/behaviour/behaviour.test.ts
@@ -11,9 +11,10 @@ import { DeployResponse } from '../testnetInterface';
 
 const PRINT_STEPS = false;
 const PARALLEL_COUNT = 8;
+const TIME_LIMIT = 60 * 60 * 1000;
 
 describe('Transpile solidity', function () {
-  this.timeout(1800000);
+  this.timeout(TIME_LIMIT);
 
   let transpileResults: SafePromise<{ stderr: string }>[];
 
@@ -44,7 +45,7 @@ describe('Transpile solidity', function () {
 });
 
 describe('Transpiled contracts are valid cairo', function () {
-  this.timeout(1800000);
+  this.timeout(TIME_LIMIT);
 
   let compileResults: SafePromise<{ stderr: string } | null>[];
 
@@ -78,7 +79,7 @@ describe('Transpiled contracts are valid cairo', function () {
 const deployedAddresses: Map<string, string> = new Map();
 
 describe('Compiled contracts are deployable', function () {
-  this.timeout(1800000);
+  this.timeout(TIME_LIMIT);
 
   // let deployResults: SafePromise<string>[];
   const deployResults: (DeployResponse | null)[] = [];
@@ -119,7 +120,7 @@ describe('Compiled contracts are deployable', function () {
 });
 
 describe('Deployed contracts have correct behaviour', function () {
-  this.timeout(1800000);
+  this.timeout(TIME_LIMIT);
 
   for (const fileTest of expectations) {
     if (fileTest.expectations instanceof Promise) {

--- a/tests/behaviour/contracts/maths/remainder.sol
+++ b/tests/behaviour/contracts/maths/remainder.sol
@@ -23,21 +23,21 @@ contract WARP {
     }
   }
 
-  function remainder8signedsafe (uint8 lhs, uint8 rhs) pure public returns (uint8) {
+  function remainder8signedsafe (int8 lhs, int8 rhs) pure public returns (int8) {
     return lhs % rhs;
   }
 
-  function remainder8signedunsafe (uint8 lhs, uint8 rhs) pure public returns (uint8) {
+  function remainder8signedunsafe (int8 lhs, int8 rhs) pure public returns (int8) {
     unchecked {
       return lhs % rhs;
     }
   }
 
-  function remainder256signedsafe (uint256 lhs, uint256 rhs) pure public returns (uint256) {
+  function remainder256signedsafe (int256 lhs, int256 rhs) pure public returns (int256) {
     return lhs % rhs;
   }
 
-  function remainder256signedunsafe (uint256 lhs, uint256 rhs) pure public returns (uint256) {
+  function remainder256signedunsafe (int256 lhs, int256 rhs) pure public returns (int256) {
     unchecked {
       return lhs % rhs;
     }

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -1903,7 +1903,8 @@ export const expectations = flatten(
           ]),
           File.Simple('remainder', [
             Expect.Simple('remainder8safe', ['103', '5'], ['3']),
-            Expect.Simple('remainder8signedsafe', ['137', '5'], ['2']),
+            //-119 % 5 = -4
+            Expect.Simple('remainder8signedsafe', ['137', '5'], ['252']),
             Expect.Simple('remainder8unsafe', ['215', '9'], ['8']),
             Expect.Simple('remainder8signedunsafe', ['2', '5'], ['2']),
             Expect.Simple('remainder256safe', ['255', '23', '5', '0'], ['3', '0']),


### PR DESCRIPTION
The warplib mod function requires bitwise pointer when dealing with signed values narrower than 256 bits, all other versions only require range_check. This progresses the viaYul/detect_mod_signed test, though it still requires the div/mod by 0 not throwing task to succeed fully