### PR TITLE
Unbounded string literals are converted into uint8[] array as well

### DIFF
--- a/tests/behaviour/contracts/stringLiteral/stringLiteralMemory.sol
+++ b/tests/behaviour/contracts/stringLiteral/stringLiteralMemory.sol
@@ -6,6 +6,14 @@ contract WARP {
         return x;
     }
 
+    function plainLiteral() public pure {
+        "WARP";
+    } 
+
+    function returnLiteral() public pure returns (string memory) {
+        return "WARP";
+    }
+
     function varDecl() public pure returns (string memory) {
         string memory x = "WARP";
         return x;
@@ -13,10 +21,6 @@ contract WARP {
 
     function tupleRet() public pure returns (string memory, string memory) {
         return ("WA", "RP");
-    }
-
-    function funcCall() public pure returns (string memory) {
-        return varDecl();
     }
 
     function funcCallWithArg() public pure returns (string memory) {

--- a/tests/behaviour/contracts/stringLiteral/stringLiteralStorage.sol
+++ b/tests/behaviour/contracts/stringLiteral/stringLiteralStorage.sol
@@ -1,0 +1,18 @@
+pragma solidity ^0.8.0;
+//SPDX-License-Identifier: MIT
+
+contract WARP {
+
+    string str;
+
+    function literalAssignment() public returns (string memory) {
+        str = "WARP";
+        return str;
+    }
+
+    function memoryToStorageAssignment() public returns (string memory) {
+        string memory x = "WARP";
+        str = x;
+        return str;
+    }
+}

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -2547,13 +2547,18 @@ export const expectations = flatten(
             ]),
           ]),
         ]),
-        new Dir('string', [
+        new Dir('stringLiteral', [
           File.Simple('stringLiteralMemory', [
+            Expect.Simple('returnLiteral', [], ['4', '87', '65', '82', '80']),
+            Expect.Simple('plainLiteral', [], []),
             Expect.Simple('varDecl', [], ['4', '87', '65', '82', '80']),
             Expect.Simple('tupleRet', [], ['2', '87', '65', '2', '82', '80']),
-            Expect.Simple('funcCall', [], ['4', '87', '65', '82', '80']),
             Expect.Simple('funcCallWithArg', [], ['4', '87', '65', '82', '80']),
             Expect.Simple('nestedFuncCallWithArg', [], ['4', '87', '65', '82', '80']),
+          ]),
+          File.Simple('stringLiteralStorage', [
+            Expect.Simple('literalAssignment', [], ['4', '87', '65', '82', '80']),
+            Expect.Simple('memoryToStorageAssignment', [], ['4', '87', '65', '82', '80']),
           ]),
         ]),
         new Dir('this_keyword', [


### PR DESCRIPTION
Unbounded string literals (to a variable, function, or tuple), were not converted to uint8[] memory arrays properly, they are successfully converted now.