### PR TITLE
String mapping getter

### DIFF
--- a/src/cairoUtilFuncGen/storage/mappingIndexAccess.ts
+++ b/src/cairoUtilFuncGen/storage/mappingIndexAccess.ts
@@ -1,7 +1,6 @@
 import assert from 'assert';
 import {
   ASTNode,
-  BytesType,
   DataLocation,
   Expression,
   FunctionCall,
@@ -11,13 +10,12 @@ import {
   MappingType,
   PointerType,
   SourceUnit,
-  StringType,
 } from 'solc-typed-ast';
 import { AST } from '../../ast/ast';
-import { printNode } from '../../utils/astPrinter';
 import { CairoType, TypeConversionContext } from '../../utils/cairoTypeSystem';
 import { createCairoFunctionStub, createCallToFunction } from '../../utils/functionGeneration';
 import { createUint8TypeName } from '../../utils/nodeTemplates';
+import { isReferenceType } from '../../utils/nodeTypeProcessing';
 import { typeNameFromTypeNode } from '../../utils/utils';
 import { locationIfComplexType, StringIndexedFuncGen } from '../base';
 import { DynArrayGen } from './dynArray';
@@ -46,11 +44,7 @@ export class MappingIndexAccessGen extends StringIndexedFuncGen {
       TypeConversionContext.StorageAllocation,
     );
 
-    if (baseType.to.keyType instanceof PointerType) {
-      assert(
-        baseType.to.keyType.to instanceof StringType || baseType.to.keyType.to instanceof BytesType,
-        `Found invalid key pointer type in mapping in ${printNode(node)}`,
-      );
+    if (isReferenceType(baseType.to.keyType)) {
       const stringLoc = generalizeType(getNodeType(index, this.ast.compilerVersion))[1];
       assert(stringLoc !== undefined);
       const call = this.createStringHashFunction(node, stringLoc, indexCairoType);

--- a/src/passes/generateGetters/gettersGenerator.ts
+++ b/src/passes/generateGetters/gettersGenerator.ts
@@ -38,6 +38,7 @@ import {
 } from '../../utils/nodeTemplates';
 import { toSingleExpression } from '../../utils/utils';
 import { isReferenceType } from '../../utils/nodeTypeProcessing';
+import { locationIfComplexType } from '../../cairoUtilFuncGen/base';
 
 /**
 * This is a pass to attach the getter function for a public state variable
@@ -230,7 +231,7 @@ function genFunctionParams(
         `_i${varCount}`,
         funcDefID,
         false,
-        DataLocation.Default,
+        locationIfComplexType(getNodeType(vType, ast.compilerVersion), DataLocation.Memory),
         StateVariableVisibility.Internal,
         Mutability.Mutable,
         vType.vKeyType.typeString,

--- a/src/passes/references/expectedLocationAnalyser.ts
+++ b/src/passes/references/expectedLocationAnalyser.ts
@@ -28,7 +28,7 @@ import { AST } from '../../ast/ast';
 import { CairoAssert } from '../../ast/cairoNodes';
 import { ASTMapper } from '../../ast/mapper';
 import { locationIfComplexType } from '../../cairoUtilFuncGen/base';
-import { printNode, printTypeNode } from '../../utils/astPrinter';
+import { printNode } from '../../utils/astPrinter';
 import { TranspileFailedError } from '../../utils/errors';
 import { error } from '../../utils/formatting';
 import { getParameterTypes, isReferenceType } from '../../utils/nodeTypeProcessing';

--- a/src/passes/references/expectedLocationAnalyser.ts
+++ b/src/passes/references/expectedLocationAnalyser.ts
@@ -28,10 +28,10 @@ import { AST } from '../../ast/ast';
 import { CairoAssert } from '../../ast/cairoNodes';
 import { ASTMapper } from '../../ast/mapper';
 import { locationIfComplexType } from '../../cairoUtilFuncGen/base';
-import { printNode } from '../../utils/astPrinter';
+import { printNode, printTypeNode } from '../../utils/astPrinter';
 import { TranspileFailedError } from '../../utils/errors';
 import { error } from '../../utils/formatting';
-import { getParameterTypes } from '../../utils/nodeTypeProcessing';
+import { getParameterTypes, isReferenceType } from '../../utils/nodeTypeProcessing';
 import { notNull } from '../../utils/typeConstructs';
 import { isExternallyVisible } from '../../utils/utils';
 
@@ -186,7 +186,7 @@ export class ExpectedLocationAnalyser extends ASTMapper {
     if (
       baseType instanceof PointerType &&
       baseType.to instanceof MappingType &&
-      baseType.to.keyType instanceof PointerType
+      isReferenceType(baseType.to.keyType)
     ) {
       const indexLoc = generalizeType(getNodeType(node.vIndexExpression, ast.compilerVersion))[1];
       assert(indexLoc !== undefined);

--- a/tests/behaviour/expectations/semantic_whitelist.ts
+++ b/tests/behaviour/expectations/semantic_whitelist.ts
@@ -714,7 +714,7 @@ const tests: string[] = [
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/functionTypes/uninitialized_internal_storage_function_call.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/functionTypes/comparison_operator_for_external_function_cleans_dirty_bits.sol', // WILL NOT SUPPORT yul
   ],
-  //---------Getter tests 24 passing, 9 pending, 3 failing
+  //---------Getter tests 36 passing
   ...[
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/getters/mapping_to_struct.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/getters/bytes.sol',


### PR DESCRIPTION
Slightly loosens the specificity when looking for reference types, catching cases which were previously being missed for mappings with strings as keys. Specifically this fixes generated getters for such instances, the last failing getter case