### PR TITLE
Add check for invalid r/s values on ecrecover

### DIFF
--- a/tests/behaviour/contracts/ecrecover/failing_ecrecover_invalid_input.sol
+++ b/tests/behaviour/contracts/ecrecover/failing_ecrecover_invalid_input.sol
@@ -1,12 +1,38 @@
 contract WARP {
+    uint256 constant SECP256K1_N = 115792089237316195423570985008687907852837564279074904382605163141518161494337;
+
     // ecrecover should return zero for malformed input
-	// (v should be 27 or 28, not 1)
-	// Note that the precompile does not return zero but returns nothing.
+    // (v should be 27 or 28, not 1)
+    // Note that the precompile does not return zero but returns nothing.
     function f() public returns (uint160) {
         return ecrecover(bytes32(type(uint256).max), 1, bytes32(uint(2)), bytes32(uint(3)));
+    }
+
+    // should return 0 on r=0
+    function g() public returns (uint160) {
+        return ecrecover(bytes32(type(uint256).max), 27, bytes32(uint(0)), bytes32(uint(1)));
+    }
+
+    // should return 0 on s=0
+    function h() public returns (uint160) {
+        return ecrecover(bytes32(type(uint256).max), 27, bytes32(uint(1)), bytes32(uint(0)));
+    }
+
+    // should return 0 on r>=n
+    function i() public returns (uint160) {
+        return ecrecover(bytes32(type(uint256).max), 27, bytes32(SECP256K1_N), bytes32(uint(1)));
+    }
+
+    // should return 0 on s>=n
+    function j() public returns (uint160) {
+        return ecrecover(bytes32(type(uint256).max), 27, bytes32(uint(1)), bytes32(SECP256K1_N));
     }
 }
 // ====
 // compileViaYul: also
 // ----
 // f() -> 0
+// g() -> 0
+// h() -> 0
+// i() -> 0
+// j() -> 0

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -369,7 +369,11 @@ export const expectations = flatten(
             Expect.Simple('f', [], ['3', '0x3', '0x1', '0x2']),
             Expect.Simple('g', [], ['3', '0x3', '0x1', '0x2']),
             Expect.Simple('h', [], ['5', '0x68', '0x65', '0x6C', '0x6C', '0x6F']),
-            Expect.Simple('i', [], ['0x38', '0', '0x1', '0', '129445968720857988376759499178045865984']),
+            Expect.Simple(
+              'i',
+              [],
+              ['0x38', '0', '0x1', '0', '129445968720857988376759499178045865984'],
+            ),
           ]),
           File.Simple('simpleConstants', [
             Expect.Simple('getX', [], ['247']),
@@ -1733,7 +1737,13 @@ export const expectations = flatten(
           File.Simple('example', [Expect.Simple('ArrayFunc', [], ['69', '0'])]),
         ]),
         new Dir('ecrecover', [
-          File.Simple('failing_ecrecover_invalid_input', [Expect.Simple('f', [], ['0'])]),
+          File.Simple('failing_ecrecover_invalid_input', [
+            Expect.Simple('f', [], ['0']),
+            Expect.Simple('g', [], ['0']),
+            Expect.Simple('h', [], ['0']),
+            Expect.Simple('i', [], ['0']),
+            Expect.Simple('j', [], ['0']),
+          ]),
           File.Simple('ecrecover_abiV2', [
             Expect.Simple(
               'a',

--- a/warplib/ecrecover.cairo
+++ b/warplib/ecrecover.cairo
@@ -10,7 +10,13 @@ from starkware.cairo.common.uint256 import Uint256
 from starkware.cairo.common.cairo_secp.bigint import BigInt3, uint256_to_bigint
 from starkware.cairo.common.cairo_secp.ec import EcPoint
 
-from warplib.maths.eq import warp_eq
+from warplib.maths.eq import warp_eq, warp_eq256
+from warplib.maths.lt import warp_lt256
+
+# This equals to 115792089237316195423570985008687907852837564279074904382605163141518161494337
+# Would be nicer if structs were allowed here.
+const SECP256K1_N_HIGH = 0xfffffffffffffffffffffffffffffffe
+const SECP256K1_N_LOW = 0xbaaedce6af48a03bbfd25e8cd0364141
 
 # NOTE: This function returns an ethereum address
 func ecrecover_eth{range_check_ptr, bitwise_ptr : BitwiseBuiltin*, keccak_ptr : felt*}(
@@ -20,11 +26,28 @@ func ecrecover_eth{range_check_ptr, bitwise_ptr : BitwiseBuiltin*, keccak_ptr : 
     let (v_is_27) = warp_eq(v, 27)
     let (v_is_28) = warp_eq(v, 28)
 
+    # Expect one of them to be 1 (true)
     if v_is_27 + v_is_28 == 0:
         return (0)
     end
 
     let v = v - 27
+
+    let (r_eq_0) = warp_eq256(r_, Uint256(0, 0))
+    let (s_eq_0) = warp_eq256(s_, Uint256(0, 0))
+
+    # Expect both of these to be 0 (false)
+    if r_eq_0 + s_eq_0 != 0:
+        return (0)
+    end
+
+    let (r_lt_n) = warp_lt256(r_, Uint256(SECP256K1_N_LOW, SECP256K1_N_HIGH))
+    let (s_lt_n) = warp_lt256(s_, Uint256(SECP256K1_N_LOW, SECP256K1_N_HIGH))
+
+    # Expect both of these to be 1 (true)
+    if r_lt_n + s_lt_n != 2:
+        return (0)
+    end
 
     let (msg_hash : BigInt3) = uint256_to_bigint(msg_hash_)
     let (r : BigInt3) = uint256_to_bigint(r_)


### PR DESCRIPTION
Following up #542. This implements the rest of the checks:
<img width="636" alt="Screenshot" src="https://user-images.githubusercontent.com/20340/174356827-ab605354-a21c-4e66-b5c1-60b8cab3c9ec.png">
