### PR TITLE
Throwing WillNotSupportError for Nested Tuples

### DIFF
--- a/example_contracts/nested_tuple.sol
+++ b/example_contracts/nested_tuple.sol
@@ -1,0 +1,19 @@
+pragma solidity ^0.8.10;
+
+contract WARP {
+  function f()
+    public
+    pure
+    returns (
+      uint256,
+      uint256,
+      uint256
+    )
+  {
+    bytes memory a;
+    bytes memory b;
+    bytes memory c;
+    (a, (b, c)) = ('0', ('1', '2'));
+    return (uint8(a[0]), uint8(b[0]), uint8(c[0]));
+  }
+}

--- a/src/passes/tupleFixes/tupleFlattener.ts
+++ b/src/passes/tupleFixes/tupleFlattener.ts
@@ -1,9 +1,17 @@
 import { TupleExpression } from 'solc-typed-ast';
 import { AST } from '../../ast/ast';
 import { ASTMapper } from '../../ast/mapper';
+import { WillNotSupportError } from '../../utils/errors';
 
 export class TupleFlattener extends ASTMapper {
   visitTupleExpression(node: TupleExpression, ast: AST): void {
+    if (
+      node.parent instanceof TupleExpression &&
+      node.parent.isInlineArray === false &&
+      node.isInlineArray === false
+    ) {
+      throw new WillNotSupportError('Nested Tuple References not Supported');
+    }
     if (
       node.vOriginalComponents.length === 1 &&
       node.vOriginalComponents[0] !== null &&

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -155,6 +155,7 @@ const expectedResults = new Map<string, ResultType>(
     ['example_contracts/nested_static_array_struct', 'Success'],
     ['example_contracts/nested_struct_static_array', 'Success'],
     ['example_contracts/nested_structs', 'Success'],
+    ['example_contracts/nested_tuple', 'WillNotSupport'],
     ['example_contracts/old_code_gen_err', 'WillNotSupport'],
     ['example_contracts/old_code_gen_err_7', 'WillNotSupport'],
     ['example_contracts/payable_function', 'Success'],

--- a/tests/behaviour/contracts/expressions/tupleOfInlineArrays.sol
+++ b/tests/behaviour/contracts/expressions/tupleOfInlineArrays.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.10;
+
+contract WARP {
+  function f() public pure returns (uint8[2] memory) {
+    uint8[2] memory x;
+    uint8[2] memory y;
+    (x, y) = ([9, 12], [10, 33]);
+    return x;
+  }
+
+  function g() public pure returns (uint8) {
+    uint8[2] memory arr = f();
+    return (arr[0] + arr[1]);
+  }
+}

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -1323,6 +1323,7 @@ export const expectations = flatten(
             ),
           ]),
           File.Simple('tupleEdgeCases', [Expect.Simple('f', ['0', '0'], ['0', '0'])]),
+          File.Simple('tupleOfInlineArrays', [Expect.Simple('g', [], ['21'])]),
         ]),
         new Dir('external_function_inputs', [
           File.Simple('dynamic_array_return_index', [


### PR DESCRIPTION
Adding test for nested tuple failure, and behavior test for tuple of inline arrays.  All tests passing.