### PR TITLE
Import DynArray Structs.

### DIFF
--- a/e.sol
+++ b/e.sol
@@ -1,0 +1,9 @@
+pragma solidity ^0.8.10;
+
+//SPDX-License-Identifier: MIT
+
+contract WARP {
+    function ints(uint8[] calldata x) public {
+
+    }
+}

--- a/src/ast/ast.ts
+++ b/src/ast/ast.ts
@@ -175,6 +175,7 @@ export class AST {
     const reachableNodeImports = sourceUnit
       .getChildren(true)
       .map((node) => this.imports.get(node) ?? new Map<string, Set<string>>());
+    this.getUtilFuncGen(sourceUnit).addDefImports();
     const utilFunctionImports = this.getUtilFuncGen(sourceUnit)?.getImports();
     return mergeImports(utilFunctionImports, ...reachableNodeImports);
   }

--- a/src/ast/ast.ts
+++ b/src/ast/ast.ts
@@ -175,7 +175,6 @@ export class AST {
     const reachableNodeImports = sourceUnit
       .getChildren(true)
       .map((node) => this.imports.get(node) ?? new Map<string, Set<string>>());
-    this.getUtilFuncGen(sourceUnit).addStructDefImports();
     const utilFunctionImports = this.getUtilFuncGen(sourceUnit)?.getImports();
     return mergeImports(utilFunctionImports, ...reachableNodeImports);
   }

--- a/src/ast/ast.ts
+++ b/src/ast/ast.ts
@@ -175,6 +175,7 @@ export class AST {
     const reachableNodeImports = sourceUnit
       .getChildren(true)
       .map((node) => this.imports.get(node) ?? new Map<string, Set<string>>());
+    this.getUtilFuncGen(sourceUnit).addStructDefImports();
     const utilFunctionImports = this.getUtilFuncGen(sourceUnit)?.getImports();
     return mergeImports(utilFunctionImports, ...reachableNodeImports);
   }

--- a/src/cairoUtilFuncGen/index.ts
+++ b/src/cairoUtilFuncGen/index.ts
@@ -188,6 +188,10 @@ export class CairoUtilFuncGen {
     };
   }
 
+  addDefImports(): void {
+    this.getAllChildren().forEach((c) => c.addDefImports());
+  }
+
   getImports(): Map<string, Set<string>> {
     return mergeImports(...this.getAllChildren().map((c) => c.getImports()));
   }

--- a/src/cairoUtilFuncGen/index.ts
+++ b/src/cairoUtilFuncGen/index.ts
@@ -188,10 +188,6 @@ export class CairoUtilFuncGen {
     };
   }
 
-  addStructDefImports(): void {
-    this.getAllChildren().forEach((c) => c.addStructDefImports());
-  }
-
   getImports(): Map<string, Set<string>> {
     return mergeImports(...this.getAllChildren().map((c) => c.getImports()));
   }

--- a/src/cairoUtilFuncGen/index.ts
+++ b/src/cairoUtilFuncGen/index.ts
@@ -188,6 +188,10 @@ export class CairoUtilFuncGen {
     };
   }
 
+  addStructDefImports(): void {
+    this.getAllChildren().forEach((c) => c.addStructDefImports());
+  }
+
   getImports(): Map<string, Set<string>> {
     return mergeImports(...this.getAllChildren().map((c) => c.getImports()));
   }

