### PR TITLE
Fix exp implicit type conversion

### DIFF
--- a/src/passes/implicitConversionToExplicit.ts
+++ b/src/passes/implicitConversionToExplicit.ts
@@ -93,10 +93,7 @@ export class ImplicitConversionToExplicit extends ASTMapper {
 
       insertConversionIfNecessary(node.vLeftExpression, resultType, ast);
       if (rightNodeType instanceof IntLiteralType) {
-        console.log(node.vRightExpression.typeString);
         const bound = getLiteralValueBound(node.vRightExpression.typeString);
-        console.log(bound);
-        console.log(node.vRightExpression.typeString);
         insertConversionIfNecessary(
           node.vRightExpression,
           intTypeForLiteral(`int_const ${bound}`),

--- a/src/passes/implicitConversionToExplicit.ts
+++ b/src/passes/implicitConversionToExplicit.ts
@@ -88,7 +88,22 @@ export class ImplicitConversionToExplicit extends ASTMapper {
         );
       }
       return;
-    } else if (['**', '*', '/', '%', '+', '-', '&', '^', '|', '&&', '||'].includes(node.operator)) {
+    } else if (node.operator === '**') {
+      const rightNodeType = getNodeType(node.vRightExpression, ast.compilerVersion);
+
+      insertConversionIfNecessary(node.vLeftExpression, resultType, ast);
+      if (rightNodeType instanceof IntLiteralType) {
+        console.log(node.vRightExpression.typeString);
+        const bound = getLiteralValueBound(node.vRightExpression.typeString);
+        console.log(bound);
+        console.log(node.vRightExpression.typeString);
+        insertConversionIfNecessary(
+          node.vRightExpression,
+          intTypeForLiteral(`int_const ${bound}`),
+          ast,
+        );
+      }
+    } else if (['*', '/', '%', '+', '-', '&', '^', '|', '&&', '||'].includes(node.operator)) {
       insertConversionIfNecessary(node.vLeftExpression, resultType, ast);
       insertConversionIfNecessary(node.vRightExpression, resultType, ast);
     } else if (['<', '>', '<=', '>=', '==', '!='].includes(node.operator)) {

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -2222,7 +2222,7 @@ export const expectations = flatten(
             new Expect('testing that external function with out of bounds input throws error', [
               [
                 'externalFunction',
-                ['3'],
+                ['2'],
                 null,
                 '0',
                 'Error: value out-of-bounds. Boolean values passed to must be in range (0, 1].',
@@ -2231,7 +2231,7 @@ export const expectations = flatten(
             new Expect('testing external function and more than 1 input asserts are placed pt. 1', [
               [
                 'externalFunction2Inputs',
-                ['3', '0'],
+                ['2', '0'],
                 null,
                 '0',
                 'Error: value out-of-bounds. Boolean values passed to must be in range (0, 1].',
@@ -2240,7 +2240,7 @@ export const expectations = flatten(
             new Expect('testing external function and more than 1 input asserts are placed pt. 2', [
               [
                 'externalFunction2Inputs',
-                ['0', '3'],
+                ['0', '2'],
                 null,
                 '0',
                 'Error: value out-of-bounds. Boolean values passed to must be in range (0, 1].',

--- a/tests/behaviour/expectations/semantic_whitelist.ts
+++ b/tests/behaviour/expectations/semantic_whitelist.ts
@@ -383,16 +383,16 @@ const tests: string[] = [
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/calldata/calldata_struct_cleaning.sol', // WILL NOT SUPPORT yul
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/calldata/copy_from_calldata_removes_bytes_data.sol', // address.call
   ],
-  //---------Cleanup tests: 20 passing, 6 pending, 6 failing
+  //---------Cleanup tests: 24 passing
   ...[
-    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/cleanup/bool_conversion_v2.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/cleanup/cleanup_bytes_types_v1.sol',
-    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/cleanup/cleanup_bytes_types_v2.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/cleanup/cleanup_in_compound_assign.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/cleanup/exp_cleanup.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/cleanup/exp_cleanup_direct.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/cleanup/exp_cleanup_nonzero_base.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/cleanup/exp_cleanup_smaller_base.sol',
+    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/cleanup/bool_conversion_v2.sol', // covered in behaviour tests where invalid input can be sent reliably
+    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/cleanup/cleanup_bytes_types_v2.sol', // irrelevant, tests abiencoder behaviour
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/cleanup/cleanup_address_types_v1.sol', //160 bit address
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/cleanup/cleanup_address_types_v2.sol', //160 bit address
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/cleanup/bool_conversion_v1.sol', //testing abiencoder behaviour


### PR DESCRIPTION
The exp operator has special rules for type conversions. It evaluates to the type of the lhs (meaning an implicit conversion to the result type should be added to the lhs in case it's a literal) and only asserts that the rhs is unsigned, with the rhs width not effecting the operation. As such versions of the warplib function had to be implemented for all combinations of felt/Uint256 on the lhs and rhs. This was tested against all semantic exp tests and they all now pass. This was also the last failure in the cleanup tests that wasn't because of the test suite abiencoder wrapping invalid data, so they now also all pass