### PR TITLE
Add Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:20.04
+
+# Install dependencies
+RUN apt update -y && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt -y install tzdata \
+        libz3-dev \
+        curl \
+        gnupg \
+        npm \
+        python3-pip \
+        libgmp3-dev
+
+# Install yarn
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN apt update -y && apt install -y yarn
+
+# Upgrade npm
+RUN npm install -g n
+RUN n stable
+
+# Install Cairo
+RUN pip install cairo-lang
+
+# Install warp
+RUN yarn global add @nethermindeth/warp
+RUN warp install
+RUN export PATH="$PATH:$(yarn global bin)"
+
+WORKDIR /dapp
+
+ENTRYPOINT [ "warp" ]

--- a/readme.md
+++ b/readme.md
@@ -156,14 +156,6 @@ Run the container with the same options and arguments as the Warp binary:
 docker run --rm -v $(pwd):/dapp warp transpile example_contracts/ERC20.sol
 ```
 
-Alternatively, define an alias and run the container as the Warp binary itself:
-
-```bash
-alias warp="docker run --rm -v $(pwd):/dapp warp"
-
-warp transpile example_contracts/ERC20.sol
-```
-
 ## Testing for contributors :stethoscope:
 
 To test that your contribution doesn't break any features you can test that all previous example contracts transpile and then cairo compile by running the following:

--- a/readme.md
+++ b/readme.md
@@ -153,13 +153,13 @@ docker build -t warp .
 Run the container with the same options and arguments as the Warp binary:
 
 ```bash
-docker run -v $(pwd):/dapp warp transpile example_contracts/ERC20.sol
+docker run --rm -v $(pwd):/dapp warp transpile example_contracts/ERC20.sol
 ```
 
 Alternatively, define an alias and run the container as the Warp binary itself:
 
 ```bash
-alias warp="docker run -v $(pwd):/dapp warp"
+alias warp="docker run --rm -v $(pwd):/dapp warp"
 
 warp transpile example_contracts/ERC20.sol
 ```

--- a/readme.md
+++ b/readme.md
@@ -153,7 +153,7 @@ docker build -t warp .
 Run the container with the same options and arguments as the Warp binary:
 
 ```bash
-docker run --rm -v $(pwd):/dapp warp transpile example_contracts/ERC20.sol
+docker run --rm -v $PWD:/dapp warp transpile example_contracts/ERC20.sol
 ```
 
 ## Testing for contributors :stethoscope:

--- a/readme.md
+++ b/readme.md
@@ -142,6 +142,20 @@ Please see the list below:
 
 Note: We have changed the return of `ecrecover` to be `uint160` because we use the `address` type for StarkNet addresses.
 
+## Docker :whale:
+
+Build the image from source:
+
+```bash
+docker build -t warp .
+```
+
+Run the container in the directory containing the target `.sol` files:
+
+```bash
+docker run -v $(pwd):/dapp warp transpile *.sol
+```
+
 ## Testing for contributors :stethoscope:
 
 To test that your contribution doesn't break any features you can test that all previous example contracts transpile and then cairo compile by running the following:

--- a/readme.md
+++ b/readme.md
@@ -150,10 +150,18 @@ Build the image from source:
 docker build -t warp .
 ```
 
-Run the container in the directory containing the target `.sol` files:
+Run the container with the same options and arguments as the Warp binary:
 
 ```bash
-docker run -v $(pwd):/dapp warp transpile *.sol
+docker run -v $(pwd):/dapp warp transpile example_contracts/ERC20.sol
+```
+
+Alternatively, define an alias and run the container as the Warp binary itself:
+
+```bash
+alias warp="docker run -v $(pwd):/dapp warp"
+
+warp transpile example_contracts/ERC20.sol
 ```
 
 ## Testing for contributors :stethoscope:

--- a/readme.md
+++ b/readme.md
@@ -153,7 +153,7 @@ docker build -t warp .
 Run the container with the same options and arguments as the Warp binary:
 
 ```bash
-docker run --rm -v $PWD:/dapp warp transpile example_contracts/ERC20.sol
+docker run --rm -v $PWD:/dapp --user $(id -u):$(id -g) warp transpile example_contracts/ERC20.sol
 ```
 
 ## Testing for contributors :stethoscope:


### PR DESCRIPTION
# Add Docker Image

This pull request introduces a rudimentary Docker image to use Warp.

## Motivation
Users should have multiple ways to install their software. Different people use different OS. The currently provided installation methods don't suffice for common OS such as Windows. Docker images provide an elegant way to increase the accessibility of Warp. Now every OS which can run Docker can be easily used for Warp.

## Summary
A fresh Dockerfile has been written. The biggest challenge was to find a suitable base image and to get all dependencies right. Among others, the `cairo-lang` package makes it non-trivial to use a lightweight image such as `alpine`. Therefore, `ubuntu:20.04` was chosen as a base image.

## Metrics:

- Image size: 1.99GB

## Usage

Build the image from inside this repository:

```bash
docker build -t warp .
```

And run the container from within this repository:

```bash
docker run -v $(pwd):/dapp warp transpile example_contracts/ERC20.sol
```

## Possible Improvements

- Decrease image size (e.g. with multi-stage builds)
- Continuous deployment such that users only need to pull the image