### PR TITLE
Fix old code generator error

### DIFF
--- a/example_contracts/old_code_gen_err.sol
+++ b/example_contracts/old_code_gen_err.sol
@@ -1,0 +1,8 @@
+pragma solidity ^0.8.0;
+//SPDX-License-Identifier: MIT
+contract WARP {
+  int16[][2] x;
+    function test(int16[][2] calldata y) external  {
+      x = y;
+    }
+}

--- a/example_contracts/old_code_gen_err_7.sol
+++ b/example_contracts/old_code_gen_err_7.sol
@@ -1,0 +1,8 @@
+pragma solidity ^0.8.0;
+//SPDX-License-Identifier: MIT
+contract WARP {
+  int16[][2] x;
+    function test(int16[][2] calldata y) external  {
+      x = y;
+    }
+}

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -152,6 +152,8 @@ const expectedResults = new Map<string, ResultType>(
     ['example_contracts/nested_static_array_struct', 'Success'],
     ['example_contracts/nested_struct_static_array', 'Success'],
     ['example_contracts/nested_structs', 'Success'],
+    ['example_contracts/old_code_gen_err', 'WillNotSupport'],
+    ['example_contracts/old_code_gen_err_7', 'WillNotSupport'],
     ['example_contracts/payable_function', 'Success'],
     ['example_contracts/pure_function', 'Success'],
     ['example_contracts/return_dyn_array', 'Success'],


### PR DESCRIPTION
The files listed below and a few more fail with the error listed below when we try to compile through YUL, so we can't get the AST for all files through with viaIR enabled.

In this PR we try the standard-json flag with the `viaIR` enabled first and if there are errors we try with `viaIR` disabled.

example_contracts/using_for/library.sol
example_contracts/variable_declarations.sol
example_contracts/view_function.sol
and many more fail with:
    YulException: Variable <<x>> is <<n>> slot(s) too deep inside the stack.
 

