### PR TITLE
transform conditionals

### DIFF
--- a/v3-core/contracts/UniswapV3Factory.sol
+++ b/v3-core/contracts/UniswapV3Factory.sol
@@ -38,7 +38,10 @@ contract UniswapV3Factory is IUniswapV3Factory, UniswapV3PoolDeployer, NoDelegat
         uint24 fee
     ) external override noDelegateCall returns (address pool) {
         require(tokenA != tokenB);
-        (address token0, address token1) = tokenA < tokenB ? (tokenA, tokenB) : (tokenB, tokenA);
+        (address token0, address token1) = (tokenB, tokenA);
+        if (tokenA < tokenB) {
+            (token0, token1) = (tokenA, tokenB);
+        }
         require(token0 != address(0));
         int24 tickSpacing = feeAmountTickSpacing[fee];
         require(tickSpacing != 0);

--- a/v3-core/contracts/libraries/Oracle.sol
+++ b/v3-core/contracts/libraries/Oracle.sol
@@ -39,9 +39,17 @@ library Oracle {
                 blockTimestamp: blockTimestamp,
                 tickCumulative: last.tickCumulative + int56(tick) * int32(delta),
                 secondsPerLiquidityCumulativeX128: last.secondsPerLiquidityCumulativeX128 +
-                    ((uint160(delta) << 128) / (liquidity > 0 ? liquidity : 1)),
+                    ((uint160(delta) << 128) / conditional0(liquidity)),
                 initialized: true
             });
+    }
+
+    function conditional0(uint128 liquidity) internal pure returns (uint128){
+        if(liquidity > 0){
+            return liquidity;
+        } else {
+            return 1;
+        }
     }
 
     /// @notice Initialize the oracle array by writing the first slot. Called once for the lifecycle of the observations array
@@ -133,8 +141,10 @@ library Oracle {
         // if there hasn't been overflow, no need to adjust
         if (a <= time && b <= time) return a <= b;
 
-        uint256 aAdjusted = a > time ? a : a + 2**32;
-        uint256 bAdjusted = b > time ? b : b + 2**32;
+        uint256 aAdjusted = a + 2**32;
+        if(a > time) aAdjusted = a;
+        uint256 bAdjusted = b + 2**32;
+        if(b > time) bAdjusted = b;
 
         return aAdjusted <= bAdjusted;
     }

