### PR TITLE
Do not run abiExtractor on abstract contracts

### DIFF
--- a/src/passes/abiExtractor.ts
+++ b/src/passes/abiExtractor.ts
@@ -29,22 +29,24 @@ export class ABIExtractor extends ASTMapper {
       // @ts-ignore Importing the ABIEncoderVersion enum causes a depenency import error
       addSignature(node, ast, fd.canonicalSignature('ABIEncoderV2')),
     );
-    node.vContracts.forEach((cd) => {
-      if (cd.vConstructor !== undefined) {
-        // We do this to trick the canonicalSignature method into giving us a result
-        const fakeConstructor = cloneASTNode(cd.vConstructor, ast);
-        fakeConstructor.isConstructor = false;
-        fakeConstructor.name = 'constructor';
-        // @ts-ignore Importing the ABIEncoderVersion enum causes a depenency import error
-        addSignature(node, ast, fakeConstructor.canonicalSignature('ABIEncoderV2'));
-      }
-      cd.vFunctions.forEach((fd) => {
-        if (isExternallyVisible(fd)) {
+    node.vContracts
+      .filter((c) => !c.abstract)
+      .forEach((cd) => {
+        if (cd.vConstructor !== undefined) {
+          // We do this to trick the canonicalSignature method into giving us a result
+          const fakeConstructor = cloneASTNode(cd.vConstructor, ast);
+          fakeConstructor.isConstructor = false;
+          fakeConstructor.name = 'constructor';
           // @ts-ignore Importing the ABIEncoderVersion enum causes a depenency import error
-          addSignature(node, ast, fd.canonicalSignature('ABIEncoderV2'));
+          addSignature(node, ast, fakeConstructor.canonicalSignature('ABIEncoderV2'));
         }
+        cd.vFunctions.forEach((fd) => {
+          if (isExternallyVisible(fd)) {
+            // @ts-ignore Importing the ABIEncoderVersion enum causes a depenency import error
+            addSignature(node, ast, fd.canonicalSignature('ABIEncoderV2'));
+          }
+        });
       });
-    });
   }
 
   // The CanonicalSignature fails for ArrayTypeNames with non-literal, non-undefined length

--- a/tests/behaviour/contracts/abstractContracts/mappingInConstructor.sol
+++ b/tests/behaviour/contracts/abstractContracts/mappingInConstructor.sol
@@ -1,0 +1,16 @@
+pragma solidity ^0.8.10;
+
+// SPDX-License-Identifier: MIT
+
+abstract contract Base {
+    constructor (mapping (uint => uint) storage m) {
+        m[5] = 20;
+    }
+}
+
+contract WARP is Base {
+    mapping (uint => uint) public map;
+
+    constructor() Base(map) {
+    }
+}

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -5,6 +5,22 @@ export const expectations = flatten(
   new Dir('tests', [
     new Dir('behaviour', [
       new Dir('contracts', [
+        new Dir('abstractContracts', [
+          File.Simple('mappingInConstructor', [
+            Expect.Simple(
+              'map',
+              ['0', '0'],
+              ['0', '0'],
+              'test a value not set by the abstract constructor',
+            ),
+            Expect.Simple(
+              'map',
+              ['5', '0'],
+              ['20', '0'],
+              'test the value set by the abstract constructor',
+            ),
+          ]),
+        ]),
         new Dir('array_len', [
           File.Simple('memoryArray', [Expect.Simple('dynMemArrayLen', [], ['45', '0'])]),
           File.Simple('storageArray', [Expect.Simple('dynStorageArrayLen', [], ['1', '0'])]),


### PR DESCRIPTION
Abstract contracts do not need abis generated because they cannot be deployed, and because their constructors are only called internally they can take mappings, which cannot be abi encoded.