### PR TITLE
Fix documentation bug in ConstantHandler

### DIFF
--- a/src/passes/constantHandler.ts
+++ b/src/passes/constantHandler.ts
@@ -5,12 +5,12 @@ import {
   Literal,
   Mutability,
   StateVariableVisibility,
-  StructuredDocumentation,
   VariableDeclaration,
   VariableDeclarationStatement,
 } from 'solc-typed-ast';
 import { AST } from '../ast/ast';
 import { ASTMapper } from '../ast/mapper';
+import { cloneDocumentation } from '../utils/cloning';
 import { collectUnboundVariables } from '../utils/functionGeneration';
 import { primitiveTypeToCairo } from '../utils/utils';
 
@@ -44,16 +44,6 @@ export class ConstantHandler extends ASTMapper {
       )
         return;
 
-      const newDocu =
-        decl.documentation === undefined || typeof decl.documentation === `string`
-          ? decl.documentation
-          : new StructuredDocumentation(
-              ast.reserveId(),
-              decl.documentation.src,
-              decl.documentation.text,
-              decl.documentation.raw,
-            );
-
       const newDecl = new VariableDeclaration(
         ast.reserveId(),
         node.src,
@@ -66,7 +56,7 @@ export class ConstantHandler extends ASTMapper {
         StateVariableVisibility.Default,
         Mutability.Constant,
         decl.typeString,
-        newDocu,
+        cloneDocumentation(decl.documentation, ast, new Map<number, number>()),
         new ElementaryTypeName(
           ast.reserveId(),
           node.src,

--- a/src/passes/deleteHandler.ts
+++ b/src/passes/deleteHandler.ts
@@ -12,6 +12,7 @@ import {
 } from 'solc-typed-ast';
 import { AST } from '../ast/ast';
 import { ASTMapper } from '../ast/mapper';
+import { cloneDocumentation } from '../utils/cloning';
 import { getDefaultValue } from '../utils/defaultValueNodes';
 
 export class DeleteHandler extends ASTMapper {
@@ -55,7 +56,7 @@ export class DeleteHandler extends ASTMapper {
           ast.reserveId(),
           node.src,
           node.vExpression,
-          node.documentation,
+          cloneDocumentation(node.documentation, ast, new Map<number, number>()),
           node.raw,
         );
         ast.insertStatementBefore(node, statement);

--- a/src/utils/cloning.ts
+++ b/src/utils/cloning.ts
@@ -546,7 +546,7 @@ function clonePlaceholder(
   );
 }
 
-function cloneDocumentation(
+export function cloneDocumentation(
   node: string | StructuredDocumentation | undefined,
   ast: AST,
   remappedIds: Map<number, number>,


### PR DESCRIPTION
While trying to transpile BaseJumpRateModelV2, the transpilation was running into an error where a `StructuredDocumentation` node was being assigned a wrong parent. 
This PR implments a fix for this by ensuring that a copy of the documentation node is given to the new `VariableDeclaration` node.