### PR TITLE
Data location fixes

### DIFF
--- a/src/cairoUtilFuncGen/memory/memoryRead.ts
+++ b/src/cairoUtilFuncGen/memory/memoryRead.ts
@@ -9,7 +9,13 @@ import {
   generalizeType,
   ArrayType,
 } from 'solc-typed-ast';
-import { CairoFelt, CairoType, CairoUint256, MemoryLocation } from '../../utils/cairoTypeSystem';
+import {
+  CairoFelt,
+  CairoType,
+  CairoUint256,
+  MemoryLocation,
+  TypeConversionContext,
+} from '../../utils/cairoTypeSystem';
 import { cloneASTNode } from '../../utils/cloning';
 import { createCairoFunctionStub, createCallToFunction } from '../../utils/functionGeneration';
 import { createNumberLiteral, createNumberTypeName } from '../../utils/nodeTemplates';
@@ -33,12 +39,14 @@ export class MemoryReadGen extends StringIndexedFuncGen {
     const args = [memoryRef];
 
     if (resultCairoType instanceof MemoryLocation) {
-      params.push(['size', createNumberTypeName(8, false, this.ast), DataLocation.Default]);
+      // The size parameter represents how much space to allocate
+      // for the contents of the newly accessed suboject
+      params.push(['size', createNumberTypeName(256, false, this.ast), DataLocation.Default]);
       args.push(
         createNumberLiteral(
           valueType instanceof ArrayType && valueType.size === undefined
             ? 2
-            : resultCairoType.width,
+            : CairoType.fromSol(valueType, this.ast, TypeConversionContext.MemoryAllocation).width,
           this.ast,
           'uint256',
         ),

--- a/tests/behaviour/contracts/copy_storage_to_memory/dynamic_arrays.sol
+++ b/tests/behaviour/contracts/copy_storage_to_memory/dynamic_arrays.sol
@@ -22,6 +22,12 @@ contract WARP {
         return (m[0], m[1], m[2]);
     }
 
+    function copySimpleArrayToIdentifier() external returns (uint8[] memory) {
+        uint8[] memory x;
+        x = simple;
+        return x;
+    }
+
     function testNestedArray(uint8[] memory a, uint8[] memory b, uint8[] memory c) public returns (uint8[] memory, uint8[] memory, uint8[] memory) {
         uint8[][] memory m = new uint8[][](3);
         m[0] = a;

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -1151,6 +1151,7 @@ export const expectations = flatten(
           File.Simple('dynamic_arrays', [
             Expect.Simple('copySimpleArrayLength', [], ['3', '0']),
             Expect.Simple('copySimpleArrayValues', [], ['5', '0', '4']),
+            Expect.Simple('copySimpleArrayToIdentifier', [], ['3', '5', '0', '4']),
             Expect.Simple(
               'testNestedArray',
               [...['3', '1', '2', '3'], ...['2', '1', '0'], ...['3', '4', '5', '6']],

--- a/warplib/memory.cairo
+++ b/warplib/memory.cairo
@@ -286,6 +286,7 @@ func wm_read_id{range_check_ptr : felt, warp_memory : DictAccess*}(loc : felt, s
         return (id)
     end
     let (id) = wm_alloc(size)
+    dict_write{dict_ptr=warp_memory}(loc, id)
     return (id)
 end
 


### PR DESCRIPTION
-Handles storage/calldata assignments to memory for assignments where the lhs is an identifier (previously this case was skipped). Addresses various/destructuringAssignment.sol
-Sets location for string literal temp vars in tuple assignments to memory, addressing array/string_literal_assign_to_storage_bytes.sol
-Fixes memory suboject allocation, addressing array/create_memory_array.sol