### PR TITLE
Starknet 0.9.1 deploy command update

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -136,6 +136,7 @@ program
 interface IDeployProps_ {
   inputs?: string;
   use_cairo_abi: boolean;
+  no_wallet: boolean;
 }
 export type IDeployProps = IDeployProps_ & IOptionalNetwork & IOptionalAccount;
 
@@ -148,6 +149,7 @@ program
   )
   .option('--use_cairo_abi', 'Use the cairo abi instead of solidity for the inputs.', false)
   .option('--network <network>', 'Starknet network URL', process.env.STARKNET_NETWORK)
+  .option('--no_wallet', 'Do not use a wallet for deployment.', false)
   .action((file: string, options: IDeployProps) => {
     runStarknetDeploy(file, options);
   });

--- a/src/starknetCli.ts
+++ b/src/starknetCli.ts
@@ -95,8 +95,20 @@ export async function runStarknetDeploy(filePath: string, options: IDeployProps)
   }
 
   try {
+    let classHash = '';
+    if (!options.no_wallet) {
+      const out = execSync(
+        `${warpVenvPrefix} starknet declare --network ${options.network} --contract ${resultPath}`,
+        {
+          stdio: 'pipe',
+        },
+      ).toString();
+      classHash = out.substring(out.indexOf('0x'), out.indexOf('\n', out.indexOf('0x')));
+    }
     execSync(
-      `${warpVenvPrefix} starknet deploy --contract ${resultPath} --network ${options.network} ${inputs}`,
+      `${warpVenvPrefix} starknet deploy --network ${options.network} ${
+        options.no_wallet ? `--no_wallet --contract ${resultPath} ` : `--class_hash ${classHash}`
+      } ${inputs}`,
       {
         stdio: 'inherit',
       },


### PR DESCRIPTION
`starknet deploy` command requires `--class_hash` option now, if `--no_wallet` option is not provided. Class hash is obtained from the command `starknet declare` . Stdout of `declare` is piped so it is not visible in the terminal.