### PR TITLE
Don't print the errors from solc to stderr

### DIFF
--- a/src/solCompile.ts
+++ b/src/solCompile.ts
@@ -111,6 +111,7 @@ function cliCompile(
       execSync(`${solcCommand} --standard-json ${allowedPaths}`, {
         input: JSON.stringify(input),
         maxBuffer: MAX_BUFFER_SIZE,
+        stdio: ['pipe', 'pipe', 'ignore'],
       }).toString(),
     ),
     compilerVersion: fullVersionFromMajor(nethersolcVersion),


### PR DESCRIPTION
We handle the errors from solc ourselves, if we let solc errors through our test suite thinks that transpilation failed.