--- a/v3-core/contracts/libraries/SwapMath.sol
+++ b/v3-core/contracts/libraries/SwapMath.sol
@@ -39,9 +39,21 @@ library SwapMath {
 
         if (exactIn) {
             uint256 amountRemainingLessFee = FullMath.mulDiv(uint256(amountRemaining), 1e6 - feePips, 1e6);
-            amountIn = zeroForOne
-                ? SqrtPriceMath.getAmount0Delta(sqrtRatioTargetX96, sqrtRatioCurrentX96, liquidity, true)
-                : SqrtPriceMath.getAmount1Delta(sqrtRatioCurrentX96, sqrtRatioTargetX96, liquidity, true);
+            if (zeroForOne) {
+                amountIn = SqrtPriceMath.getAmount0Delta(
+                    sqrtRatioTargetX96,
+                    sqrtRatioCurrentX96,
+                    liquidity,
+                    true
+                );
+            } else {
+                amountIn = SqrtPriceMath.getAmount1Delta(
+                    sqrtRatioCurrentX96,
+                    sqrtRatioTargetX96,
+                    liquidity,
+                    true
+                );
+            }
             if (amountRemainingLessFee >= amountIn) sqrtRatioNextX96 = sqrtRatioTargetX96;
             else
                 sqrtRatioNextX96 = SqrtPriceMath.getNextSqrtPriceFromInput(
@@ -51,9 +63,21 @@ library SwapMath {
                     zeroForOne
                 );
         } else {
-            amountOut = zeroForOne
-                ? SqrtPriceMath.getAmount1Delta(sqrtRatioTargetX96, sqrtRatioCurrentX96, liquidity, false)
-                : SqrtPriceMath.getAmount0Delta(sqrtRatioCurrentX96, sqrtRatioTargetX96, liquidity, false);
+            if (zeroForOne) {
+                amountOut = SqrtPriceMath.getAmount1Delta(
+                    sqrtRatioTargetX96,
+                    sqrtRatioCurrentX96,
+                    liquidity,
+                    false
+                );
+            } else {
+                amountOut = SqrtPriceMath.getAmount0Delta(
+                    sqrtRatioCurrentX96,
+                    sqrtRatioTargetX96,
+                    liquidity,
+                    false
+                );
+            }
             if (uint256(-amountRemaining) >= amountOut) sqrtRatioNextX96 = sqrtRatioTargetX96;
             else
                 sqrtRatioNextX96 = SqrtPriceMath.getNextSqrtPriceFromOutput(
@@ -68,19 +92,39 @@ library SwapMath {
 
         // get the input/output amounts
         if (zeroForOne) {
-            amountIn = max && exactIn
-                ? amountIn
-                : SqrtPriceMath.getAmount0Delta(sqrtRatioNextX96, sqrtRatioCurrentX96, liquidity, true);
-            amountOut = max && !exactIn
-                ? amountOut
-                : SqrtPriceMath.getAmount1Delta(sqrtRatioNextX96, sqrtRatioCurrentX96, liquidity, false);
+            if (!(max && exactIn)) {
+                amountIn = SqrtPriceMath.getAmount0Delta(
+                    sqrtRatioNextX96,
+                    sqrtRatioCurrentX96,
+                    liquidity,
+                    true
+                );
+            }
+            if (!(max && !exactIn)) {
+                amountOut = SqrtPriceMath.getAmount1Delta(
+                    sqrtRatioNextX96,
+                    sqrtRatioCurrentX96,
+                    liquidity,
+                    false
+                );
+            }
         } else {
-            amountIn = max && exactIn
-                ? amountIn
-                : SqrtPriceMath.getAmount1Delta(sqrtRatioCurrentX96, sqrtRatioNextX96, liquidity, true);
-            amountOut = max && !exactIn
-                ? amountOut
-                : SqrtPriceMath.getAmount0Delta(sqrtRatioCurrentX96, sqrtRatioNextX96, liquidity, false);
+            if (!(max && exactIn)) {
+                amountIn = SqrtPriceMath.getAmount1Delta(
+                    sqrtRatioCurrentX96,
+                    sqrtRatioNextX96,
+                    liquidity,
+                    true
+                );
+            }
+            if (!(max && !exactIn)) {
+                amountOut = SqrtPriceMath.getAmount0Delta(
+                    sqrtRatioCurrentX96,
+                    sqrtRatioNextX96,
+                    liquidity,
+                    false
+                );
+            }
         }
 
         // cap the output amount to not exceed the remaining output amount

--- a/v3-core/contracts/libraries/Tick.sol
+++ b/v3-core/contracts/libraries/Tick.sol
@@ -144,9 +144,11 @@ library Tick {
         info.liquidityGross = liquidityGrossAfter;
 
         // when the lower (upper) tick is crossed left to right (right to left), liquidity must be added (removed)
-        info.liquidityNet = upper
-            ? int256(info.liquidityNet).sub(liquidityDelta).toInt128()
-            : int256(info.liquidityNet).add(liquidityDelta).toInt128();
+        if (upper) {
+            info.liquidityNet = int256(info.liquidityNet).sub(liquidityDelta).toInt128();
+        } else {
+            info.liquidityNet = int256(info.liquidityNet).add(liquidityDelta).toInt128();
+        }
     }
 
     /// @notice Clears tick data

--- a/v3-core/contracts/libraries/TickBitmap.sol
+++ b/v3-core/contracts/libraries/TickBitmap.sol
@@ -57,9 +57,13 @@ library TickBitmap {
             // if there are no initialized ticks to the right of or at the current tick, return rightmost in the word
             initialized = masked != 0;
             // overflow/underflow is possible, but prevented externally by limiting both tickSpacing and tick
-            next = initialized
-                ? (compressed - int24(uint24(bitPos - BitMath.mostSignificantBit(masked)))) * tickSpacing
-                : (compressed - int24(uint24(bitPos))) * tickSpacing;
+            if (initialized) {
+                next =
+                    (compressed - int24(uint24(bitPos - BitMath.mostSignificantBit(masked)))) *
+                    tickSpacing;
+            } else {
+                next = (compressed - int24(uint24(bitPos))) * tickSpacing;
+            }
         } else {
             // start from the word of the next tick, since the current tick state doesn't matter
             (int16 wordPos, uint8 bitPos) = position(compressed + 1);
@@ -70,9 +74,13 @@ library TickBitmap {
             // if there are no initialized ticks to the left of the current tick, return leftmost in the word
             initialized = masked != 0;
             // overflow/underflow is possible, but prevented externally by limiting both tickSpacing and tick
-            next = initialized
-                ? (compressed + 1 + int24(uint24(BitMath.leastSignificantBit(masked) - bitPos))) * tickSpacing
-                : (compressed + 1 + int24(uint24(type(uint8).max - bitPos))) * tickSpacing;
+            if (initialized) {
+                next =
+                    (compressed + 1 + int24(uint24(BitMath.leastSignificantBit(masked) - bitPos))) *
+                    tickSpacing;
+            } else {
+                next = (compressed + 1 + int24(uint24(type(uint8).max - bitPos))) * tickSpacing;
+            }
         }
     }
 }

--- a/v3-core/contracts/test/LowGasSafeMathEchidnaTest.sol
+++ b/v3-core/contracts/test/LowGasSafeMathEchidnaTest.sol
@@ -25,12 +25,20 @@ contract LowGasSafeMathEchidnaTest {
     function checkAddi(int256 x, int256 y) external pure {
         int256 z = LowGasSafeMath.add(x, y);
         assert(z == x + y);
-        assert(y < 0 ? z < x : z >= x);
+        if (y < 0) {
+            assert(z < x);
+        } else {
+            assert(z >= x);
+        }
     }
 
     function checkSubi(int256 x, int256 y) external pure {
         int256 z = LowGasSafeMath.sub(x, y);
         assert(z == x - y);
-        assert(y < 0 ? z > x : z <= x);
+        if (y < 0) {
+            assert(z > x);
+        } else {
+            assert(z <= x);
+        }
     }
 }

--- a/v3-core/contracts/test/OracleEchidnaTest.sol
+++ b/v3-core/contracts/test/OracleEchidnaTest.sol
@@ -99,7 +99,7 @@ contract OracleEchidnaTest {
         require(index < cardinality && index != (oracle.index() + 1) % cardinality);
 
         (uint32 blockTimestamp0, int56 tickCumulative0, , bool initialized0) =
-            oracle.observations(index == 0 ? cardinality - 1 : index - 1);
+            oracle.observations(conditional(index, cardinality));
         (uint32 blockTimestamp1, int56 tickCumulative1, , bool initialized1) = oracle.observations(index);
 
         require(initialized0);
@@ -108,6 +108,14 @@ contract OracleEchidnaTest {
         uint32 timeElapsed = blockTimestamp1 - blockTimestamp0;
         assert(timeElapsed > 0);
         assert((tickCumulative1 - tickCumulative0) % timeElapsed == 0);
+    }
+
+    function conditional(uint16 index, uint16 cardinality) internal pure returns (uint16) {
+        if (index == 0) {
+            return cardinality - 1;
+        } else {
+            return index - 1;
+        }
     }
 
     function checkTimeWeightedAveragesAlwaysFitsType(uint32 secondsAgo) external view {

--- a/v3-core/contracts/test/SqrtPriceMathEchidnaTest.sol
+++ b/v3-core/contracts/test/SqrtPriceMathEchidnaTest.sol
@@ -134,10 +134,12 @@ contract SqrtPriceMathEchidnaTest {
         uint256 numerator2 = sqrtP - sqrtQ;
         uint256 denominator = uint256(sqrtP) * sqrtQ;
 
-        uint256 safeResult =
-            roundUp
-                ? FullMath.mulDivRoundingUp(numerator1, numerator2, denominator)
-                : FullMath.mulDiv(numerator1, numerator2, denominator);
+        uint256 safeResult = 0;
+        if (roundUp) {
+            safeResult = FullMath.mulDivRoundingUp(numerator1, numerator2, denominator);
+        } else {
+            safeResult = FullMath.mulDiv(numerator1, numerator2, denominator);
+        }
         uint256 fullResult = SqrtPriceMath.getAmount0Delta(sqrtQ, sqrtP, liquidity, roundUp);
 
         assert(safeResult == fullResult);

--- a/v3-core/contracts/test/TickBitmapEchidnaTest.sol
+++ b/v3-core/contracts/test/TickBitmapEchidnaTest.sol
@@ -11,7 +11,11 @@ contract TickBitmapEchidnaTest {
     // returns whether the given tick is initialized
     function isInitialized(int24 tick) private view returns (bool) {
         (int24 next, bool initialized) = bitmap.nextInitializedTickWithinOneWord(tick, 1, true);
-        return next == tick ? initialized : false;
+        if(next == tick){
+            return initialized;
+        } else {
+            return false;
+        }
     }
 
     function flipTick(int24 tick) external {

--- a/v3-core/contracts/test/TickBitmapTest.sol
+++ b/v3-core/contracts/test/TickBitmapTest.sol
@@ -35,6 +35,10 @@ contract TickBitmapTest {
     // returns whether the given tick is initialized
     function isInitialized(int24 tick) external view returns (bool) {
         (int24 next, bool initialized) = bitmap.nextInitializedTickWithinOneWord(tick, 1, true);
-        return next == tick ? initialized : false;
+        if (next == tick) {
+            return initialized;
+        } else {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
As conditionals are still not supported, they were transformed into if statements. In cases where there was a need to create a new variable, the conditional was changed for a function call instead in order to avoid Stack too deep compiling error