### PR TITLE
getContaining methods refactoring

### DIFF
--- a/src/ast/ast.ts
+++ b/src/ast/ast.ts
@@ -24,7 +24,7 @@ import { printNode } from '../utils/astPrinter';
 import { TranspileFailedError } from '../utils/errors';
 import { Implicits } from '../utils/implicits';
 import { createBlock } from '../utils/nodeTemplates';
-import { isExternalCall, mergeImports } from '../utils/utils';
+import { getContainingSourceUnit, isExternalCall, mergeImports } from '../utils/utils';
 import { CairoFunctionDefinition } from './cairoNodes';
 
 /*
@@ -140,8 +140,7 @@ export class AST {
   getContainingRoot(node: ASTNode): SourceUnit {
     if (node instanceof SourceUnit) return node;
 
-    const root = node.getClosestParentByType(SourceUnit);
-    assert(root !== undefined, `Could not find root source unit for ${printNode(node)}`);
+    const root = getContainingSourceUnit(node);
     assert(
       this.roots.includes(root),
       `Found ${printNode(root)} as root of ${printNode(node)}, but this is not in the AST roots`,
@@ -185,11 +184,7 @@ export class AST {
   }
 
   getUtilFuncGen(node: ASTNode): CairoUtilFuncGen {
-    const sourceUnit = node instanceof SourceUnit ? node : node.getClosestParentByType(SourceUnit);
-    assert(
-      sourceUnit !== undefined,
-      'Could not find the sourceUnit to attach the nodes generated functions to',
-    );
+    const sourceUnit = node instanceof SourceUnit ? node : getContainingSourceUnit(node);
     const gen = this.cairoUtilFuncGen.get(sourceUnit.id);
     if (gen === undefined) {
       const newGen = new CairoUtilFuncGen(this, sourceUnit);

--- a/src/passes/expressionSplitter/conditionalFunctionaliser.ts
+++ b/src/passes/expressionSplitter/conditionalFunctionaliser.ts
@@ -1,4 +1,3 @@
-import assert = require('assert');
 import {
   Assignment,
   ASTNode,
@@ -8,7 +7,6 @@ import {
   Expression,
   ExpressionStatement,
   FunctionCall,
-  FunctionDefinition,
   getNodeType,
   Identifier,
   IfStatement,
@@ -19,7 +17,6 @@ import {
   VariableDeclarationStatement,
 } from 'solc-typed-ast';
 import { AST } from '../../ast/ast';
-import { printNode } from '../../utils/astPrinter';
 import { cloneASTNode } from '../../utils/cloning';
 import { getDefaultValue } from '../../utils/defaultValueNodes';
 import { collectUnboundVariables, createOuterCall } from '../../utils/functionGeneration';
@@ -64,12 +61,6 @@ export function getConditionalReturnVariable(
     Mutability.Mutable,
     node.typeString,
   );
-}
-
-export function getContainingFunction(node: ASTNode): FunctionDefinition {
-  const func = node.getClosestParentByType(FunctionDefinition);
-  assert(func !== undefined, `Unable to find containing function for ${printNode(node)}`);
-  return func;
 }
 
 // The inputs to the function should be only the free variables

--- a/src/passes/expressionSplitter/expressionSplitter.ts
+++ b/src/passes/expressionSplitter/expressionSplitter.ts
@@ -26,12 +26,11 @@ import { TranspileFailedError } from '../../utils/errors';
 import { createCallToFunction, fixParameterScopes } from '../../utils/functionGeneration';
 import { SPLIT_EXPRESSION_PREFIX } from '../../utils/nameModifiers';
 import { createEmptyTuple, createIdentifier } from '../../utils/nodeTemplates';
-import { counterGenerator } from '../../utils/utils';
+import { counterGenerator, getContainingFunction } from '../../utils/utils';
 import {
   addStatementsToCallFunction,
   createFunctionBody,
   getConditionalReturnVariable,
-  getContainingFunction,
   getInputs,
   getNodeVariables,
   getParams,

--- a/src/passes/ifFunctionaliser.ts
+++ b/src/passes/ifFunctionaliser.ts
@@ -23,6 +23,7 @@ import {
   createParameterList,
   createReturn,
 } from '../utils/nodeTemplates';
+import { getContainingFunction } from '../utils/utils';
 
 export class IfFunctionaliser extends ASTMapper {
   generatedFunctionCount: Map<FunctionDefinition, number> = new Map();
@@ -90,12 +91,6 @@ function getContainingBlock(node: IfStatement): Block {
     error(`Unable to find parent of ${printNode(node)}`),
   );
   return containingFunction.vBody;
-}
-
-function getContainingFunction(node: IfStatement): FunctionDefinition {
-  const func = node.getClosestParentByType(FunctionDefinition);
-  assert(func !== undefined, `Unable to find containing function for ${printNode(node)}`);
-  return func;
 }
 
 function splitBlock(block: Block, split: Statement, ast: AST): Block {

--- a/src/passes/loopFunctionaliser/breakToReturn.ts
+++ b/src/passes/loopFunctionaliser/breakToReturn.ts
@@ -1,17 +1,12 @@
-import assert from 'assert';
-import { Break, FunctionDefinition } from 'solc-typed-ast';
+import { Break } from 'solc-typed-ast';
 import { AST } from '../../ast/ast';
 import { ASTMapper } from '../../ast/mapper';
-import { printNode } from '../../utils/astPrinter';
 import { createReturn } from '../../utils/nodeTemplates';
+import { getContainingFunction } from '../../utils/utils';
 
 export class BreakToReturn extends ASTMapper {
   visitBreak(node: Break, ast: AST): void {
-    const containingFunction = node.getClosestParentByType(FunctionDefinition);
-    assert(
-      containingFunction !== undefined,
-      `Unable to find containing function for ${printNode(node)}`,
-    );
+    const containingFunction = getContainingFunction(node);
 
     ast.replaceNode(
       node,

--- a/src/passes/loopFunctionaliser/continueToLoopCall.ts
+++ b/src/passes/loopFunctionaliser/continueToLoopCall.ts
@@ -4,6 +4,7 @@ import { AST } from '../../ast/ast';
 import { ASTMapper } from '../../ast/mapper';
 import { printNode } from '../../utils/astPrinter';
 import { createReturn } from '../../utils/nodeTemplates';
+import { getContainingFunction } from '../../utils/utils';
 import { createLoopCall } from './utils';
 
 export class ContinueToLoopCall extends ASTMapper {
@@ -12,11 +13,7 @@ export class ContinueToLoopCall extends ASTMapper {
   }
 
   visitContinue(node: Continue, ast: AST): void {
-    const containingFunction = node.getClosestParentByType(FunctionDefinition);
-    assert(
-      containingFunction !== undefined,
-      `Unable to find containing function for ${printNode(node)}`,
-    );
+    const containingFunction = getContainingFunction(node);
 
     const continueFunction = this.loopToContinueFunction.get(containingFunction.id);
     assert(

--- a/src/passes/loopFunctionaliser/returnToBreak.ts
+++ b/src/passes/loopFunctionaliser/returnToBreak.ts
@@ -26,7 +26,7 @@ import {
   createReturn,
 } from '../../utils/nodeTemplates';
 import { cloneASTNode } from '../../utils/cloning';
-import { toSingleExpression } from '../../utils/utils';
+import { getContainingFunction, toSingleExpression } from '../../utils/utils';
 import { RETURN_FLAG_PREFIX, RETURN_VALUE_PREFIX } from '../../utils/nameModifiers';
 
 export class ReturnToBreak extends ASTMapper {
@@ -134,11 +134,7 @@ export class ReturnToBreak extends ASTMapper {
   }
 
   getReturnVariables(node: ASTNode): VariableDeclaration[] {
-    const containingFunction = node.getClosestParentByType(FunctionDefinition);
-    assert(
-      containingFunction !== undefined,
-      `Could not find a containing function for ${printNode(node)}`,
-    );
+    const containingFunction = getContainingFunction(node);
 
     const retVars = this.returnVariables.get(containingFunction);
     assert(retVars !== undefined, `Could not find return variables for ${printNode(node)}`);
@@ -150,9 +146,7 @@ export class ReturnToBreak extends ASTMapper {
 let retVarCounter = 0;
 
 function insertReturnValueDeclaration(node: Block, ast: AST): VariableDeclaration[] {
-  const containingFunction = node.getClosestParentByType(FunctionDefinition);
-  assert(containingFunction !== undefined, `Unable to find containing function for ${node}`);
-
+  const containingFunction = getContainingFunction(node);
   if (containingFunction.vReturnParameters.vParameters.length === 0) {
     return [];
   }
@@ -182,11 +176,7 @@ function insertOuterLoopRetFlagCheck(
   retVars: VariableDeclaration[],
   ast: AST,
 ): void {
-  const containingFunction = node.getClosestParentByType(FunctionDefinition);
-  assert(
-    containingFunction !== undefined,
-    `Unable to find containing function for ${printNode(node)}`,
-  );
+  const containingFunction = getContainingFunction(node);
   ast.insertStatementAfter(
     node,
     new IfStatement(

--- a/src/passes/loopFunctionaliser/utils.ts
+++ b/src/passes/loopFunctionaliser/utils.ts
@@ -16,7 +16,6 @@ import {
   WhileStatement,
 } from 'solc-typed-ast';
 import { AST } from '../../ast/ast';
-import { printNode } from '../../utils/astPrinter';
 import { cloneASTNode } from '../../utils/cloning';
 import { createCallToFunction, fixParameterScopes } from '../../utils/functionGeneration';
 import { WHILE_PREFIX } from '../../utils/nameModifiers';
@@ -26,6 +25,7 @@ import {
   createParameterList,
   createReturn,
 } from '../../utils/nodeTemplates';
+import { getContainingSourceUnit } from '../../utils/utils';
 
 // It's okay to use a global counter here as it only affects private functions
 // and never anything that can be referenced from another file
@@ -40,8 +40,7 @@ export function extractWhileToFunction(
 ): FunctionDefinition {
   const scope =
     node.getClosestParentByType<ContractDefinition>(ContractDefinition) ??
-    node.getClosestParentByType(SourceUnit);
-  assert(scope !== undefined, `Couldn't find ${printNode(node)}'s function target root`);
+    getContainingSourceUnit(node);
 
   // Create input parameters and keep the new referencing number in variablesRemapping
   // for later fixing

--- a/src/passes/newToDeploy.ts
+++ b/src/passes/newToDeploy.ts
@@ -36,6 +36,7 @@ import { CONTRACT_INFIX } from '../utils/nameModifiers';
 import { printNode } from '../utils/astPrinter';
 import { TranspileFailedError } from '../utils/errors';
 import { getParameterTypes } from '../utils/nodeTypeProcessing';
+import { getContainingSourceUnit } from '../utils/utils';
 
 /** Pass that takes all expressions of the form:
  *
@@ -91,8 +92,7 @@ export class NewToDeploy extends ASTMapper {
     // Get or create placeholder for the class hash
     let placeholder = this.placeHolderMap.get(contractToCreate.name);
     if (placeholder === undefined) {
-      const sourceUnit = node.getClosestParentByType(SourceUnit);
-      assert(sourceUnit !== undefined, `Couldn not find source unit of ${printNode(node)}`);
+      const sourceUnit = getContainingSourceUnit(node);
       placeholder = this.createPlaceHolder(sourceUnit, contractToCreate, ast);
       sourceUnit.insertAtBeginning(placeholder);
       ast.setContextRecursive(placeholder);
@@ -176,8 +176,7 @@ export class NewToDeploy extends ASTMapper {
     declaredContract: ContractDefinition,
     ast: AST,
   ): VariableDeclaration {
-    const declaredContractSourceUnit = declaredContract.getClosestParentByType(SourceUnit);
-    assert(declaredContractSourceUnit !== undefined);
+    const declaredContractSourceUnit = getContainingSourceUnit(declaredContract);
 
     const declaredContractFullPath = declaredContractSourceUnit.absolutePath.split(
       new RegExp('/+|\\\\+'),

--- a/src/passes/references/expectedLocationAnalyser.ts
+++ b/src/passes/references/expectedLocationAnalyser.ts
@@ -33,7 +33,7 @@ import { TranspileFailedError } from '../../utils/errors';
 import { error } from '../../utils/formatting';
 import { getParameterTypes, isDynamicArray, isReferenceType } from '../../utils/nodeTypeProcessing';
 import { notNull } from '../../utils/typeConstructs';
-import { isExternallyVisible } from '../../utils/utils';
+import { getContainingFunction, isExternallyVisible } from '../../utils/utils';
 
 /*
 Analyses the tree top down, marking nodes with the storage location associated
@@ -212,8 +212,7 @@ export class ExpectedLocationAnalyser extends ASTMapper {
   }
 
   visitReturn(node: Return, ast: AST): void {
-    const func = node.getClosestParentByType(FunctionDefinition);
-    assert(func !== undefined, `Unable to find containing function for ${printNode(node)}`);
+    const func = getContainingFunction(node);
     if (isExternallyVisible(func)) {
       if (node.vExpression) {
         // External functions need to read out their returns

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -4,6 +4,7 @@ import {
   ArrayType,
   ArrayTypeName,
   Assignment,
+  ASTNode,
   BoolType,
   BytesType,
   CompileFailedError,
@@ -47,7 +48,7 @@ import {
 import Web3 from 'web3';
 import { AST } from '../ast/ast';
 import { isSane } from './astChecking';
-import { printTypeNode } from './astPrinter';
+import { printNode, printTypeNode } from './astPrinter';
 import {
   logError,
   NotSupportedYetError,
@@ -479,4 +480,10 @@ export function getSourceFromLocation(source: string, location: SourceLocation):
     .reduce(([s, n], c) => [[...s, `${n}  ${c}`], n + 1], [new Array<string>(), followingLineNum]);
 
   return [...previousLines, ...currentLine, ...followingLines].join('\n');
+}
+
+export function getContainingFunction(node: ASTNode): FunctionDefinition {
+  const func = node.getClosestParentByType(FunctionDefinition);
+  assert(func !== undefined, `Unable to find containing function for ${printNode(node)}`);
+  return func;
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -34,6 +34,7 @@ import {
   PointerType,
   Return,
   SourceLocation,
+  SourceUnit,
   StateVariableVisibility,
   StringType,
   StructDefinition,
@@ -486,4 +487,10 @@ export function getContainingFunction(node: ASTNode): FunctionDefinition {
   const func = node.getClosestParentByType(FunctionDefinition);
   assert(func !== undefined, `Unable to find containing function for ${printNode(node)}`);
   return func;
+}
+
+export function getContainingSourceUnit(node: ASTNode): SourceUnit {
+  const root = node.getClosestParentByType(SourceUnit);
+  assert(root !== undefined, `Unable to find root source unit for ${printNode(node)}`);
+  return root;
 }


### PR DESCRIPTION
There were many places in the code where the closest parent which was a `FunctionDefinition` was wanted and then there was an assertion checking this parent node was not `undefined`. Also there were two methods, which enclosed this behavior, so they were the same, in different parts of the code. This PR creates a method `getContainingFunction` for these cases, that is placed in the `utils` folder of the passes.
A similar situation occurred with `SourceUnit`, so a `getContainingSourceUnit` method was created the same way.