--- a/src/cairoUtilFuncGen/inputArgCheck/inputCheck.ts
+++ b/src/cairoUtilFuncGen/inputArgCheck/inputCheck.ts
@@ -128,7 +128,6 @@ export class InputCheckGen extends StringIndexedFuncGen {
         `alloc_locals`,
         ...structDef.vMembers.map((decl) => {
           const memberType = getNodeType(decl, this.ast.compilerVersion);
-          this.checkForImport(memberType);
           if (checkableType(memberType)) {
             const memberCheck = this.getOrCreate(memberType);
             return [`${memberCheck}(arg.${decl.name})`];
@@ -152,7 +151,6 @@ export class InputCheckGen extends StringIndexedFuncGen {
 
     const cairoType = CairoType.fromSol(type, this.ast, TypeConversionContext.CallDataRef);
     const elementType = generalizeType(type.elementT)[0];
-    this.checkForImport(elementType);
     this.generatedFunctions.set(key, {
       name: funcName,
       code: [
@@ -211,7 +209,6 @@ export class InputCheckGen extends StringIndexedFuncGen {
     assert(cairoType instanceof CairoDynArray);
     const ptrType = cairoType.vPtr;
     const elementType = generalizeType(getElementType(type))[0];
-    this.checkForImport(elementType);
     const indexCheck = [`${this.getOrCreate(elementType)}(ptr[0])`];
 
     this.generatedFunctions.set(key, {

--- a/src/passes/cairoUtilImporter.ts
+++ b/src/passes/cairoUtilImporter.ts
@@ -1,7 +1,20 @@
-import { ElementaryTypeName } from 'solc-typed-ast';
+import assert from 'assert';
+import {
+  ArrayType,
+  DataLocation,
+  ElementaryTypeName,
+  generalizeType,
+  getNodeType,
+  SourceUnit,
+  StructDefinition,
+  UserDefinedType,
+  VariableDeclaration,
+} from 'solc-typed-ast';
 import { AST } from '../ast/ast';
 import { CairoFunctionDefinition } from '../ast/cairoNodes';
 import { ASTMapper } from '../ast/mapper';
+import { printTypeNode } from '../utils/astPrinter';
+import { formatPath } from '../utils/formatting';
 import { isExternallyVisible, primitiveTypeToCairo } from '../utils/utils';
 
 /*
@@ -30,6 +43,56 @@ export class CairoUtilImporter extends ASTMapper {
       ast.registerImport(node, 'starkware.cairo.common.alloc', 'alloc');
     }
 
+    // Making sure all the dynamic array struct constructors are present
+    node.vParameters.vParameters.forEach((decl) => {
+      const type = getNodeType(decl, ast.compilerVersion);
+      if (
+        type instanceof ArrayType &&
+        type.size === undefined &&
+        decl.storageLocation === DataLocation.CallData
+      ) {
+        ast.getUtilFuncGen(node).externalFunctions.inputs.darrayStructConstructor.gen(decl, node);
+      }
+      this.checkForImports(decl, ast);
+    });
+
     this.commonVisit(node, ast);
+  }
+
+  protected checkForImports(decl: VariableDeclaration, ast: AST): void {
+    const type = generalizeType(getNodeType(decl, ast.compilerVersion))[0];
+    const sourceUnit = decl.root;
+    if (type instanceof UserDefinedType && type.definition instanceof StructDefinition) {
+      assert(sourceUnit !== undefined, 'Unable to find SourceUnit for CairoUtilGen.');
+      const typeDefSourceUnit = type.definition.root;
+      assert(
+        typeDefSourceUnit instanceof SourceUnit,
+        `Unable to find SourceUnit holding type definition ${printTypeNode(type)}.`,
+      );
+      if (sourceUnit !== typeDefSourceUnit) {
+        ast.registerImport(
+          type.definition,
+          formatPath(typeDefSourceUnit.absolutePath),
+          type.definition.name,
+        );
+      }
+      type.definition.vMembers.forEach((decl) => this.checkForImports(decl, ast));
+    } else if (
+      type instanceof ArrayType &&
+      type.elementT instanceof UserDefinedType &&
+      type.elementT.definition instanceof StructDefinition
+    ) {
+      if (
+        sourceUnit !== type.elementT.definition.root &&
+        type.elementT.definition.root instanceof SourceUnit
+      ) {
+        ast.registerImport(
+          type.elementT.definition,
+          formatPath(type.elementT.definition.root.absolutePath),
+          type.elementT.definition.name,
+        );
+        type.elementT.definition.vMembers.forEach((decl) => this.checkForImports(decl, ast));
+      }
+    }
   }
 }

--- a/src/passes/cairoUtilImporter.ts
+++ b/src/passes/cairoUtilImporter.ts
@@ -40,8 +40,46 @@ export class CairoUtilImporter extends ASTMapper {
       ) {
         ast.getUtilFuncGen(node).externalFunctions.inputs.darrayStructConstructor.gen(decl, node);
       }
+      //   this.checkForImports(decl, ast);
     });
 
     this.commonVisit(node, ast);
   }
+
+  // protected checkForImports(decl: VariableDeclaration, ast: AST): void {
+  //   const type = generalizeType(getNodeType(decl, ast.compilerVersion))[0];
+  //   const sourceUnit = decl.root;
+  //   if (type instanceof UserDefinedType && type.definition instanceof StructDefinition) {
+  //     assert(sourceUnit !== undefined, 'Unable to find SourceUnit for CairoUtilGen.');
+  //     const typeDefSourceUnit = type.definition.root;
+  //     assert(
+  //       typeDefSourceUnit instanceof SourceUnit,
+  //       `Unable to find SourceUnit holding type definition ${printTypeNode(type)}.`,
+  //     );
+  //     if (sourceUnit !== typeDefSourceUnit) {
+  //       ast.registerImport(
+  //         type.definition,
+  //         formatPath(typeDefSourceUnit.absolutePath),
+  //         type.definition.name,
+  //       );
+  //     }
+  //     type.definition.vMembers.forEach((decl) => this.checkForImports(decl, ast));
+  //   } else if (
+  //     type instanceof ArrayType &&
+  //     type.elementT instanceof UserDefinedType &&
+  //     type.elementT.definition instanceof StructDefinition
+  //   ) {
+  //     if (
+  //       sourceUnit !== type.elementT.definition.root &&
+  //       type.elementT.definition.root instanceof SourceUnit
+  //     ) {
+  //       ast.registerImport(
+  //         type.elementT.definition,
+  //         formatPath(type.elementT.definition.root.absolutePath),
+  //         type.elementT.definition.name,
+  //       );
+  //       type.elementT.definition.vMembers.forEach((decl) => this.checkForImports(decl, ast));
+  //     }
+  //   }
+  // }
 }

--- a/src/passes/cairoUtilImporter.ts
+++ b/src/passes/cairoUtilImporter.ts
@@ -1,20 +1,7 @@
-import assert from 'assert';
-import {
-  ArrayType,
-  DataLocation,
-  ElementaryTypeName,
-  generalizeType,
-  getNodeType,
-  SourceUnit,
-  StructDefinition,
-  UserDefinedType,
-  VariableDeclaration,
-} from 'solc-typed-ast';
+import { ArrayType, DataLocation, ElementaryTypeName, getNodeType } from 'solc-typed-ast';
 import { AST } from '../ast/ast';
 import { CairoFunctionDefinition } from '../ast/cairoNodes';
 import { ASTMapper } from '../ast/mapper';
-import { printTypeNode } from '../utils/astPrinter';
-import { formatPath } from '../utils/formatting';
 import { isExternallyVisible, primitiveTypeToCairo } from '../utils/utils';
 
 /*
@@ -53,46 +40,8 @@ export class CairoUtilImporter extends ASTMapper {
       ) {
         ast.getUtilFuncGen(node).externalFunctions.inputs.darrayStructConstructor.gen(decl, node);
       }
-      this.checkForImports(decl, ast);
     });
 
     this.commonVisit(node, ast);
-  }
-
-  protected checkForImports(decl: VariableDeclaration, ast: AST): void {
-    const type = generalizeType(getNodeType(decl, ast.compilerVersion))[0];
-    const sourceUnit = decl.root;
-    if (type instanceof UserDefinedType && type.definition instanceof StructDefinition) {
-      assert(sourceUnit !== undefined, 'Unable to find SourceUnit for CairoUtilGen.');
-      const typeDefSourceUnit = type.definition.root;
-      assert(
-        typeDefSourceUnit instanceof SourceUnit,
-        `Unable to find SourceUnit holding type definition ${printTypeNode(type)}.`,
-      );
-      if (sourceUnit !== typeDefSourceUnit) {
-        ast.registerImport(
-          type.definition,
-          formatPath(typeDefSourceUnit.absolutePath),
-          type.definition.name,
-        );
-      }
-      type.definition.vMembers.forEach((decl) => this.checkForImports(decl, ast));
-    } else if (
-      type instanceof ArrayType &&
-      type.elementT instanceof UserDefinedType &&
-      type.elementT.definition instanceof StructDefinition
-    ) {
-      if (
-        sourceUnit !== type.elementT.definition.root &&
-        type.elementT.definition.root instanceof SourceUnit
-      ) {
-        ast.registerImport(
-          type.elementT.definition,
-          formatPath(type.elementT.definition.root.absolutePath),
-          type.elementT.definition.name,
-        );
-        type.elementT.definition.vMembers.forEach((decl) => this.checkForImports(decl, ast));
-      }
-    }
   }
 }


### PR DESCRIPTION
Looks like Struct Definitions are being imported correctly from FREE contracts now. So removed a redundant function that also checked that they were imported.

Unfortunately, it does not fix dynArray structs being imported since the node representing them is actually a function definition stub that just writes the struct def to the file.

This PR fixes part of `tests/behaviour/solidity/test/libsolidity/semanticTests/freeFunctions/storage_calldata_refs.sol`.
The above test will be fully fixed once this PR: https://github.com/NethermindEth/warp/pull/441 is merged. 