### PR TITLE
Weaken overzealous sanity check

### DIFF
--- a/src/utils/astChecking.ts
+++ b/src/utils/astChecking.ts
@@ -600,9 +600,11 @@ export function checkSane(unit: SourceUnit, ctx: ASTContext): void {
 
       checkDirectChildren(node, 'vCondition', 'vTrueBody', 'vFalseBody');
     } else if (node instanceof Return) {
-      checkFieldAndVFieldMatch(node, 'functionReturnParameters', 'vFunctionReturnParameters');
-
-      checkVFieldCtx(node, 'vFunctionReturnParameters', ctx);
+      // return functionReturnParameters member is undefined for returns in modifiers
+      if (node.functionReturnParameters !== undefined) {
+        checkFieldAndVFieldMatch(node, 'functionReturnParameters', 'vFunctionReturnParameters');
+        checkVFieldCtx(node, 'vFunctionReturnParameters', ctx);
+      }
       checkDirectChildren(node, 'vExpression');
     } else if (node instanceof TryCatchClause) {
       checkDirectChildren(node, 'vParameters', 'vBlock');

--- a/src/utils/astPrinter.ts
+++ b/src/utils/astPrinter.ts
@@ -110,6 +110,7 @@ export const DefaultASTPrinter = new ASTPrinter()
     print: context,
   })
   .lookFor('fieldNames')
+  .lookFor('functionReturnParameters')
   .lookFor({
     prop: 'implicits',
     nodeType: 'CairoFunctionDefinition',

--- a/tests/behaviour/contracts/modifiers/modifierWithReturn.sol
+++ b/tests/behaviour/contracts/modifiers/modifierWithReturn.sol
@@ -1,0 +1,12 @@
+pragma solidity ^0.8.14;
+
+contract WARP {
+    modifier m() {
+      _;
+      return;
+    }
+
+    function returnFiveThroughModifiers() m m public returns (uint8) {
+      return 5;
+    }
+}

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -2335,6 +2335,9 @@ export const expectations = flatten(
             Expect.Simple('f', ['90000', '0'], ['10000', '0']),
             Expect.Simple('f', ['110000', '0'], ['0', '0']),
           ]),
+          File.Simple('modifierWithReturn', [
+            Expect.Simple('returnFiveThroughModifiers', [], ['5']),
+          ]),
           File.Simple('multipleModifiers', [
             new Expect('modifier', [
               ['openEvent', [], [], '0'],


### PR DESCRIPTION
solc-typed-ast declares Returns as having the number parameter functionReturnParameters, but it can actually be undefined as returns can appear in modifiers