### PR TITLE
Handle Contract.var even without inheritance

### DIFF
--- a/src/passes/references/index.ts
+++ b/src/passes/references/index.ts
@@ -8,6 +8,7 @@ import { StorageDelete } from './delete';
 import { ExpectedLocationAnalyser } from './expectedLocationAnalyser';
 import { ExternalReturnReceiver } from './externalReturnReceiver';
 import { MemoryAllocations } from './memoryAllocations';
+import { StateVarRefFlattener } from './stateVarRefFlattener';
 import { StoredPointerDereference } from './storedPointerDereference';
 
 /*
@@ -36,6 +37,7 @@ export class References extends ASTMapper {
       const actualDataLocations: Map<Expression, DataLocation> = new Map();
       const expectedDataLocations: Map<Expression, DataLocation> = new Map();
 
+      new StateVarRefFlattener().dispatchVisit(root, ast);
       new ExternalReturnReceiver().dispatchVisit(root, ast);
       new ActualLocationAnalyser(actualDataLocations).dispatchVisit(root, ast);
       new ExpectedLocationAnalyser(actualDataLocations, expectedDataLocations).dispatchVisit(

--- a/src/passes/references/stateVarRefFlattener.ts
+++ b/src/passes/references/stateVarRefFlattener.ts
@@ -1,0 +1,18 @@
+import { MemberAccess, VariableDeclaration } from 'solc-typed-ast';
+import { AST } from '../../ast/ast';
+import { ASTMapper } from '../../ast/mapper';
+import { createIdentifier } from '../../utils/nodeTemplates';
+
+export class StateVarRefFlattener extends ASTMapper {
+  visitMemberAccess(node: MemberAccess, ast: AST): void {
+    if (
+      node.vReferencedDeclaration instanceof VariableDeclaration &&
+      node.vReferencedDeclaration.stateVariable
+    ) {
+      ast.replaceNode(node, createIdentifier(node.vReferencedDeclaration, ast));
+      return;
+    }
+
+    this.visitExpression(node, ast);
+  }
+}

--- a/tests/behaviour/contracts/storage/scalars.sol
+++ b/tests/behaviour/contracts/storage/scalars.sol
@@ -11,7 +11,7 @@ contract WARP {
   }
 
   function readValues() view public returns (uint8, int16) {
-    uint8 a = x;
+    uint8 a = WARP.x;
     int16 b = y;
     return (a,b);
   }


### PR DESCRIPTION
Flattens `Contract.var` down to just `var`, which is safe since we mangle names and have handled inheritance and getters by this point