### PR TITLE
Fix memory read for strings/bytes

### DIFF
--- a/src/cairoUtilFuncGen/memory/arrayLiteral.ts
+++ b/src/cairoUtilFuncGen/memory/arrayLiteral.ts
@@ -96,13 +96,13 @@ export class MemoryArrayLiteralGen extends StringIndexedFuncGen {
 
   private getOrCreate(type: TypeNode, size: number, dynamic: boolean): string {
     const elementCairoType = CairoType.fromSol(type, this.ast);
-    const key = `${size}${elementCairoType.fullStringRepresentation}`;
+    const key = `${dynamic ? 'd' : 's'}${size}${elementCairoType.fullStringRepresentation}`;
     const existing = this.generatedFunctions.get(key);
     if (existing !== undefined) {
       return existing.name;
     }
 
-    const funcName = `WM${this.generatedFunctions.size}_arr`;
+    const funcName = `WM${this.generatedFunctions.size}_${dynamic ? 'd' : 's'}_arr`;
 
     const argString = mapRange(size, (n) => `e${n}: ${elementCairoType.toString()}`).join(', ');
 

--- a/src/cairoUtilFuncGen/memory/memoryRead.ts
+++ b/src/cairoUtilFuncGen/memory/memoryRead.ts
@@ -7,7 +7,6 @@ import {
   DataLocation,
   FunctionStateMutability,
   generalizeType,
-  ArrayType,
 } from 'solc-typed-ast';
 import {
   CairoFelt,
@@ -19,6 +18,7 @@ import {
 import { cloneASTNode } from '../../utils/cloning';
 import { createCairoFunctionStub, createCallToFunction } from '../../utils/functionGeneration';
 import { createNumberLiteral, createNumberTypeName } from '../../utils/nodeTemplates';
+import { isDynamicArray } from '../../utils/nodeTypeProcessing';
 import { add, locationIfComplexType, StringIndexedFuncGen } from '../base';
 import { serialiseReads } from '../serialisation';
 
@@ -44,7 +44,7 @@ export class MemoryReadGen extends StringIndexedFuncGen {
       params.push(['size', createNumberTypeName(256, false, this.ast), DataLocation.Default]);
       args.push(
         createNumberLiteral(
-          valueType instanceof ArrayType && valueType.size === undefined
+          isDynamicArray(valueType)
             ? 2
             : CairoType.fromSol(valueType, this.ast, TypeConversionContext.MemoryAllocation).width,
           this.ast,


### PR DESCRIPTION
MemoryReadGen was not picking up strings and bytes as complex types, and WM_arr was being stored purely based on initialisation length, meaning dynamic gens were being used for static and vice versa if one of the correct length had already been generated