### PR TITLE
Fix misuse of createIdentifier

### DIFF
--- a/src/passes/inheritanceInliner/functionInheritance.ts
+++ b/src/passes/inheritanceInliner/functionInheritance.ts
@@ -162,7 +162,9 @@ function createDelegatingFunction(
       createReturn(
         createCallToFunction(
           delegate,
-          newFunc.vParameters.vParameters.map((v) => createIdentifier(v, ast)),
+          newFunc.vParameters.vParameters.map((v) =>
+            createIdentifier(v, ast, undefined, funcToCopy),
+          ),
           ast,
         ),
         newFunc.vReturnParameters.id,


### PR DESCRIPTION
Fixes a use of createIdentifier without a reference node that was leading to a crash with the weth10.sol contract