### PR TITLE
Fix tuple assignment for structs

### DIFF
--- a/src/cairoUtilFuncGen/storage/mappingIndexAccess.ts
+++ b/src/cairoUtilFuncGen/storage/mappingIndexAccess.ts
@@ -33,7 +33,11 @@ export class MappingIndexAccessGen extends StringIndexedFuncGen {
       [
         ['name', typeNameFromTypeNode(baseType, this.ast), DataLocation.Storage],
         // TODO check that this is always default
-        ['index', typeNameFromTypeNode(baseType.to.keyType, this.ast), DataLocation.Default],
+        [
+          'index',
+          typeNameFromTypeNode(baseType.to.keyType, this.ast),
+          locationIfComplexType(baseType.to.keyType, DataLocation.Storage),
+        ],
       ],
       [
         [

--- a/src/cairoWriter.ts
+++ b/src/cairoWriter.ts
@@ -23,6 +23,7 @@ import {
   ErrorDefinition,
   EventDefinition,
   ExpressionStatement,
+  ExternalReferenceType,
   ForStatement,
   FunctionCall,
   FunctionCallKind,
@@ -64,6 +65,8 @@ import {
   TryCatchClause,
   TryStatement,
   TupleExpression,
+  TupleType,
+  TypeNode,
   UnaryOperation,
   UncheckedBlock,
   UserDefinedType,
@@ -206,18 +209,35 @@ class VariableDeclarationStatementWriter extends CairoASTNodeWriter {
     );
 
     const documentation = getDocumentation(node.documentation, writer);
-    const declarations = node.assignments.flatMap((id) => {
-      if (id === null) {
-        return [`__warp_gv${this.gapVarCounter++}`];
-      }
+    const initialValueType = getNodeType(node.vInitialValue, this.ast.compilerVersion);
+
+    const getValueN = (n: number): TypeNode => {
+      if (initialValueType instanceof TupleType) {
+        return initialValueType.elements[n];
+      } else if (n === 0) return initialValueType;
+      throw new TranspileFailedError(
+        `Attempted to extract value at index ${n} of non-tuple return`,
+      );
+    };
+
+    const getDeclarationForId = (id: number): VariableDeclaration => {
       const declaration = node.vDeclarations.find((decl) => decl.id === id);
       assert(declaration !== undefined, `Unable to find variable declaration for assignment ${id}`);
-      const type = generalizeType(getNodeType(declaration, this.ast.compilerVersion))[0];
+      return declaration;
+    };
+
+    const declarations = node.assignments.flatMap((id, index) => {
+      const type = generalizeType(getValueN(index))[0];
       if (
         isDynamicArray(type) &&
         node.vInitialValue instanceof FunctionCall &&
         isExternalCall(node.vInitialValue)
       ) {
+        if (id === null) {
+          const uniqueSuffix = this.gapVarCounter++;
+          return [`__warp_gv_len${uniqueSuffix}`, `__warp_gv${uniqueSuffix}`];
+        }
+        const declaration = getDeclarationForId(id);
         assert(
           declaration.storageLocation === DataLocation.CallData,
           `WARNING: declaration receiving calldata dynarray has location ${declaration.storageLocation}`,
@@ -225,7 +245,10 @@ class VariableDeclarationStatementWriter extends CairoASTNodeWriter {
         const writtenVar = writer.write(declaration);
         return [`${writtenVar}_len`, writtenVar];
       } else {
-        return [writer.write(declaration)];
+        if (id === null) {
+          return [`__warp_gv${this.gapVarCounter++}`];
+        }
+        return [writer.write(getDeclarationForId(id))];
       }
     });
     if (
@@ -813,6 +836,13 @@ class IndexAccessWriter extends CairoASTNodeWriter {
 }
 class IdentifierWriter extends CairoASTNodeWriter {
   writeInner(node: Identifier, _: ASTWriter): SrcDesc {
+    if (
+      node.vIdentifierType === ExternalReferenceType.Builtin &&
+      node.name === 'super' &&
+      !(node.parent instanceof MemberAccess)
+    ) {
+      return ['0'];
+    }
     if (
       isDynamicCallDataArray(getNodeType(node, this.ast.compilerVersion)) &&
       ((node.getClosestParentByType(Return) !== undefined &&

--- a/src/passes/expressionSplitter/conditionalFunctionaliser.ts
+++ b/src/passes/expressionSplitter/conditionalFunctionaliser.ts
@@ -107,15 +107,20 @@ export function createFunctionBody(node: Conditional, returns: ParameterList, as
         ast.reserveId(),
         '',
         node.vCondition,
-        createReturnBody(returns, node.vTrueExpression, ast),
-        createReturnBody(returns, node.vFalseExpression, ast),
+        createReturnBody(returns, node.vTrueExpression, ast, node),
+        createReturnBody(returns, node.vFalseExpression, ast, node),
       ),
     ],
     ast,
   );
 }
 
-export function createReturnBody(returns: ParameterList, value: Expression, ast: AST): Block {
+export function createReturnBody(
+  returns: ParameterList,
+  value: Expression,
+  ast: AST,
+  lookupNode?: ASTNode,
+): Block {
   const firstVar = returns.vParameters[0];
   return createBlock(
     [
@@ -127,11 +132,11 @@ export function createReturnBody(returns: ParameterList, value: Expression, ast:
           '',
           firstVar.typeString,
           '=',
-          createIdentifier(firstVar, ast),
+          createIdentifier(firstVar, ast, undefined, lookupNode),
           value,
         ),
       ),
-      createReturn(returns.vParameters, returns.id, ast),
+      createReturn(returns.vParameters, returns.id, ast, lookupNode),
     ],
     ast,
   );

--- a/src/passes/implicitConversionToExplicit.ts
+++ b/src/passes/implicitConversionToExplicit.ts
@@ -45,12 +45,7 @@ import { error } from '../utils/formatting';
 import { createElementaryConversionCall } from '../utils/functionGeneration';
 import { createNumberLiteral } from '../utils/nodeTemplates';
 import { getParameterTypes, intTypeForLiteral } from '../utils/nodeTypeProcessing';
-import {
-  typeNameFromTypeNode,
-  bigintToTwosComplement,
-  toHexString,
-  isExternalCall,
-} from '../utils/utils';
+import { typeNameFromTypeNode, isExternalCall } from '../utils/utils';
 
 /*
 Detects implicit conversions by running solc-typed-ast's type analyser on
@@ -248,18 +243,6 @@ export class ImplicitConversionToExplicit extends ASTMapper {
       node.typeString = intTypeForLiteral(
         `int_const ${getLiteralValueBound(node.typeString)}`,
       ).pp();
-    }
-    this.commonVisit(node, ast);
-  }
-
-  visitLiteral(node: Literal, ast: AST): void {
-    const nodeType = getNodeType(node, ast.compilerVersion);
-    if (nodeType instanceof IntLiteralType) {
-      const typeTo = intTypeForLiteral(`int_const ${getLiteralValueBound(node.typeString)}`);
-      const truncated = bigintToTwosComplement(BigInt(node.value), typeTo.nBits).toString(10);
-      node.value = truncated;
-      node.hexValue = toHexString(truncated);
-      node.typeString = typeTo.pp();
     }
     this.commonVisit(node, ast);
   }

--- a/src/passes/literalExpressionEvaluator/literalExpressionEvaluator.ts
+++ b/src/passes/literalExpressionEvaluator/literalExpressionEvaluator.ts
@@ -98,6 +98,12 @@ function evaluateUnaryLiteral(node: UnaryOperation): RationalLiteral | boolean |
   if (op === null) return null;
 
   switch (node.operator) {
+    case '~': {
+      if (typeof op === 'boolean') {
+        throw new TranspileFailedError('Attempted to apply unary bitwise negation to boolean');
+      }
+      return op.bitwiseNegate();
+    }
     case '-':
       if (typeof op === 'boolean') {
         throw new TranspileFailedError('Attempted to apply unary numeric negation to boolean');

--- a/src/passes/literalExpressionEvaluator/rationalLiteral.ts
+++ b/src/passes/literalExpressionEvaluator/rationalLiteral.ts
@@ -111,6 +111,16 @@ export class RationalLiteral {
     return new RationalLiteral(this.numerator >> op, this.denominator);
   }
 
+  bitwiseNegate(): RationalLiteral | null {
+    const intValue = this.toInteger();
+    if (intValue === null) {
+      return null;
+    }
+
+    // -x = ~x + 1 in two's complement
+    return new RationalLiteral(-intValue - 1n, 1n);
+  }
+
   toInteger(): bigint | null {
     if (this.numerator % this.denominator === 0n) {
       return this.numerator / this.denominator;

--- a/src/passes/typeInformationCalculator.ts
+++ b/src/passes/typeInformationCalculator.ts
@@ -92,7 +92,7 @@ export class TypeInformationCalculator extends ASTMapper {
 
     if (nodeType instanceof IntType && (memberName === 'min' || memberName === 'max')) {
       const value = memberName === 'min' ? calculateIntMin(nodeType) : calculateIntMax(nodeType);
-      return createNumberLiteral(value, ast);
+      return createNumberLiteral(value, ast, nodeType.pp());
     }
 
     if (nodeType instanceof UserDefinedType) {

--- a/src/passes/typeInformationCalculator.ts
+++ b/src/passes/typeInformationCalculator.ts
@@ -23,7 +23,7 @@ import { createNumberLiteral, createStringLiteral } from '../utils/nodeTemplates
 
 function calculateIntMin(type: IntType): bigint {
   if (type.signed) {
-    return -(2n ** BigInt(type.nBits - 1));
+    return 2n ** BigInt(type.nBits - 1);
   } else {
     return 0n;
   }

--- a/src/utils/getTypeString.ts
+++ b/src/utils/getTypeString.ts
@@ -79,6 +79,8 @@ export function getFunctionTypeString(node: FunctionDefinition, compilerVersion:
       const baseType = getNodeType(decl, compilerVersion);
       if (
         baseType instanceof ArrayType ||
+        baseType instanceof BytesType ||
+        baseType instanceof StringType ||
         (baseType instanceof UserDefinedType && baseType.definition instanceof StructDefinition)
       ) {
         if (decl.storageLocation === DataLocation.Default) {

--- a/src/utils/nodeTemplates.ts
+++ b/src/utils/nodeTemplates.ts
@@ -191,12 +191,13 @@ export function createReturn(
   toReturn: Expression | VariableDeclaration[] | undefined,
   retParamListId: number,
   ast: AST,
+  lookupNode?: ASTNode,
 ): Return {
   const retValue =
     toReturn === undefined || toReturn instanceof Expression
       ? toReturn
       : toSingleExpression(
-          toReturn.map((decl) => createIdentifier(decl, ast)),
+          toReturn.map((decl) => createIdentifier(decl, ast, undefined, lookupNode)),
           ast,
         );
   const node = new Return(ast.reserveId(), '', retParamListId, retValue);

--- a/tests/behaviour/contracts/copy_memory_to_storage/dynamic_arrays.sol
+++ b/tests/behaviour/contracts/copy_memory_to_storage/dynamic_arrays.sol
@@ -29,4 +29,8 @@ contract WARP {
       arr256[i] = i + 1 + shift * (i + 2);
     }
   }
+
+  function tupleAssign(uint length1, uint length2) public {
+    (arr8, arr256) = (new uint8[](length1), new uint256[](length2));
+  }
 }

--- a/tests/behaviour/contracts/public_state_vars/structs.sol
+++ b/tests/behaviour/contracts/public_state_vars/structs.sol
@@ -22,6 +22,23 @@ contract WARP {
 
     B public d;
 
+    struct S {
+        uint256 x;
+        string a; // this is present in the accessor
+        uint256[] b; // this is not present
+        uint256 y;
+    }
+    S public s;
+
+    function getStructIgnoringDynArray(uint x, uint y) public returns (uint256, uint256) {
+        s.x = x;
+        s.a = "abc";
+        s.b = [7, 8, 9];
+        s.y = y;
+        (uint256 q, , uint256 w) = this.s();
+        return (q, w);
+    }
+
     constructor() public {
         a.a = 1;
         a.b = 2;

--- a/tests/behaviour/contracts/storage/swap.sol
+++ b/tests/behaviour/contracts/storage/swap.sol
@@ -1,0 +1,19 @@
+contract WARP {
+    struct S {
+        uint8 a;
+        uint8 b;
+    }
+    S public struct1;
+    S public struct2;
+
+    function set(uint8 a, uint8 b, uint8 c, uint8 d) public {
+        struct1.a = a;
+        struct1.b = b;
+        struct2.a = c;
+        struct2.b = d;
+    }
+
+    function swap() public {
+        (struct1, struct2) = (struct2, struct1);
+    }
+}

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -702,6 +702,10 @@ export const expectations = flatten(
               ['arr256', ['11', '0'], ['0', '0'], '0'],
               ['arr256', ['12', '0'], null, '0'],
             ]),
+            new Expect('lengths set properly with tuple assignment', [
+              ['tupleAssign', ['12', '0', '5', '0'], [], '0'],
+              ['getLengths', [], ['12', '0', '5', '0'], '0'],
+            ]),
           ]),
           File.Simple('dynamic_arrays_2d', [
             new Expect('two dimensional dynamic arrays to storage', [
@@ -2598,6 +2602,7 @@ export const expectations = flatten(
                 '0',
               ],
             ),
+            Expect.Simple('getStructIgnoringDynArray', ['7', '9', '8', '0'], ['7', '9', '8', '0']),
           ]),
           File.Simple('misc', [
             Expect.Simple('a', ['0', '0'], ['1', '0', '2', '0']),
@@ -2847,6 +2852,12 @@ export const expectations = flatten(
               ['assign', ['10', '11'], [], '0'],
               ['getMember', [], ['10', '11'], '0'],
             ]),
+          ]),
+          File.Simple('swap', [
+            Expect.Simple('set', ['5', '6', '7', '8'], []),
+            Expect.Simple('swap', [], []),
+            Expect.Simple('struct1', [], ['5', '6']),
+            Expect.Simple('struct2', [], ['5', '6']),
           ]),
         ]),
         new Dir('stringLiteral', [

--- a/tests/behaviour/expectations/semantic_whitelist.ts
+++ b/tests/behaviour/expectations/semantic_whitelist.ts
@@ -1378,7 +1378,7 @@ const tests: string[] = [
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/variables/delete_locals.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/variables/storing_invalid_boolean.sol', // WILL NOT SUPPORT yul
   ],
-  //---------Various tests: 91 passing, 26 pending, 11 failing
+  //---------Various tests:124 passing
   ...[
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/various/assignment_to_const_var_involving_expression.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/various/crazy_elementary_typenames_on_stack.sol',
@@ -1395,7 +1395,6 @@ const tests: string[] = [
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/various/memory_overwrite.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/various/multi_modifiers.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/various/multi_variable_declaration.sol',
-    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/various/negative_stack_height.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/various/nested_calldata_struct.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/various/nested_calldata_struct_to_memory.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/various/positive_integers_to_signed.sol',
@@ -1412,6 +1411,7 @@ const tests: string[] = [
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/various/swap_in_storage_overwrite.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/various/tuples.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/various/typed_multi_variable_declaration.sol',
+    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/various/negative_stack_height.sol', // starknet-compile takes too long to transpile the output, testnet dies
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/various/erc20.sol', // WILL NOT SUPPORT indexed
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/various/skip_dynamic_types_for_static_arrays_with_dynamic_elements.sol', // nested dynarrays
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/various/store_bytes.sol', // msg.data
@@ -1440,9 +1440,9 @@ const tests: string[] = [
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/various/code_access_content.sol', // WILL NOT SUPPORT yul
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/various/codebalance_assembly.sol', // WILL NOT SUPPORT yul
   ],
-  //---------ViaYul: 250 passing, 23 pending, 28 failing
+  //---------ViaYul: 268 passing
   ...[
-    //---------ViaYul array memory allocation: 19 passing, 1 failing
+    //---------ViaYul array memory allocation: 20 passing
     ...[
       // 'tests/behaviour/solidity/test/libsolidity/semanticTests/viaYul/array_memory_allocation/array_zeroed_memory_index_access.sol',
       // 'tests/behaviour/solidity/test/libsolidity/semanticTests/viaYul/array_memory_allocation/array_2d_zeroed_memory_index_access.sol',
@@ -1463,12 +1463,12 @@ const tests: string[] = [
       // 'tests/behaviour/solidity/test/libsolidity/semanticTests/viaYul/conditional/conditional_with_assignment.sol',
       // 'tests/behaviour/solidity/test/libsolidity/semanticTests/viaYul/conditional/conditional_true_false_literal.sol',
     ],
-    //---------ViaYul conversion: 12 passing, 3 pending, 1 failing
+    //---------ViaYul conversion: 12 passing
     ...[
       // 'tests/behaviour/solidity/test/libsolidity/semanticTests/viaYul/conversion/explicit_cast_local_assignment.sol',
       // 'tests/behaviour/solidity/test/libsolidity/semanticTests/viaYul/conversion/explicit_cast_function_call.sol',
       // 'tests/behaviour/solidity/test/libsolidity/semanticTests/viaYul/conversion/explicit_cast_assignment.sol',
-      // 'tests/behaviour/solidity/test/libsolidity/semanticTests/viaYul/conversion/explicit_string_bytes_calldata_cast.sol',
+      // 'tests/behaviour/solidity/test/libsolidity/semanticTests/viaYul/conversion/explicit_string_bytes_calldata_cast.sol', // STRETCH slices
       // 'tests/behaviour/solidity/test/libsolidity/semanticTests/viaYul/conversion/function_cast.sol', // WILL NOT SUPPORT function objects
       // 'tests/behaviour/solidity/test/libsolidity/semanticTests/viaYul/conversion/implicit_cast_assignment.sol', // WILL NOT SUPPORT yul
       // 'tests/behaviour/solidity/test/libsolidity/semanticTests/viaYul/conversion/implicit_cast_local_assignment.sol', // WILL NOT SUPPORT yul


### PR DESCRIPTION
GetNodeType was failing because it was being called on nodes detached from the tree that rely on struct definition nodes to resolve their typing. Conditionals were failing for the same reason so I've bundled the fix in with this. Additionally, this addresses the string default issue, and an issue with bytes and strings passed into our generated functions being dereferenced when they should not be