### PR TITLE
Use absolute path for logo

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,11 +2,6 @@
   "name": "@nethermindeth/warp",
   "version": "2.0.1",
   "description": "Solidity to Cairo Transpiler",
-  "repositoty": {
-    "type": "git",
-    "url": "https://github.com/NethermindEth/warp.git",
-    "directory": "."
-  },
   "main": "index.ts",
   "author": "Nethermind",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,11 @@
   "name": "@nethermindeth/warp",
   "version": "2.0.1",
   "description": "Solidity to Cairo Transpiler",
+  "repositoty": {
+    "type": "git",
+    "url": "https://github.com/NethermindEth/warp.git",
+    "directory": "."
+  },
   "main": "index.ts",
   "author": "Nethermind",
   "engines": {

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-<img src="./resources/WARP.svg" width="900" height="512" />
+<img src="https://raw.githubusercontent.com/NethermindEth/warp/main/resources/WARP.svg" width="900" height="512" />
 
 # Warp
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-<img src="https://raw.githubusercontent.com/NethermindEth/warp/main/resources/WARP.svg./resources/WARP.svg" width="900" height="512" />
+<img src="https://raw.githubusercontent.com/NethermindEth/warp/main/resources/WARP.svg" width="900" height="512" />
 
 # Warp
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-<img src="./resources/WARP.svg" width="900" height="512" />
+<img src="https://raw.githubusercontent.com/NethermindEth/warp/main/resources/WARP.svg./resources/WARP.svg" width="900" height="512" />
 
 # Warp
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-<img src="https://raw.githubusercontent.com/NethermindEth/warp/main/resources/WARP.svg" width="900" height="512" />
+<img src="./resources/WARP.svg" width="900" height="512" />
 
 # Warp
 


### PR DESCRIPTION
The logo is broken on npmjs.com because it tries to resolve the image relative to the url.
While this solution is not ideal for development the logo is unlikely to change in the near
future so I see no harm in setting this absolute path.
