### PR TITLE
Cleanup contract name mangling

### DIFF
--- a/src/passes/sourceUnitSplitter.ts
+++ b/src/passes/sourceUnitSplitter.ts
@@ -13,6 +13,9 @@ import { cloneASTNode } from '../utils/cloning';
 
 type Scoped = FunctionDefinition | ContractDefinition | VariableDeclaration | StructDefinition;
 
+export const CONTRACT_INFIX = '__WC__';
+export const FREE_SUFIX = '__WARP_FREE__';
+
 export class SourceUnitSplitter extends ASTMapper {
   static map(ast: AST): AST {
     ast.roots = ast.roots.flatMap((su) => splitSourceUnit(su, ast));
@@ -106,11 +109,11 @@ function updateScope(nodes: readonly Scoped[], newScope: number): readonly Scope
 }
 
 export function mangleFreeFilePath(path: string): string {
-  return `${path}__WARP_FREE__`;
+  return `${path}${FREE_SUFIX}`;
 }
 
 export function mangleContractFilePath(path: string, contractName: string): string {
-  return `${path}__WARP_CONTRACT__${contractName}`;
+  return `${path}${CONTRACT_INFIX}${contractName}`;
 }
 
 function getAllSourceUnitDefinitions(sourceUnit: SourceUnit) {

--- a/src/passes/sourceUnitSplitter.ts
+++ b/src/passes/sourceUnitSplitter.ts
@@ -14,7 +14,7 @@ import { cloneASTNode } from '../utils/cloning';
 type Scoped = FunctionDefinition | ContractDefinition | VariableDeclaration | StructDefinition;
 
 export const CONTRACT_INFIX = '__WC__';
-export const FREE_SUFIX = '__WARP_FREE__';
+export const FREE_SUFIX = '__WC_FREE';
 
 export class SourceUnitSplitter extends ASTMapper {
   static map(ast: AST): AST {

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -13,6 +13,7 @@ import * as fs from 'fs';
 import { outputFileSync } from 'fs-extra';
 import { error } from './utils/formatting';
 import { manglePath } from './passes/filePathMangler';
+import { CONTRACT_INFIX } from './passes';
 
 type ResultType =
   | 'CairoCompileFailed'
@@ -325,7 +326,7 @@ function combineResults(results: ResultType[]): ResultType {
 function getTestsWithUnexpectedResults(results: Map<string, ResultType>): string[] {
   const testsWithUnexpectedResults: string[] = [];
   const groupedResults = groupBy([...results.entries()], ([file, _]) => {
-    return file.split('__WARP_CONTRACT__')[0];
+    return file.split(CONTRACT_INFIX)[0];
   });
   [...groupedResults.entries()].forEach((e) => {
     const expected = expectedResults.get(e[0]);
@@ -357,12 +358,12 @@ function printResults(results: Map<string, ResultType>, unexpectedResults: strin
       console.log(`Actual outcome:`);
       const Actual = new Map<string, ResultType>();
       results.forEach((value, key) => {
-        if (key === o || key.startsWith(`${o}__WARP_CONTRACT__`)) {
+        if (key === o || key.startsWith(`${o}${CONTRACT_INFIX}`)) {
           Actual.set(key, value);
         }
       });
       Actual.forEach((value, key) => {
-        if (key.includes('__WARP_CONTRACT__')) {
+        if (key.includes(CONTRACT_INFIX)) {
           console.log(key + '.cairo' + ' : ' + value);
         } else {
           console.log(key + '.sol' + ' : ' + value);


### PR DESCRIPTION
Uses a slightly shorter `__WC__` infix and defines a single source of truth for it.