### PR TITLE
No longer require inputs to be quoted

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -145,7 +145,7 @@ program
   });
 
 interface IDeployProps_ {
-  inputs?: string;
+  inputs?: string[];
   use_cairo_abi: boolean;
   no_wallet: boolean;
 }
@@ -156,7 +156,7 @@ program
   .command('deploy <file>')
   .option('-d, --debug_info', 'Compile include debug information.', false)
   .option(
-    '--inputs <inputs>',
+    '--inputs <inputs...>',
     'Arguments to be passed to constructor of the program as a comma seperated list of strings, ints and lists.',
     undefined,
   )
@@ -196,7 +196,7 @@ program
 interface ICallOrInvokeProps_ {
   address: string;
   function: string;
-  inputs?: string;
+  inputs?: string[];
   use_cairo_abi: boolean;
 }
 export type ICallOrInvokeProps = ICallOrInvokeProps_ &
@@ -209,7 +209,7 @@ program
   .requiredOption('--address <address>', 'Address of contract to invoke.')
   .requiredOption('--function <function>', 'Function to invoke.')
   .option(
-    '--inputs <inputs>',
+    '--inputs <inputs...>',
     'Input to function as a comma separated string, use square brackets to represent lists and structs. Numbers can be represented in decimal and hex.',
     undefined,
   )
@@ -233,7 +233,7 @@ program
   .requiredOption('--address <address>', 'Address of contract to call.')
   .requiredOption('--function <function>', 'Function to call.')
   .option(
-    '--inputs <inputs>',
+    '--inputs <inputs...>',
     'Input to function as a comma separated string, use square brackets to represent lists and structs. Numbers can be represented in decimal and hex.',
     undefined,
   )

--- a/src/passes/abiExtractor.ts
+++ b/src/passes/abiExtractor.ts
@@ -102,10 +102,10 @@ export async function encodeInputs(
   filePath: string,
   func: string,
   useCairoABI: boolean,
-  rawInputs?: string,
+  rawInputs?: string[],
 ): Promise<[string, string]> {
   if (useCairoABI) {
-    const inputs = rawInputs ? `--inputs ${rawInputs.split(',').join(' ')}` : '';
+    const inputs = rawInputs ? `--inputs ${rawInputs.join(' ').split(',').join(' ')}` : '';
     return [func, inputs];
   }
 
@@ -115,7 +115,7 @@ export async function encodeInputs(
 
   const funcName = `${func}_${selector}`;
   const inputs = rawInputs
-    ? `--inputs ${transcodeCalldata(funcSignature, parseInputs(rawInputs))
+    ? `--inputs ${transcodeCalldata(funcSignature, parseInputs(rawInputs.join(' ')))
         .map((i) => i.toString())
         .join(' ')}`
     : '';


### PR DESCRIPTION
There was a small bug in that the inputs required the input to be a single value
which meant that the entire input had to be quoted to be passed to `--inputs`.
This updates the expectations so that the inputs are a space separated list.
We require them to be comma separated as well but this is a style choice and
can be easily changed if we wish.

The call now looks like this:

```
warp deploy --network <network> <contract> --inputs "asdf", "asdf"
```

Where as previously:
```
warp deploy --network <network> <contract> --inputs '"asdf", "asdf"'
```

Unfortunately there is a small bug in our cli library where 'array' inputs
as the one we're using for `inputs` above doesn't know when to stop parsing the
array and instead look for the next command. This means `--inputs` has
to be specified last.
