### PR TITLE
Using library structs

### DIFF
--- a/src/passes/ifFunctionaliser.ts
+++ b/src/passes/ifFunctionaliser.ts
@@ -186,7 +186,7 @@ function createSplitFunction(
 
   const args = [...unboundVariables.keys()].map((decl) => createIdentifier(decl, ast));
 
-  const call = createCallToFunction(funcDef, args, ast);
+  const call = createCallToFunction(funcDef, args, ast, existingFunction);
 
   return [funcDef, call];
 }

--- a/src/passes/rejectUnsupportedFeatures.ts
+++ b/src/passes/rejectUnsupportedFeatures.ts
@@ -4,6 +4,8 @@ import {
   ArrayTypeName,
   BytesType,
   Conditional,
+  ContractDefinition,
+  ContractKind,
   DataLocation,
   ElementaryTypeName,
   ErrorDefinition,
@@ -160,10 +162,12 @@ export class RejectUnsupportedFeatures extends ASTMapper {
   }
 
   visitFunctionDefinition(node: FunctionDefinition, ast: AST): void {
-    [...node.vParameters.vParameters, ...node.vReturnParameters.vParameters].forEach((decl) => {
-      const type = getNodeType(decl, ast.compilerVersion);
-      functionArgsCheck(type, ast, isExternallyVisible(node), decl.storageLocation);
-    });
+    if (!(node.vScope instanceof ContractDefinition && node.vScope.kind === ContractKind.Library)) {
+      [...node.vParameters.vParameters, ...node.vReturnParameters.vParameters].forEach((decl) => {
+        const type = getNodeType(decl, ast.compilerVersion);
+        functionArgsCheck(type, ast, isExternallyVisible(node), decl.storageLocation);
+      });
+    }
     if (node.kind === FunctionKind.Fallback) {
       if (node.vParameters.vParameters.length > 0)
         throw new WillNotSupportError(`${node.kind} with arguments is not supported`);

--- a/src/utils/functionGeneration.ts
+++ b/src/utils/functionGeneration.ts
@@ -32,16 +32,17 @@ export function createCallToFunction(
   functionDef: FunctionDefinition,
   argList: Expression[],
   ast: AST,
+  nodeInSourceUnit?: ASTNode,
 ): FunctionCall {
   return new FunctionCall(
     ast.reserveId(),
     '',
-    getReturnTypeString(functionDef, ast),
+    getReturnTypeString(functionDef, ast, nodeInSourceUnit),
     FunctionCallKind.FunctionCall,
     new Identifier(
       ast.reserveId(),
       '',
-      getFunctionTypeString(functionDef, ast.compilerVersion),
+      getFunctionTypeString(functionDef, ast.compilerVersion, nodeInSourceUnit),
       functionDef.name,
       functionDef.id,
     ),

--- a/src/utils/getTypeString.ts
+++ b/src/utils/getTypeString.ts
@@ -2,6 +2,7 @@ import assert from 'assert';
 import {
   AddressType,
   ArrayType,
+  ASTNode,
   BoolType,
   BuiltinStructType,
   BuiltinType,
@@ -15,7 +16,7 @@ import {
   FunctionType,
   FunctionVisibility,
   generalizeType,
-  getNodeType,
+  getNodeTypeInCtx,
   ImportRefType,
   IntLiteralType,
   IntType,
@@ -73,10 +74,14 @@ export function getEnumTypeString(node: EnumDefinition): string {
   return `enum ${node.name}`;
 }
 
-export function getFunctionTypeString(node: FunctionDefinition, compilerVersion: string): string {
+export function getFunctionTypeString(
+  node: FunctionDefinition,
+  compilerVersion: string,
+  nodeInSourceUnit?: ASTNode,
+): string {
   const inputs = node.vParameters.vParameters
     .map((decl) => {
-      const baseType = getNodeType(decl, compilerVersion);
+      const baseType = getNodeTypeInCtx(decl, compilerVersion, nodeInSourceUnit ?? decl);
       if (
         baseType instanceof ArrayType ||
         baseType instanceof BytesType ||
@@ -114,11 +119,15 @@ export function getFunctionTypeString(node: FunctionDefinition, compilerVersion:
   return `function (${inputs})${visibility} ${node.stateMutability} ${outputs}`;
 }
 
-export function getReturnTypeString(node: FunctionDefinition, ast: AST): string {
+export function getReturnTypeString(
+  node: FunctionDefinition,
+  ast: AST,
+  nodeInSourceUnit?: ASTNode,
+): string {
   const retParams = node.vReturnParameters.vParameters;
   const parametersTypeString = retParams
     .map((decl) => {
-      const type = getNodeType(decl, ast.compilerVersion);
+      const type = getNodeTypeInCtx(decl, ast.compilerVersion, nodeInSourceUnit ?? decl);
       return type instanceof PointerType
         ? type
         : specializeType(generalizeType(type)[0], decl.storageLocation);

--- a/tests/behaviour/contracts/libraries/libStructs.sol
+++ b/tests/behaviour/contracts/libraries/libStructs.sol
@@ -1,0 +1,19 @@
+library Lib {
+    struct Data { uint a; uint[] b; }
+    function set(Data storage _s) public
+    {
+        _s.a = 7;
+        while (_s.b.length < 20)
+            _s.b.push();
+        _s.b[19] = 8;
+    }
+}
+contract WARP {
+    mapping(string => Lib.Data) data;
+    function f() public returns (uint a, uint b)
+    {
+        Lib.set(data["abc"]);
+        a = data["abc"].a;
+        b = data["abc"].b[19];
+    }
+}

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -2550,6 +2550,14 @@ export const expectations = flatten(
             new Expect('f', [['f', [], [], '234']]),
             new Expect('sender', [['sender', [], ['234'], '465']]),
           ]),
+          File.Simple('libStructs', [
+            Expect.Simple(
+              'f',
+              [],
+              ['7', '0', '8', '0'],
+              'test using struct defined in library in other contract',
+            ),
+          ]),
           new Dir('freeFunctionsLib', [
             File.Simple('direct_and_indirect', [Expect.Simple('freeFuncLib', ['2'], ['4'])]),
             File.Simple('sameName', [Expect.Simple('freeFuncLib', ['1'], ['0'])]),


### PR DESCRIPTION
Fixes libraries/using_library_structs.sol by allowing library functions to take complex inputs and fixing type lookup in the If functionaliser