### PR TITLE
Fix --compile-cairo bug

### DIFF
--- a/src/io.ts
+++ b/src/io.ts
@@ -86,12 +86,14 @@ export function outputResult(
     formatOutput(fullCodeOutPath);
 
     if (options.compileCairo) {
-      const { resultPath, abiPath } = compileCairo(fullCodeOutPath);
-      if (resultPath) {
-        fs.unlinkSync(resultPath);
-      }
-      if (abiPath) {
-        fs.unlinkSync(abiPath);
+      const { success, resultPath, abiPath } = compileCairo(fullCodeOutPath);
+      if (!success) {
+        if (resultPath) {
+          fs.unlinkSync(resultPath);
+        }
+        if (abiPath) {
+          fs.unlinkSync(abiPath);
+        }
       }
     }
   }


### PR DESCRIPTION
The json files created from compiling the transpiled contracts were being deleted. Adds a fix. 