### PR TITLE
Fixes for `warp deploy` command

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -148,6 +148,7 @@ interface IDeployProps_ {
   inputs?: string;
   use_cairo_abi: boolean;
   no_wallet: boolean;
+  wallet?: string;
 }
 
 export type IDeployProps = IDeployProps_ & IOptionalNetwork & IOptionalAccount & IOptionalDebugInfo;
@@ -163,6 +164,7 @@ program
   .option('--use_cairo_abi', 'Use the cairo abi instead of solidity for the inputs.', false)
   .option('--network <network>', 'Starknet network URL', process.env.STARKNET_NETWORK)
   .option('--no_wallet', 'Do not use a wallet for deployment.', false)
+  .option('--wallet <wallet>', 'Waller provider to use', undefined)
   .option('--account <account>', 'Account to use for deployment', undefined)
   .action((file: string, options: IDeployProps) => {
     runStarknetDeploy(file, options);

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,7 +164,7 @@ program
   .option('--use_cairo_abi', 'Use the cairo abi instead of solidity for the inputs.', false)
   .option('--network <network>', 'Starknet network URL', process.env.STARKNET_NETWORK)
   .option('--no_wallet', 'Do not use a wallet for deployment.', false)
-  .option('--wallet <wallet>', 'Waller provider to use', undefined)
+  .option('--wallet <wallet>', 'Waller provider to use', process.env.STARKNET_WALLET)
   .option('--account <account>', 'Account to use for deployment', undefined)
   .action((file: string, options: IDeployProps) => {
     runStarknetDeploy(file, options);

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,7 +164,7 @@ program
   .option('--use_cairo_abi', 'Use the cairo abi instead of solidity for the inputs.', false)
   .option('--network <network>', 'Starknet network URL', process.env.STARKNET_NETWORK)
   .option('--no_wallet', 'Do not use a wallet for deployment.', false)
-  .option('--wallet <wallet>', 'Waller provider to use', process.env.STARKNET_WALLET)
+  .option('--wallet <wallet>', 'Wallet provider to use', process.env.STARKNET_WALLET)
   .option('--account <account>', 'Account to use for deployment', undefined)
   .action((file: string, options: IDeployProps) => {
     runStarknetDeploy(file, options);


### PR DESCRIPTION
The `warp deploy` command internally uses `starknet declare` before it runs the `starknet deploy` command. This currently fails because the declare command needs the `--network` flag which does not get passed to it. Added a fix for the same. 

( To recreate the issue, run 
```
bin/warp deploy warp_output/tests/benchmark/BaseJumpRateModelV2__WC__BaseJumpRateModelV2.cairo --inputs 0,0,0,0,0 --network alpha-goerli
```
 on the develop branch )

If we do not specify `--no_wallet`, the deploy command errors out with the following message:
```
Error: AssertionError: A wallet must be specified (using --wallet or the STARKNET_WALLET environment variable), unless specifically using --no_wallet.
starknet deploy failed
```
To fix this, the user can either set the `STARKNET_WALLET` env variable or pass `--wallet` in the `warp deploy` command.
Added support for the `--wallet` option for deploy command.
