### PR TITLE
Use PAT for pushing to Github Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          personal_token: ${{ secrets.API_TOKEN_GITHUB }}
           # Build output to publish to the `gh-pages` branch:
           publish_dir: ./docs/build
           # The following lines assign commit authorship to the official


### PR DESCRIPTION
The Github workflow is failing for pushing the docusaurus site to Github Pages. 
Trying PAT instead of Github Token to see if that fixes it.