### PR TITLE
Uniswap bump to 0.8.14

### DIFF
--- a/v3-core/contracts/NoDelegateCall.sol
+++ b/v3-core/contracts/NoDelegateCall.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity =0.7.6;
+pragma solidity ^0.8.14;
 
 /// @title Prevents delegatecall to a contract
 /// @notice Base contract that provides a modifier for preventing delegatecall to methods in a child contract

--- a/v3-core/contracts/UniswapV3Factory.sol
+++ b/v3-core/contracts/UniswapV3Factory.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity =0.7.6;
+pragma solidity ^0.8.14;
 
-import './interfaces/IUniswapV3Factory.sol ';
+import './interfaces/IUniswapV3Factory.sol';
 
 import './UniswapV3PoolDeployer.sol';
 import './NoDelegateCall.sol';

--- a/v3-core/contracts/UniswapV3Pool.sol
+++ b/v3-core/contracts/UniswapV3Pool.sol
@@ -462,7 +462,7 @@ contract UniswapV3Pool is IUniswapV3Pool, NoDelegateCall {
                     owner: recipient,
                     tickLower: tickLower,
                     tickUpper: tickUpper,
-                    liquidityDelta: int256(amount).toInt128()
+                    liquidityDelta: int256(uint256(amount)).toInt128()
                 })
             );
 
@@ -519,7 +519,7 @@ contract UniswapV3Pool is IUniswapV3Pool, NoDelegateCall {
                     owner: msg.sender,
                     tickLower: tickLower,
                     tickUpper: tickUpper,
-                    liquidityDelta: -int256(amount).toInt128()
+                    liquidityDelta: -int256(uint256(amount)).toInt128()
                 })
             );
 

--- a/v3-core/contracts/UniswapV3Pool.sol
+++ b/v3-core/contracts/UniswapV3Pool.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity =0.7.6;
+pragma solidity ^0.8.14;
 
 import './interfaces/IUniswapV3Pool.sol';
 

--- a/v3-core/contracts/UniswapV3PoolDeployer.sol
+++ b/v3-core/contracts/UniswapV3PoolDeployer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity =0.7.6;
+pragma solidity ^0.8.14;
 
 import './interfaces/IUniswapV3PoolDeployer.sol';
 

--- a/v3-core/contracts/libraries/FullMath.sol
+++ b/v3-core/contracts/libraries/FullMath.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.4.0 <0.8.0;
+pragma solidity ^0.8.14;
 
 /// @title Contains 512-bit math functions
 /// @notice Facilitates multiplication and division that can have overflow of an intermediate value without any loss of precision
