### PR TITLE
Split external function calls returning dynarrays properly

### DIFF
--- a/src/cairoWriter.ts
+++ b/src/cairoWriter.ts
@@ -97,6 +97,7 @@ import {
   mergeImports,
   mangleOwnContractInterface,
   primitiveTypeToCairo,
+  isExternalCall,
 } from './utils/utils';
 
 const INDENT = ' '.repeat(4);
@@ -216,8 +217,7 @@ class VariableDeclarationStatementWriter extends CairoASTNodeWriter {
       if (
         isDynamicArray(type) &&
         node.vInitialValue instanceof FunctionCall &&
-        node.vInitialValue.vReferencedDeclaration instanceof FunctionDefinition &&
-        node.vInitialValue.vReferencedDeclaration.visibility === FunctionVisibility.External
+        isExternalCall(node.vInitialValue)
       ) {
         assert(
           declaration.storageLocation === DataLocation.CallData,
@@ -767,9 +767,7 @@ class IdentifierWriter extends CairoASTNodeWriter {
           FunctionVisibility.External &&
         node.getClosestParentByType(IndexAccess) === undefined &&
         node.getClosestParentByType(MemberAccess) === undefined) ||
-        (node.parent instanceof FunctionCall &&
-          node.parent.vReferencedDeclaration instanceof FunctionDefinition &&
-          node.parent.vReferencedDeclaration.visibility === FunctionVisibility.External))
+        (node.parent instanceof FunctionCall && isExternalCall(node.parent)))
     ) {
       return [`${node.name}.len, ${node.name}.ptr`];
     }

--- a/src/passes/implicitConversionToExplicit.ts
+++ b/src/passes/implicitConversionToExplicit.ts
@@ -45,7 +45,12 @@ import { error } from '../utils/formatting';
 import { createElementaryConversionCall } from '../utils/functionGeneration';
 import { createNumberLiteral } from '../utils/nodeTemplates';
 import { getParameterTypes, intTypeForLiteral } from '../utils/nodeTypeProcessing';
-import { typeNameFromTypeNode, bigintToTwosComplement, toHexString } from '../utils/utils';
+import {
+  typeNameFromTypeNode,
+  bigintToTwosComplement,
+  toHexString,
+  isExternalCall,
+} from '../utils/utils';
 
 /*
 Detects implicit conversions by running solc-typed-ast's type analyser on
@@ -212,7 +217,10 @@ export class ImplicitConversionToExplicit extends ASTMapper {
 
     if (baseType instanceof MappingType) {
       insertConversionIfNecessary(node.vIndexExpression, baseType.keyType, ast);
-    } else if (location === DataLocation.CallData) {
+    } else if (
+      location === DataLocation.CallData ||
+      (node.vBaseExpression instanceof FunctionCall && isExternalCall(node.vBaseExpression))
+    ) {
       insertConversionIfNecessary(node.vIndexExpression, new IntType(248, false), ast);
     } else {
       insertConversionIfNecessary(node.vIndexExpression, new IntType(256, false), ast);

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -398,3 +398,10 @@ export function mangleOwnContractInterface(contractOrName: ContractDefinition | 
   const name = typeof contractOrName === 'string' ? contractOrName : contractOrName.name;
   return `${name}_interface`;
 }
+
+export function isExternalCall(node: FunctionCall): boolean {
+  return (
+    node.vReferencedDeclaration instanceof FunctionDefinition &&
+    isExternallyVisible(node.vReferencedDeclaration)
+  );
+}

--- a/tests/behaviour/contracts/calldata/returningDynArrayExternally.sol
+++ b/tests/behaviour/contracts/calldata/returningDynArrayExternally.sol
@@ -1,0 +1,12 @@
+pragma solidity ^0.8.10;
+
+// SPDX-License-Identifier: MIT
+
+contract WARP {
+    function test(bytes calldata x) public returns (bytes calldata) {
+        return x;
+    }
+    function tester(bytes calldata x) public returns (bytes1) {
+        return this.test(x)[2];
+    }
+}

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -181,6 +181,9 @@ export const expectations = flatten(
             ),
             Expect.Simple('returnFirstIndex', ['2', ...['1', '2']], ['1']),
           ]),
+          File.Simple('returningDynArrayExternally', [
+            Expect.Simple('tester', ['3', '4', '5', ' 6'], ['6']),
+          ]),
         ]),
         new Dir('concat', [
           File.Simple('bytes', [


### PR DESCRIPTION
External function calls with return types like `bytes memory` need to be treated as calldata returns. This modifies extractToConstant to check for this case and change the location of the constant