### PR TITLE
Index access func loc fix

### DIFF
--- a/src/passes/expressionSplitter/expressionSplitter.ts
+++ b/src/passes/expressionSplitter/expressionSplitter.ts
@@ -16,6 +16,7 @@ import {
   VariableDeclarationStatement,
   generalizeType,
   getNodeType,
+  FunctionKind,
 } from 'solc-typed-ast';
 import { AST } from '../../ast/ast';
 import { ASTMapper } from '../../ast/mapper';
@@ -126,7 +127,7 @@ export class ExpressionSplitter extends ASTMapper {
       newFuncId,
       '',
       containingFunction.scope,
-      containingFunction.kind,
+      containingFunction.kind === FunctionKind.Free ? FunctionKind.Free : FunctionKind.Function,
       `_conditional${this.funcNameCounter++}`,
       false,
       FunctionVisibility.Internal,

--- a/src/passes/references/dataAccessFunctionaliser.ts
+++ b/src/passes/references/dataAccessFunctionaliser.ts
@@ -309,7 +309,14 @@ export class DataAccessFunctionaliser extends ReferenceSubPass {
     }
 
     if (replacement !== null) {
-      this.replace(node, replacement, undefined, actualLoc, expectedLoc, ast);
+      this.replace(
+        node,
+        replacement,
+        undefined,
+        actualLoc,
+        expectedLoc ?? DataLocation.Default,
+        ast,
+      );
       this.dispatchVisit(replacement, ast);
     } else {
       this.visitExpression(node, ast);

--- a/tests/behaviour/contracts/conditionals/and.sol
+++ b/tests/behaviour/contracts/conditionals/and.sol
@@ -3,6 +3,11 @@ pragma solidity ^0.8.0;
 
 contract WARP {
   uint256 public a;
+  
+  uint256[] b;
+  constructor() {
+    require(a < 1 && a == b.length);
+  }
 
   function f(uint256 value, bool flag) public returns (uint256) {
     uint256 y = 30;

--- a/tests/behaviour/contracts/index_access/arrayIndexAccess.sol
+++ b/tests/behaviour/contracts/index_access/arrayIndexAccess.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.0;
+
+contract WARP {
+
+    bool[1] oneDArr;
+    bool[1][1] twoDArr;
+
+    function inIfExpression(uint8 x) public returns (uint8) {
+      oneDArr[0] = false;
+      if (!oneDArr[0]) {
+        x = x + 1;
+      }
+      return x;
+    }
+
+    function inRequire(uint8 x) public returns (uint8) {
+      twoDArr[0][0] = true;
+      require(twoDArr[0][0]);
+      x = x + 1;
+      return x;
+    }
+}

--- a/tests/behaviour/contracts/index_access/mapIndexAccess.sol
+++ b/tests/behaviour/contracts/index_access/mapIndexAccess.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.0;
+
+contract WARP {
+
+    mapping(uint => bool) oneDMap;
+    mapping(uint => mapping(uint => bool)) twoDMap;
+
+    function inIfExpression(uint8 x) public returns (uint8) {
+      oneDMap[0] = false;
+      if (!oneDMap[0]) {
+        x = x + 1;
+      }
+      return x;
+    }
+
+    function inRequire(uint8 x) public returns (uint8) {
+      twoDMap[0][0] = true;
+      require(twoDMap[0][0]);
+      x = x + 1;
+      return x;
+    }
+}

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -2564,6 +2564,16 @@ export const expectations = flatten(
         new Dir('imports', [
           File.Simple('importto', [Expect.Simple('checkImports', ['3', '2'], ['1'])]),
         ]),
+        new Dir('index_access', [
+          File.Simple('arrayIndexAccess', [
+            Expect.Simple('inIfExpression', ['5'], ['6']),
+            Expect.Simple('inRequire', ['5'], ['6']),
+          ]),
+          File.Simple('mapIndexAccess', [
+            Expect.Simple('inIfExpression', ['5'], ['6']),
+            Expect.Simple('inRequire', ['5'], ['6']),
+          ]),
+        ]),
         new Dir('inheritance', [
           new Dir('constructors', [
             new File(


### PR DESCRIPTION
IndexAccess nodes without any Return or VarDeclStmt parents get an expected location of undefined, which then causes the read function for it to be not generated. Smh like
```
bool[] storage arr;
if(arr[0]) {...}
```
crashes. Because it converts arr[0]  into `WARP_DARRAY0_felt_IDX(arr,0)` rather than `WS0_READ_felt(WARP_DARRAY0_felt_IDX(arr,0))` . Expected locations are set from parent to child, so was not able to fix this from the expectedLocationAnalyzer. Instead did it when the IndexAccess is laced by a function.