### PR TITLE
Fix bytes index access in type conversion

### DIFF
--- a/src/passes/bytesConverter.ts
+++ b/src/passes/bytesConverter.ts
@@ -72,8 +72,7 @@ export class BytesConverter extends ASTMapper {
       !(
         node.vIndexExpression &&
         generalizeType(getNodeType(node.vBaseExpression, ast.compilerVersion))[0] instanceof
-          FixedBytesType &&
-        getNodeType(node, ast.compilerVersion) instanceof FixedBytesType
+          FixedBytesType
       )
     ) {
       this.visitExpression(node, ast);

--- a/tests/behaviour/expectations/semantic_whitelist.ts
+++ b/tests/behaviour/expectations/semantic_whitelist.ts
@@ -131,15 +131,15 @@ const tests: string[] = [
   ],
   //---------Array tests - 374 passing, 103 pending, 52 failing
   ...[
-    //---------Array concat tests: 20 passing, 6 pending, 2 failing
+    //---------Array concat tests: 24 passing
     ...[
       // 'tests/behaviour/solidity/test/libsolidity/semanticTests/array/concat/bytes_concat_2_args.sol',
       // 'tests/behaviour/solidity/test/libsolidity/semanticTests/array/concat/bytes_concat_3_args.sol',
       // 'tests/behaviour/solidity/test/libsolidity/semanticTests/array/concat/bytes_concat_as_argument.sol',
-      // 'tests/behaviour/solidity/test/libsolidity/semanticTests/array/concat/bytes_concat_different_types.sol',
       // 'tests/behaviour/solidity/test/libsolidity/semanticTests/array/concat/bytes_concat_empty_argument_list.sol',
       // 'tests/behaviour/solidity/test/libsolidity/semanticTests/array/concat/bytes_concat_empty_strings.sol',
       // 'tests/behaviour/solidity/test/libsolidity/semanticTests/array/concat/bytes_concat_nested.sol',
+      // 'tests/behaviour/solidity/test/libsolidity/semanticTests/array/concat/bytes_concat_different_types.sol', // STRETCH slices
     ],
     //---------Array copying tests 114 passing, 62 pending, 29 failing
     ...[
@@ -215,7 +215,7 @@ const tests: string[] = [
       // 'tests/behaviour/solidity/test/libsolidity/semanticTests/array/copying/array_copy_clear_storage.sol', // WILL NOT SUPPORT yul
       // 'tests/behaviour/solidity/test/libsolidity/semanticTests/array/copying/empty_bytes_copy.sol', // WILL NOT SUPPORT yul
     ],
-    //---------Array delete tests: 9 passing, 2 pending, 1 failing
+    //---------Array delete tests: 12 passing
     ...[
       // 'tests/behaviour/solidity/test/libsolidity/semanticTests/array/delete/bytes_delete_element.sol',
       // 'tests/behaviour/solidity/test/libsolidity/semanticTests/array/delete/delete_on_array_of_structs.sol',
@@ -226,7 +226,7 @@ const tests: string[] = [
       // 'tests/behaviour/solidity/test/libsolidity/semanticTests/array/delete/delete_storage_array.sol', // WILL NOT SUPPORT yul
       // 'tests/behaviour/solidity/test/libsolidity/semanticTests/array/delete/delete_bytes_array.sol', // WILL NOT SUPPORT yul
     ],
-    //---------Array index access tests: 32 passing, 2 pending, 2 failing
+    //---------Array index access tests: 36 passing
     ...[
       // 'tests/behaviour/solidity/test/libsolidity/semanticTests/array/indexAccess/arrays_complex_memory_index_access.sol',
       // 'tests/behaviour/solidity/test/libsolidity/semanticTests/array/indexAccess/bytes_index_access.sol',


### PR DESCRIPTION
BytesConverter runs after BuiltinHandler, meaning the `uint8(bytes24[0])` will have been replaced with just `bytes24[0]` with typestring `uint8`. This was causing the BytesConverter to skip that case since it didn't see it as a fixedbytes index access