### PR TITLE
Implement mulmod and addmod

### DIFF
--- a/src/passes/rejectUnsupportedFeatures.ts
+++ b/src/passes/rejectUnsupportedFeatures.ts
@@ -126,7 +126,7 @@ export class RejectUnsupportedFeatures extends ASTMapper {
   }
 
   visitFunctionCall(node: FunctionCall, ast: AST): void {
-    const unsupportedMath = ['sha256', 'ripemd160', 'addmod', 'mulmod'];
+    const unsupportedMath = ['sha256', 'ripemd160'];
     const unsupportedAbi = [
       'decode',
       'encode',

--- a/tests/behaviour/expectations/semantic_whitelist.ts
+++ b/tests/behaviour/expectations/semantic_whitelist.ts
@@ -112,7 +112,7 @@ const tests: string[] = [
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/accessor/accessor_for_const_state_variable.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/accessor/accessor_for_state_variable.sol',
   ],
-  //---------Arithmetics - 43 passing
+  //---------Arithmetics - 49 passing
   ...[
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/arithmetics/block_inside_unchecked.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/arithmetics/checked_add_v1.sol',
@@ -124,8 +124,8 @@ const tests: string[] = [
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/arithmetics/divisiod_by_zero.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/arithmetics/signed_mod.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/arithmetics/unchecked_div_by_zero.sol',
-    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/arithmetics/addmod_mulmod.sol', // STRETCH addmod, mulmod
-    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/arithmetics/addmod_mulmod_zero.sol', // STRETCH addmod, mulmod
+    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/arithmetics/addmod_mulmod.sol',
+    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/arithmetics/addmod_mulmod_zero.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/arithmetics/check_var_init.sol', // REQUIRES CAIRO 0.9 - uses new
   ],
   //---------Array tests - 374 passing, 103 pending, 52 failing

--- a/warplib/maths/addmod.cairo
+++ b/warplib/maths/addmod.cairo
@@ -20,11 +20,9 @@ end
 
 func warp_addmod256{range_check_ptr}(x : Uint256, y : Uint256, k : Uint256) -> (res : Uint256):
     alloc_locals
-    if k.high == 0:
-        if k.low == 0:
-            with_attr error_message("Modulo by zero error"):
-                assert 1 = 0
-            end
+    if k.high + k.low == 0:
+        with_attr error_message("Modulo by zero error"):
+            assert 1 = 0
         end
     end
 

--- a/warplib/maths/addmod.cairo
+++ b/warplib/maths/addmod.cairo
@@ -3,22 +3,7 @@ from warplib.maths.utils import felt_to_uint256
 
 const SHIFT = 2 ** 128
 
-func warp_addmod{range_check_ptr}(x : felt, y : felt, k : felt) -> (res : felt):
-    if k == 0:
-        with_attr error_message("Modulo by zero error"):
-            assert 1 = 0
-        end
-    end
-    let (x_256) = felt_to_uint256(x)
-    let (y_256) = felt_to_uint256(y)
-    let (k_256) = felt_to_uint256(k)
-    # We know for certain the carry is 0
-    let (xy, _) = uint256_add(x_256, y_256)
-    let (_, res256) = uint256_unsigned_div_rem(xy, k_256)
-    return (res256.low + SHIFT * res256.high)
-end
-
-func warp_addmod256{range_check_ptr}(x : Uint256, y : Uint256, k : Uint256) -> (res : Uint256):
+func warp_addmod{range_check_ptr}(x : Uint256, y : Uint256, k : Uint256) -> (res : Uint256):
     alloc_locals
     if k.high + k.low == 0:
         with_attr error_message("Modulo by zero error"):

--- a/warplib/maths/mulmod.cairo
+++ b/warplib/maths/mulmod.cairo
@@ -1,0 +1,42 @@
+from starkware.cairo.common.uint256 import Uint256, uint256_unsigned_div_rem, uint256_add, uint256_mul, uint256_sub, ALL_ONES
+from warplib.maths.utils import felt_to_uint256
+
+const SHIFT = 2 ** 128
+
+func warp_mulmod{range_check_ptr}(x : felt, y : felt, k : felt) -> (res : felt):
+    let (x_256) = felt_to_uint256(x)
+    let (y_256) = felt_to_uint256(y)
+    let (k_256) = felt_to_uint256(k)
+
+    let (res256) = warp_mulmod256(x_256, y_256, k_256)
+
+    return (res256.low + SHIFT * res256.high)
+end
+
+func warp_mulmod256{range_check_ptr}(x : Uint256, y : Uint256, k : Uint256) -> (res : Uint256):
+    alloc_locals
+    if k.high + k.low == 0:
+        with_attr error_message("Modulo by zero error"):
+            assert 1 = 0
+        end
+    end
+
+    let (xy_low, xy_high) = uint256_mul(x, y)
+    if xy_high.low + xy_high.high == 0:
+        let (_, res) = uint256_unsigned_div_rem(xy_low, k)
+        return (res)
+    end
+
+    let uint256_MAX = Uint256(low=ALL_ONES, high=ALL_ONES)
+    let (_, exp_mod_k) = uint256_unsigned_div_rem(uint256_MAX, k)
+    let (exp_mod_k, _) = uint256_add(exp_mod_k, Uint256(1, 0))
+    let (_, exp_mod_k) = uint256_unsigned_div_rem(exp_mod_k, k)
+
+    let (_, xy_high_mod_k) = uint256_unsigned_div_rem(xy_high, k)
+    let (_, xy_low_mod_k) = uint256_unsigned_div_rem(xy_low, k)
+
+    let (xy_high_exp_mod_k) = warp_mulmod256(exp_mod_k, xy_high_mod_k, k)
+    let (res) = warp_mulmod256(xy_high_exp_mod_k, xy_low_mod_k, k)
+
+    return (res)
+end

--- a/warplib/maths/mulmod.cairo
+++ b/warplib/maths/mulmod.cairo
@@ -1,20 +1,8 @@
 from starkware.cairo.common.uint256 import Uint256, uint256_unsigned_div_rem, uint256_add, uint256_mul, uint256_sub, ALL_ONES
 from warplib.maths.utils import felt_to_uint256
-from warplib.maths.addmod import warp_addmod256
+from warplib.maths.addmod import warp_addmod
 
-const SHIFT = 2 ** 128
-
-func warp_mulmod{range_check_ptr}(x : felt, y : felt, k : felt) -> (res : felt):
-    let (x_256) = felt_to_uint256(x)
-    let (y_256) = felt_to_uint256(y)
-    let (k_256) = felt_to_uint256(k)
-
-    let (res256) = warp_mulmod256(x_256, y_256, k_256)
-
-    return (res256.low + SHIFT * res256.high)
-end
-
-func warp_mulmod256{range_check_ptr}(x : Uint256, y : Uint256, k : Uint256) -> (res : Uint256):
+func warp_mulmod{range_check_ptr}(x : Uint256, y : Uint256, k : Uint256) -> (res : Uint256):
     alloc_locals
     if k.high + k.low == 0:
         with_attr error_message("Modulo by zero error"):
@@ -36,8 +24,8 @@ func warp_mulmod256{range_check_ptr}(x : Uint256, y : Uint256, k : Uint256) -> (
     let (_, xy_high_mod_k) = uint256_unsigned_div_rem(xy_high, k)
     let (_, xy_low_mod_k) = uint256_unsigned_div_rem(xy_low, k)
 
-    let (xy_high_exp_mod_k) = warp_mulmod256(exp_mod_k, xy_high_mod_k, k)
-    let (res) = warp_addmod256(xy_high_exp_mod_k, xy_low_mod_k, k)
+    let (xy_high_exp_mod_k) = warp_mulmod(exp_mod_k, xy_high_mod_k, k)
+    let (res) = warp_addmod(xy_high_exp_mod_k, xy_low_mod_k, k)
 
     return (res)
 end

--- a/warplib/maths/mulmod.cairo
+++ b/warplib/maths/mulmod.cairo
@@ -1,5 +1,6 @@
 from starkware.cairo.common.uint256 import Uint256, uint256_unsigned_div_rem, uint256_add, uint256_mul, uint256_sub, ALL_ONES
 from warplib.maths.utils import felt_to_uint256
+from warplib.maths.addmod import warp_addmod256
 
 const SHIFT = 2 ** 128
 
@@ -36,7 +37,7 @@ func warp_mulmod256{range_check_ptr}(x : Uint256, y : Uint256, k : Uint256) -> (
     let (_, xy_low_mod_k) = uint256_unsigned_div_rem(xy_low, k)
 
     let (xy_high_exp_mod_k) = warp_mulmod256(exp_mod_k, xy_high_mod_k, k)
-    let (res) = warp_mulmod256(xy_high_exp_mod_k, xy_low_mod_k, k)
+    let (res) = warp_addmod256(xy_high_exp_mod_k, xy_low_mod_k, k)
 
     return (res)
 end


### PR DESCRIPTION
Implements mulmod and addmod.

```
mulmod(uint256 x, uint256 y, uint256 k): uint256
addmod(uint256 x, uint256 y, uint256 k): uint256
```

Mulmod and addmod in solidity only operate on uint256s. They use 'arbitrary'
precision internally such that the overflows of x + y or x * y are also
included in the argument to the mod.
