### PR TITLE
Fix function call assignment bug from short circuiting

### DIFF
--- a/src/cairoWriter.ts
+++ b/src/cairoWriter.ts
@@ -917,7 +917,21 @@ class BinaryOperationWriter extends CairoASTNodeWriter {
 class AssignmentWriter extends CairoASTNodeWriter {
   writeInner(node: Assignment, writer: ASTWriter): SrcDesc {
     assert(node.operator === '=', `Unexpected operator ${node.operator}`);
-    const nodes = [node.vLeftHandSide, node.vRightHandSide].map((v) => writer.write(v));
+    const [lhs, rhs] = [node.vLeftHandSide, node.vRightHandSide];
+    const nodes = [lhs, rhs].map((v) => writer.write(v));
+    // This is specifically needed because of the construtions involved with writing
+    // conditionals (derived from short circuit expressions). Other tuple assignments
+    // and function call assignments will have been split
+    if (
+      rhs instanceof FunctionCall &&
+      !(
+        rhs.vReferencedDeclaration instanceof CairoFunctionDefinition &&
+        rhs.vReferencedDeclaration.functionStubKind === FunctionStubKind.StructDefStub
+      ) &&
+      !(lhs instanceof TupleExpression)
+    ) {
+      return [`let (${nodes[0]}) ${node.operator} ${nodes[1]}`];
+    }
     return [`let ${nodes[0]} ${node.operator} ${nodes[1]}`];
   }
 }


### PR DESCRIPTION
Fixes the recurring bug with assignments of the form `let x = f()` arising from handling of short circuiting operators