### PR TITLE
make every lib fns private

### DIFF
--- a/src/passes/references/index.ts
+++ b/src/passes/references/index.ts
@@ -58,6 +58,7 @@ export class References extends ASTMapper {
   }
 }
 
+// import { printNode } from '../../utils/astPrinter';
 // function printLocations(
 //   actualDataLocations: Map<Expression, DataLocation>,
 //   expectedDataLocations: Map<Expression, DataLocation>,

--- a/src/passes/storageAllocator.ts
+++ b/src/passes/storageAllocator.ts
@@ -74,6 +74,14 @@ export class StorageAllocator extends ASTMapper {
       node.nameLocation,
       node.raw,
     );
+
+    if (node.kind === ContractKind.Library) {
+      // mark all library functions as private
+      cairoNode.vFunctions.forEach((f) => {
+        f.visibility = FunctionVisibility.Private;
+      });
+    }
+
     ast.replaceNode(node, cairoNode);
 
     // This next code line is a hotfix when there is struct inheritance and the base contract's definiton

--- a/tests/behaviour/expectations/semantic_whitelist.ts
+++ b/tests/behaviour/expectations/semantic_whitelist.ts
@@ -901,6 +901,7 @@ const tests: string[] = [
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/libraries/using_for_overload.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/libraries/using_for_storage_structs.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/libraries/using_library_mappings_return.sol',
+    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/libraries/using_library_structs.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/libraries/using_library_mappings_public.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/libraries/internal_library_function_bound_to_contract.sol', // STRETCH new
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/libraries/mapping_returns_in_library.sol', // STRETCH conditional


### PR DESCRIPTION
Now, `tests/behaviour/solidity/test/libsolidity/semanticTests/libraries/using_library_mappings_return.sol` is passing