@@ -71,7 +71,7 @@ library FullMath {
         // Factor powers of two out of denominator
         // Compute largest power of two divisor of denominator.
         // Always >= 1.
-        uint256 twos = -denominator & denominator;
+        uint256 twos = uint256(-int256(denominator)) & denominator;
         // Divide denominator by power of two
         //assembly {
         //    denominator := div(denominator, twos)

--- a/v3-core/contracts/libraries/Oracle.sol
+++ b/v3-core/contracts/libraries/Oracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity >=0.5.0 <0.8.0;
+pragma solidity ^0.8.14;
 
 /// @title Oracle
 /// @notice Provides price and liquidity data useful for a wide variety of system designs
@@ -37,7 +37,7 @@ library Oracle {
         return
             Observation({
                 blockTimestamp: blockTimestamp,
-                tickCumulative: last.tickCumulative + int56(tick) * delta,
+                tickCumulative: last.tickCumulative + int56(tick) * int32(delta),
                 secondsPerLiquidityCumulativeX128: last.secondsPerLiquidityCumulativeX128 +
                     ((uint160(delta) << 128) / (liquidity > 0 ? liquidity : 1)),
                 initialized: true
@@ -274,8 +274,8 @@ library Oracle {
             uint32 targetDelta = target - beforeOrAt.blockTimestamp;
             return (
                 beforeOrAt.tickCumulative +
-                    ((atOrAfter.tickCumulative - beforeOrAt.tickCumulative) / observationTimeDelta) *
-                    targetDelta,
+                    ((atOrAfter.tickCumulative - beforeOrAt.tickCumulative) / int32(observationTimeDelta)) *
+                    int32(targetDelta),
                 beforeOrAt.secondsPerLiquidityCumulativeX128 +
                     uint160(
                         (uint256(

--- a/v3-core/contracts/libraries/Position.sol
+++ b/v3-core/contracts/libraries/Position.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity >=0.5.0 <0.8.0;
+pragma solidity ^0.8.14;
 
 import './FullMath.sol';
 import './FixedPoint128.sol';

--- a/v3-core/contracts/libraries/Tick.sol
+++ b/v3-core/contracts/libraries/Tick.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity >=0.5.0 <0.8.0;
+pragma solidity ^0.8.14;
 
 import './LowGasSafeMath.sol';
 import './SafeCast.sol';

--- a/v3-core/contracts/libraries/TickBitmap.sol
+++ b/v3-core/contracts/libraries/TickBitmap.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity >=0.5.0;
+pragma solidity ^0.8.14;
 
 import './BitMath.sol';
 
@@ -13,7 +13,7 @@ library TickBitmap {
     /// @return bitPos The bit position in the word where the flag is stored
     function position(int24 tick) private pure returns (int16 wordPos, uint8 bitPos) {
         wordPos = int16(tick >> 8);
-        bitPos = uint8(tick % 256);
+        bitPos = uint8(uint24(tick % 256));
     }
 
     /// @notice Flips the initialized state for a given tick from false to true, or vice versa
@@ -58,8 +58,8 @@ library TickBitmap {
             initialized = masked != 0;
             // overflow/underflow is possible, but prevented externally by limiting both tickSpacing and tick
             next = initialized
-                ? (compressed - int24(bitPos - BitMath.mostSignificantBit(masked))) * tickSpacing
-                : (compressed - int24(bitPos)) * tickSpacing;
+                ? (compressed - int24(uint24(bitPos - BitMath.mostSignificantBit(masked)))) * tickSpacing
+                : (compressed - int24(uint24(bitPos))) * tickSpacing;
         } else {
             // start from the word of the next tick, since the current tick state doesn't matter
             (int16 wordPos, uint8 bitPos) = position(compressed + 1);
@@ -71,8 +71,8 @@ library TickBitmap {
             initialized = masked != 0;
             // overflow/underflow is possible, but prevented externally by limiting both tickSpacing and tick
             next = initialized
-                ? (compressed + 1 + int24(BitMath.leastSignificantBit(masked) - bitPos)) * tickSpacing
-                : (compressed + 1 + int24(type(uint8).max - bitPos)) * tickSpacing;
+                ? (compressed + 1 + int24(uint24(BitMath.leastSignificantBit(masked) - bitPos))) * tickSpacing
+                : (compressed + 1 + int24(uint24(type(uint8).max - bitPos))) * tickSpacing;
         }
     }
 }

--- a/v3-core/contracts/libraries/TickMath.sol
+++ b/v3-core/contracts/libraries/TickMath.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity >=0.5.0 <0.8.0;
+pragma solidity ^0.8.14;
 
 /// @title Math library for computing sqrt prices from ticks and vice versa
 /// @notice Computes sqrt price for ticks of size 1.0001, i.e. sqrt(1.0001^tick) as fixed point Q64.96 numbers. Supports
@@ -22,7 +22,7 @@ library TickMath {
     /// at the given tick
     function getSqrtRatioAtTick(int24 tick) internal pure returns (uint160 sqrtPriceX96) {
         uint256 absTick = tick < 0 ? uint256(-int256(tick)) : uint256(int256(tick));
-        require(absTick <= uint256(MAX_TICK), 'T');
+        require(absTick <= uint256(uint24(MAX_TICK)), 'T');
 
         uint256 ratio = absTick & 0x1 != 0 ? 0xfffcb933bd6fad37aa2d162d1a594001 : 0x100000000000000000000000000000000;
         if (absTick & 0x2 != 0) ratio = (ratio * 0xfff97272373d413259a46990580e213a) >> 128;


### PR DESCRIPTION
Initially tried bumping using `solidity-upgrade` tool but it did more harm than good producing invalid code on `NoDelegateCall` and no upgrades anywhere else.

So I ended doing the bump manually, which was mostly changing implicit to explicit conversions. Also checked the code for any other breaking changes (including silent ones) according to this list [here](https://docs.soliditylang.org/en/v0.8.15/080-breaking-changes.html#how-to-update-your-code) but found none