### PR TITLE
Add filter for Member Access in ref_lib pass

### DIFF
--- a/src/passes/referencedLibraries.ts
+++ b/src/passes/referencedLibraries.ts
@@ -55,17 +55,20 @@ export class ReferencedLibraries extends ASTMapper {
 function getLibBase(node: ContractDefinition, ContractDefLibs: Map<number, ASTNode>): number[] {
   const ids: number[] = [node.id];
 
-  node.getChildren().forEach((child) => {
-    if (child instanceof FunctionCall) {
-      ContractDefLibs.forEach((astNode, id) => {
-        assert(child.vExpression instanceof MemberAccess);
-        const f_id = child.vExpression.referencedDeclaration;
-        if (astNode.getChildren().some((node) => node.id === f_id)) {
-          ids.push(id);
-        }
-      });
-    }
-  });
+  node
+    .getChildren()
+    .filter((child) => child instanceof FunctionCall && child.vExpression instanceof MemberAccess)
+    .forEach((child) => {
+      if (child instanceof FunctionCall) {
+        ContractDefLibs.forEach((astNode, id) => {
+          assert(child.vExpression instanceof MemberAccess);
+          const f_id = child.vExpression.referencedDeclaration;
+          if (astNode.getChildren().some((node) => node.id === f_id)) {
+            ids.push(id);
+          }
+        });
+      }
+    });
 
   return ids;
 }

--- a/tests/behaviour/expectations/semantic_whitelist.ts
+++ b/tests/behaviour/expectations/semantic_whitelist.ts
@@ -870,7 +870,7 @@ const tests: string[] = [
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/libraries/internal_call_bound_with_parentheses.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/libraries/internal_call_bound_with_parentheses1.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/libraries/internal_library_function_bound_to_literal.sol',
-    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/libraries/internal_library_function_bound_to_fixed_bytes.sol',
+    'tests/behaviour/solidity/test/libsolidity/semanticTests/libraries/internal_library_function_bound_to_fixed_bytes.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/libraries/internal_library_function_bound_to_address.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/libraries/internal_library_function_bound_to_bool.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/libraries/internal_library_function_bound.sol',


### PR DESCRIPTION
Now `tests/behaviour/solidity/test/libsolidity/semanticTests/libraries/internal_library_function_bound_to_fixed_bytes.sol` is passing