### PR TITLE
Handle unitialised storage pointers

### DIFF
--- a/src/utils/defaultValueNodes.ts
+++ b/src/utils/defaultValueNodes.ts
@@ -12,7 +12,6 @@ import {
   getNodeType,
   Identifier,
   IntType,
-  MappingType,
   MemberAccess,
   NewExpression,
   PointerType,
@@ -26,12 +25,14 @@ import {
 import { AST } from '../ast/ast';
 import { printNode, printTypeNode } from './astPrinter';
 import { NotSupportedYetError } from './errors';
+import { generateExpressionTypeString } from './getTypeString';
 import {
   createAddressTypeName,
   createBoolLiteral,
   createNumberLiteral,
   createStringLiteral,
 } from './nodeTemplates';
+import { isStorageSpecificType } from './nodeTypeProcessing';
 import { typeNameFromTypeNode } from './utils';
 
 export function getDefaultValue(
@@ -39,13 +40,13 @@ export function getDefaultValue(
   parentNode: Expression | VariableDeclaration,
   ast: AST,
 ): Expression {
-  if (nodeType instanceof AddressType) return addressDefault(nodeType, parentNode, ast);
+  if (isStorageSpecificType(nodeType, ast)) return intDefault(nodeType, parentNode, ast);
+  else if (nodeType instanceof AddressType) return addressDefault(nodeType, parentNode, ast);
   else if (nodeType instanceof ArrayType) return arrayDefault(nodeType, parentNode, ast);
   else if (nodeType instanceof BytesType) return bytesDefault(nodeType, parentNode, ast);
   else if (nodeType instanceof BoolType) return boolDefault(parentNode, ast);
   else if (nodeType instanceof FixedBytesType) return fixedBytesDefault(nodeType, parentNode, ast);
   else if (nodeType instanceof IntType) return intDefault(nodeType, parentNode, ast);
-  else if (nodeType instanceof MappingType) return intDefault(nodeType, parentNode, ast);
   else if (nodeType instanceof PointerType) return pointerDefault(nodeType, parentNode, ast);
   else if (nodeType instanceof StringType) return stringDefault(parentNode, ast);
   else if (nodeType instanceof UserDefinedType) return userDefDefault(nodeType, parentNode, ast);
@@ -58,7 +59,7 @@ function intDefault(
   parentNode: Expression | VariableDeclaration,
   ast: AST,
 ): Expression {
-  return createNumberLiteral(0, ast, node.pp());
+  return createNumberLiteral(0, ast, generateExpressionTypeString(node));
 }
 
 function fixedBytesDefault(

--- a/src/utils/nodeTypeProcessing.ts
+++ b/src/utils/nodeTypeProcessing.ts
@@ -235,3 +235,14 @@ export function getSize(type: ArrayType | BytesType | StringType): bigint | unde
     return undefined;
   }
 }
+
+export function isStorageSpecificType(type: TypeNode, ast: AST): boolean {
+  if (type instanceof MappingType) return true;
+  if (type instanceof PointerType) return isStorageSpecificType(type.to, ast);
+  if (type instanceof ArrayType) return isStorageSpecificType(type.elementT, ast);
+  if (type instanceof UserDefinedType && type.definition instanceof StructDefinition)
+    return type.definition.vMembers.some((m) =>
+      isStorageSpecificType(getNodeType(m, ast.compilerVersion), ast),
+    );
+  return false;
+}

--- a/tests/behaviour/expectations/semantic_whitelist.ts
+++ b/tests/behaviour/expectations/semantic_whitelist.ts
@@ -907,7 +907,6 @@ const tests: string[] = [
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/libraries/mapping_returns_in_library.sol', // STRETCH conditional
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/libraries/internal_library_function_bound_to_address_named_send_transfer.sol', // WILL NOT SUPPORT raw address calls
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/libraries/internal_library_function_bound_to_interface.sol', // STRETCH new
-    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/libraries/using_library_structs.sol', // nested dynarray inputs
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/libraries/external_call_with_function_pointer_parameter.sol', // WILL NOT SUPPORT function objects
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/libraries/internal_library_function_bound_to_external_function.sol', // WILL NOT SUPPORT function objects
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/libraries/internal_library_function_bound_to_function_named_selector.sol', // WILL NOT SUPPORT function objects


### PR DESCRIPTION
Previously default values for reference types and mappings went into memory. This switches it so that if the variable is a type that can't go in memory, then it is given a placeholder initialValue that matches its type