### PR TITLE
Modifier fixes

### DIFF
--- a/src/passes/functionModifierHandler/functionModifierInliner.ts
+++ b/src/passes/functionModifierHandler/functionModifierInliner.ts
@@ -38,8 +38,12 @@ export class FunctionModifierInliner extends ASTMapper {
   }
 
   visitPlaceholderStatement(node: PlaceholderStatement, ast: AST) {
-    const args = this.parameters.map((v) => createIdentifier(v, ast));
-    const resultIdentifiers = this.retVariables.map((v) => createIdentifier(v, ast));
+    const args = this.parameters.map((v) =>
+      createIdentifier(v, ast, undefined, this.currentFunction),
+    );
+    const resultIdentifiers = this.retVariables.map((v) =>
+      createIdentifier(v, ast, undefined, this.currentFunction),
+    );
     const assignmentValue = toSingleExpression(resultIdentifiers, ast);
 
     ast.replaceNode(

--- a/src/utils/astChecking.ts
+++ b/src/utils/astChecking.ts
@@ -782,29 +782,45 @@ class IdChecker extends ASTMapper {
   static Ids = new Set();
 
   visitContractDefinition(node: ContractDefinition, ast: AST): void {
-    assert(IdChecker.Ids.has(node.scope) || !ast.context.map.has(node.scope));
+    assert(
+      IdChecker.Ids.has(node.scope) || !ast.context.map.has(node.scope),
+      `${printNode(node)} has invalid scope`,
+    );
   }
 
   visitFunctionDefinition(node: FunctionDefinition, ast: AST): void {
-    assert(IdChecker.Ids.has(node.scope) || !ast.context.map.has(node.scope));
+    assert(
+      IdChecker.Ids.has(node.scope) || !ast.context.map.has(node.scope),
+      `${printNode(node)} has invalid scope`,
+    );
   }
 
   visitImportDirective(node: ImportDirective, ast: AST): void {
-    assert(IdChecker.Ids.has(node.scope) || !ast.context.map.has(node.scope));
+    assert(
+      IdChecker.Ids.has(node.scope) || !ast.context.map.has(node.scope),
+      `${printNode(node)} has invalid scope`,
+    );
   }
 
   visitStructDefinition(node: StructDefinition, ast: AST): void {
-    assert(IdChecker.Ids.has(node.scope) || !ast.context.map.has(node.scope));
+    assert(
+      IdChecker.Ids.has(node.scope) || !ast.context.map.has(node.scope),
+      `${printNode(node)} has invalid scope`,
+    );
   }
 
   visitVariableDeclaration(node: VariableDeclaration, ast: AST): void {
-    assert(IdChecker.Ids.has(node.scope) || !ast.context.map.has(node.scope));
+    assert(
+      IdChecker.Ids.has(node.scope) || !ast.context.map.has(node.scope),
+      `${printNode(node)} has invalid scope`,
+    );
   }
 
   visitIdentifier(node: Identifier, ast: AST): void {
     assert(
       IdChecker.Ids.has(node.referencedDeclaration) ||
         !ast.context.map.has(node.referencedDeclaration),
+      `${printNode(node)} has invalid referenced declaration`,
     );
   }
 
@@ -812,6 +828,7 @@ class IdChecker extends ASTMapper {
     assert(
       IdChecker.Ids.has(node.referencedDeclaration) ||
         !ast.context.map.has(node.referencedDeclaration),
+      `${printNode(node)} has invalid referenced declaration`,
     );
   }
 
@@ -819,6 +836,7 @@ class IdChecker extends ASTMapper {
     assert(
       IdChecker.Ids.has(node.referencedDeclaration) ||
         !ast.context.map.has(node.referencedDeclaration),
+      `${printNode(node)} has invalid referenced declaration`,
     );
   }
 
@@ -826,6 +844,7 @@ class IdChecker extends ASTMapper {
     assert(
       IdChecker.Ids.has(node.referencedDeclaration) ||
         !ast.context.map.has(node.referencedDeclaration),
+      `${printNode(node)} has invalid referenced declaration`,
     );
   }
 

--- a/tests/behaviour/expectations/semantic_whitelist.ts
+++ b/tests/behaviour/expectations/semantic_whitelist.ts
@@ -959,10 +959,7 @@ const tests: string[] = [
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/modifiers/function_modifier_library.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/modifiers/function_modifier_local_variables.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/modifiers/function_modifier_loop_viair.sol',
-    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/modifiers/function_modifier_loop.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/modifiers/function_modifier_multi_invocation_viair.sol',
-    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/modifiers/function_modifier_multi_invocation.sol',
-    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/modifiers/function_modifier_multi_with_return.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/modifiers/function_modifier_multiple_times_local_vars.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/modifiers/function_modifier_multiple_times.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/modifiers/function_modifier_overriding.sol',
@@ -975,6 +972,9 @@ const tests: string[] = [
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/modifiers/return_does_not_skip_modifier.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/modifiers/return_in_modifier.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/modifiers/stacked_return_with_modifiers.sol',
+    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/modifiers/function_modifier_loop.sol', // tests old code gen, clashes with function_modifier_loop
+    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/modifiers/function_modifier_multi_invocation.sol', // tests old code gen, clashes with function_modifier_multi_invocation_viair
+    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/modifiers/function_modifier_multi_with_return.sol', // tests old code gen, clashes with above
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/modifiers/modifer_recursive.sol', // STRETCH conditionals
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/modifiers/access_through_module_name.sol', // WILL NOT SUPPORT module
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/modifiers/function_modifier.sol', // WILL NOT SUPPORT msg.value


### PR DESCRIPTION
Captures return variables going into modifiers, since they can be modified by expressions passed as arguments to the modifiers. Also comments out modifier tests that explicitly clash with other modifier tests based on whether they're testing the via-yul behaviour or the old code gen