### PR TITLE
Improve efficiency of control flow algorithms

### DIFF
--- a/src/passes/returnInserter.ts
+++ b/src/passes/returnInserter.ts
@@ -1,7 +1,7 @@
-import { FunctionDefinition, Return } from 'solc-typed-ast';
+import { FunctionDefinition } from 'solc-typed-ast';
 import { AST } from '../ast/ast';
 import { ASTMapper } from '../ast/mapper';
-import { analyseControlFlow } from '../utils/controlFlowAnalyser';
+import { hasPathWithoutReturn } from '../utils/controlFlowAnalyser';
 import { createIdentifier, createReturn } from '../utils/nodeTemplates';
 import { toSingleExpression } from '../utils/utils';
 
@@ -9,9 +9,7 @@ export class ReturnInserter extends ASTMapper {
   visitFunctionDefinition(node: FunctionDefinition, ast: AST): void {
     if (node.vBody === undefined) return;
 
-    const controlFlows = analyseControlFlow(node.vBody);
-
-    if (controlFlows.some((flow) => !flow.some((s) => s instanceof Return))) {
+    if (hasPathWithoutReturn(node.vBody)) {
       const retVars = node.vReturnParameters.vParameters;
       let expression;
       if (retVars.length !== 0) {

--- a/src/passes/unreachableStatementPruner.ts
+++ b/src/passes/unreachableStatementPruner.ts
@@ -1,18 +1,14 @@
 import { FunctionDefinition, Statement, StatementWithChildren } from 'solc-typed-ast';
 import { AST } from '../ast/ast';
 import { ASTMapper } from '../ast/mapper';
-import { analyseControlFlow } from '../utils/controlFlowAnalyser';
+import { collectReachableStatements } from '../utils/controlFlowAnalyser';
+import { union } from '../utils/utils';
 export class UnreachableStatementPruner extends ASTMapper {
   reachableStatements: Set<Statement> = new Set();
   visitFunctionDefinition(node: FunctionDefinition, ast: AST): void {
     const body = node.vBody;
     if (body === undefined) return;
-    const controlFlows = analyseControlFlow(body);
-    controlFlows.forEach((flow) =>
-      flow.forEach((statement) => {
-        this.reachableStatements.add(statement);
-      }),
-    );
+    this.reachableStatements = union(this.reachableStatements, collectReachableStatements(body));
     this.commonVisit(node, ast);
   }
   visitStatement(node: Statement, ast: AST): void {

--- a/src/utils/controlFlowAnalyser.ts
+++ b/src/utils/controlFlowAnalyser.ts
@@ -6,7 +6,7 @@ export function hasPathWithoutReturn(statement: Statement): boolean {
   } else if (statement instanceof IfStatement) {
     if (hasPathWithoutReturn(statement.vTrueBody)) {
       return true;
-    } else if (statement.vFalseBody !== undefined && hasPathWithoutReturn(statement.vFalseBody)) {
+    } else if (statement.vFalseBody === undefined || hasPathWithoutReturn(statement.vFalseBody)) {
       return true;
     } else {
       return false;

--- a/src/utils/controlFlowAnalyser.ts
+++ b/src/utils/controlFlowAnalyser.ts
@@ -1,34 +1,41 @@
 import { Block, IfStatement, Return, Statement, UncheckedBlock } from 'solc-typed-ast';
-import { printNode } from './astPrinter';
 
-export function analyseControlFlow(statement: Statement): Statement[][] {
+export function hasPathWithoutReturn(statement: Statement): boolean {
   if (statement instanceof Block || statement instanceof UncheckedBlock) {
-    const start: Statement[][] = [[statement]];
-    return statement.vStatements.reduce((inFlows, curr) => {
-      const outFlows = analyseControlFlow(curr);
-      return mergeFlows(inFlows, outFlows);
-    }, start);
+    return statement.vStatements.every(hasPathWithoutReturn);
   } else if (statement instanceof IfStatement) {
-    const trueFlow = analyseControlFlow(statement.vTrueBody);
-    const falseFlow = statement.vFalseBody ? analyseControlFlow(statement.vFalseBody) : [[]];
-    return mergeFlows([[statement]], [...trueFlow, ...falseFlow]);
+    if (hasPathWithoutReturn(statement.vTrueBody)) {
+      return true;
+    } else if (statement.vFalseBody !== undefined && hasPathWithoutReturn(statement.vFalseBody)) {
+      return true;
+    } else {
+      return false;
+    }
+  } else if (statement instanceof Return) {
+    return false;
   } else {
-    return [[statement]];
+    return true;
   }
 }
 
-function mergeFlows(inFlows: Statement[][], outFlows: Statement[][]): Statement[][] {
-  return inFlows.flatMap((i) => {
-    if (i.length > 0 && i[i.length - 1] instanceof Return) {
-      return [i];
-    } else {
-      return outFlows.map((o) => [...i, ...o]);
-    }
-  });
+export function collectReachableStatements(statement: Statement): Set<Statement> {
+  // This is created up front for space efficiency, to avoid constant creation and unions of sets
+  const reachableStatements = new Set<Statement>();
+  collectReachableStatementsImpl(statement, reachableStatements);
+  return reachableStatements;
 }
 
-export function printControlFlow(flow: Statement[][]): string {
-  return flow
-    .map((path: Statement[], index: number) => [`${index}.`, ...path.map(printNode)].join('\n'))
-    .join('\n');
+export function collectReachableStatementsImpl(
+  statement: Statement,
+  collection: Set<Statement>,
+): void {
+  collection.add(statement);
+  if (statement instanceof Block || statement instanceof UncheckedBlock) {
+    statement.vStatements.forEach((subStatement) =>
+      collectReachableStatementsImpl(subStatement, collection),
+    );
+  } else if (statement instanceof IfStatement) {
+    collectReachableStatementsImpl(statement.vTrueBody, collection);
+    if (statement.vFalseBody) collectReachableStatementsImpl(statement.vFalseBody, collection);
+  }
 }


### PR DESCRIPTION
The previous CFA algorithm was causing out of memory errors. It was used in two cases, neither of which required all the information it was gathering. I've replaced it with two much smaller algorithms with vastly better space usage