### PR TITLE
throw unsupported error: Free fns in exp stmt

### DIFF
--- a/src/passes/rejectUnsupportedFeatures.ts
+++ b/src/passes/rejectUnsupportedFeatures.ts
@@ -7,7 +7,6 @@ import {
   DataLocation,
   ElementaryTypeName,
   ErrorDefinition,
-  Expression,
   ExpressionStatement,
   ExternalReferenceType,
   FunctionCall,

--- a/src/passes/rejectUnsupportedFeatures.ts
+++ b/src/passes/rejectUnsupportedFeatures.ts
@@ -7,6 +7,8 @@ import {
   DataLocation,
   ElementaryTypeName,
   ErrorDefinition,
+  Expression,
+  ExpressionStatement,
   ExternalReferenceType,
   FunctionCall,
   FunctionCallKind,
@@ -63,6 +65,13 @@ export class RejectUnsupportedFeatures extends ASTMapper {
   }
   visitVariableDeclaration(node: VariableDeclaration, ast: AST): void {
     const typeNode = getNodeType(node, ast.compilerVersion);
+    if (typeNode instanceof FunctionType)
+      throw new WillNotSupportError('Function objects are not supported');
+    this.commonVisit(node, ast);
+  }
+
+  visitExpressionStatement(node: ExpressionStatement, ast: AST): void {
+    const typeNode = getNodeType(node.vExpression, ast.compilerVersion);
     if (typeNode instanceof FunctionType)
       throw new WillNotSupportError('Function objects are not supported');
     this.commonVisit(node, ast);

--- a/tests/behaviour/expectations/semantic_whitelist.ts
+++ b/tests/behaviour/expectations/semantic_whitelist.ts
@@ -886,7 +886,7 @@ const tests: string[] = [
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/libraries/internal_library_function.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/libraries/internal_types_in_library.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/libraries/internal_library_function_return_var_size.sol',
-    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/libraries/library_stray_values.sol',
+    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/libraries/library_stray_values.sol', // WILL NOT SUPPORT function objects
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/libraries/library_staticcall_delegatecall.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/libraries/library_call_in_homestead.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/libraries/library_enum_as_an_expression.sol',


### PR DESCRIPTION
Throw `WillNotSupportError` in `tests/behaviour/solidity/test/libsolidity/semanticTests/libraries/library_stray_values.sol`