### PR TITLE
Check correct use of getNodeType methods

### DIFF
--- a/src/ast/ast.ts
+++ b/src/ast/ast.ts
@@ -7,7 +7,6 @@ import {
   Expression,
   FunctionCall,
   generalizeType,
-  getNodeType,
   Identifier,
   Mutability,
   SourceUnit,
@@ -24,6 +23,7 @@ import { printNode } from '../utils/astPrinter';
 import { TranspileFailedError } from '../utils/errors';
 import { Implicits } from '../utils/implicits';
 import { createBlock } from '../utils/nodeTemplates';
+import { safeGetNodeType } from '../utils/nodeTypeProcessing';
 import { getContainingSourceUnit, isExternalCall, mergeImports } from '../utils/utils';
 import { CairoFunctionDefinition } from './cairoNodes';
 
@@ -94,11 +94,12 @@ export class AST {
     let location: DataLocation;
     if (node instanceof FunctionCall && isExternalCall(node)) {
       location =
-        generalizeType(getNodeType(node, this.compilerVersion))[1] === undefined
+        generalizeType(safeGetNodeType(node, this.compilerVersion))[1] === undefined
           ? DataLocation.Default
           : DataLocation.CallData;
     } else {
-      location = generalizeType(getNodeType(node, this.compilerVersion))[1] ?? DataLocation.Default;
+      location =
+        generalizeType(safeGetNodeType(node, this.compilerVersion))[1] ?? DataLocation.Default;
     }
     const replacementVariable = new VariableDeclaration(
       this.tempId,

--- a/src/cairoUtilFuncGen/calldata/calldataToMemory.ts
+++ b/src/cairoUtilFuncGen/calldata/calldataToMemory.ts
@@ -1,6 +1,5 @@
 import {
   FunctionCall,
-  getNodeType,
   DataLocation,
   ArrayType,
   Expression,
@@ -21,11 +20,16 @@ import { uint256 } from '../../warplib/utils';
 import { NotSupportedYetError } from '../../utils/errors';
 import { printTypeNode } from '../../utils/astPrinter';
 import { mapRange, narrowBigIntSafe, typeNameFromTypeNode } from '../../utils/utils';
-import { getElementType, getSize, isReferenceType } from '../../utils/nodeTypeProcessing';
+import {
+  getElementType,
+  getSize,
+  isReferenceType,
+  safeGetNodeType,
+} from '../../utils/nodeTypeProcessing';
 
 export class CallDataToMemoryGen extends StringIndexedFuncGen {
   gen(node: Expression, nodeInSourceUnit?: ASTNode): FunctionCall {
-    const type = generalizeType(getNodeType(node, this.ast.compilerVersion))[0];
+    const type = generalizeType(safeGetNodeType(node, this.ast.compilerVersion))[0];
 
     const name = this.getOrCreate(type);
     const functionStub = createCairoFunctionStub(
@@ -187,7 +191,7 @@ export class CallDataToMemoryGen extends StringIndexedFuncGen {
         `    alloc_locals`,
         `    let (mem_start) = wm_alloc(${uint256(memoryType.width)})`,
         ...structDef.vMembers.map((decl): string => {
-          const memberType = getNodeType(decl, this.ast.compilerVersion);
+          const memberType = safeGetNodeType(decl, this.ast.compilerVersion);
           if (isReferenceType(memberType)) {
             const recursiveFunc = this.getOrCreate(memberType);
             const code = [

--- a/src/cairoUtilFuncGen/calldata/calldataToStorage.ts
+++ b/src/cairoUtilFuncGen/calldata/calldataToStorage.ts
@@ -6,7 +6,6 @@ import {
   DataLocation,
   Expression,
   generalizeType,
-  getNodeType,
   SourceUnit,
   StringType,
   StructDefinition,
@@ -18,7 +17,7 @@ import { printTypeNode } from '../../utils/astPrinter';
 import { CairoDynArray, CairoType, TypeConversionContext } from '../../utils/cairoTypeSystem';
 import { NotSupportedYetError } from '../../utils/errors';
 import { createCairoFunctionStub, createCallToFunction } from '../../utils/functionGeneration';
-import { getElementType } from '../../utils/nodeTypeProcessing';
+import { getElementType, safeGetNodeType } from '../../utils/nodeTypeProcessing';
 import { mapRange, narrowBigIntSafe, typeNameFromTypeNode } from '../../utils/utils';
 import { add, delegateBasedOnType, StringIndexedFuncGen } from '../base';
 import { DynArrayGen } from '../storage/dynArray';
@@ -35,8 +34,12 @@ export class CalldataToStorageGen extends StringIndexedFuncGen {
   }
 
   gen(storageLocation: Expression, calldataLocation: Expression, nodeInSourceUnit?: ASTNode) {
-    const storageType = generalizeType(getNodeType(storageLocation, this.ast.compilerVersion))[0];
-    const calldataType = generalizeType(getNodeType(calldataLocation, this.ast.compilerVersion))[0];
+    const storageType = generalizeType(
+      safeGetNodeType(storageLocation, this.ast.compilerVersion),
+    )[0];
+    const calldataType = generalizeType(
+      safeGetNodeType(calldataLocation, this.ast.compilerVersion),
+    )[0];
 
     const name = this.getOrCreate(calldataType);
     const functionStub = createCairoFunctionStub(
@@ -90,7 +93,7 @@ export class CalldataToStorageGen extends StringIndexedFuncGen {
 
     const members = structDef.vMembers.map((varDecl) => `${structName}.${varDecl.name}`);
     const copyInstructions = this.generateStructCopyInstructions(
-      structDef.vMembers.map((varDecl) => getNodeType(varDecl, this.ast.compilerVersion)),
+      structDef.vMembers.map((varDecl) => safeGetNodeType(varDecl, this.ast.compilerVersion)),
       members,
     );
 

--- a/src/cairoUtilFuncGen/calldata/externalDynArray/externalDynArrayStructConstructor.ts
+++ b/src/cairoUtilFuncGen/calldata/externalDynArray/externalDynArrayStructConstructor.ts
@@ -23,7 +23,12 @@ import { createIdentifier } from '../../../utils/nodeTemplates';
 import { FunctionStubKind } from '../../../ast/cairoNodes';
 import { typeNameFromTypeNode } from '../../../utils/utils';
 import { printTypeNode } from '../../../utils/astPrinter';
-import { getElementType, isDynamicArray, safeGetNodeType } from '../../../utils/nodeTypeProcessing';
+import {
+  getElementType,
+  isDynamicArray,
+  safeGetNodeType,
+  safeGetNodeTypeInCtx,
+} from '../../../utils/nodeTypeProcessing';
 
 const INDENT = ' '.repeat(4);
 
@@ -34,7 +39,9 @@ export class ExternalDynArrayStructConstructor extends StringIndexedFuncGen {
     astNode: VariableDeclaration | Expression,
     nodeInSourceUnit?: ASTNode,
   ): FunctionCall | undefined {
-    const type = generalizeType(safeGetNodeType(astNode, this.ast.compilerVersion))[0];
+    const type = generalizeType(
+      safeGetNodeTypeInCtx(astNode, this.ast.compilerVersion, nodeInSourceUnit ?? astNode),
+    )[0];
     assert(
       isDynamicArray(type),
       `Attempted to create dynArray struct for non-dynarray type ${printTypeNode(type)}`,
@@ -57,7 +64,7 @@ export class ExternalDynArrayStructConstructor extends StringIndexedFuncGen {
 
     if (astNode instanceof VariableDeclaration) {
       const functionInputs: Identifier[] = [
-        createIdentifier(astNode, this.ast, DataLocation.CallData),
+        createIdentifier(astNode, this.ast, DataLocation.CallData, nodeInSourceUnit ?? astNode),
       ];
       return createCallToFunction(structDefStub, functionInputs, this.ast);
     } else {

--- a/src/cairoUtilFuncGen/calldata/externalDynArray/externalDynArrayStructConstructor.ts
+++ b/src/cairoUtilFuncGen/calldata/externalDynArray/externalDynArrayStructConstructor.ts
@@ -26,7 +26,6 @@ import { printTypeNode } from '../../../utils/astPrinter';
 import {
   getElementType,
   isDynamicArray,
-  safeGetNodeType,
   safeGetNodeTypeInCtx,
 } from '../../../utils/nodeTypeProcessing';
 

--- a/src/cairoUtilFuncGen/calldata/externalDynArray/externalDynArrayStructConstructor.ts
+++ b/src/cairoUtilFuncGen/calldata/externalDynArray/externalDynArrayStructConstructor.ts
@@ -4,7 +4,6 @@ import {
   DataLocation,
   Identifier,
   FunctionStateMutability,
-  getNodeType,
   ArrayType,
   Expression,
   ASTNode,
@@ -24,7 +23,7 @@ import { createIdentifier } from '../../../utils/nodeTemplates';
 import { FunctionStubKind } from '../../../ast/cairoNodes';
 import { typeNameFromTypeNode } from '../../../utils/utils';
 import { printTypeNode } from '../../../utils/astPrinter';
-import { getElementType, isDynamicArray } from '../../../utils/nodeTypeProcessing';
+import { getElementType, isDynamicArray, safeGetNodeType } from '../../../utils/nodeTypeProcessing';
 
 const INDENT = ' '.repeat(4);
 
@@ -35,7 +34,7 @@ export class ExternalDynArrayStructConstructor extends StringIndexedFuncGen {
     astNode: VariableDeclaration | Expression,
     nodeInSourceUnit?: ASTNode,
   ): FunctionCall | undefined {
-    const type = generalizeType(getNodeType(astNode, this.ast.compilerVersion))[0];
+    const type = generalizeType(safeGetNodeType(astNode, this.ast.compilerVersion))[0];
     assert(
       isDynamicArray(type),
       `Attempted to create dynArray struct for non-dynarray type ${printTypeNode(type)}`,

--- a/src/cairoUtilFuncGen/calldata/implicitArrayConversion.ts
+++ b/src/cairoUtilFuncGen/calldata/implicitArrayConversion.ts
@@ -6,7 +6,6 @@ import {
   FixedBytesType,
   FunctionCall,
   generalizeType,
-  getNodeType,
   IntType,
   PointerType,
   SourceUnit,
@@ -16,7 +15,7 @@ import { AST } from '../../ast/ast';
 import { CairoDynArray, CairoType, TypeConversionContext } from '../../utils/cairoTypeSystem';
 import { cloneASTNode } from '../../utils/cloning';
 import { createCairoFunctionStub, createCallToFunction } from '../../utils/functionGeneration';
-import { isDynamicStorageArray } from '../../utils/nodeTypeProcessing';
+import { isDynamicStorageArray, safeGetNodeType } from '../../utils/nodeTypeProcessing';
 import { mapRange, narrowBigIntSafe, typeNameFromTypeNode } from '../../utils/utils';
 import { uint256 } from '../../warplib/utils';
 import { add, CairoFunction, StringIndexedFuncGen } from '../base';
@@ -40,8 +39,12 @@ export class ImplicitArrayConversion extends StringIndexedFuncGen {
     targetExpression: Expression,
     sourceExpression: Expression,
   ): [Expression, boolean] {
-    const targetType = generalizeType(getNodeType(targetExpression, this.ast.compilerVersion))[0];
-    const sourceType = generalizeType(getNodeType(sourceExpression, this.ast.compilerVersion))[0];
+    const targetType = generalizeType(
+      safeGetNodeType(targetExpression, this.ast.compilerVersion),
+    )[0];
+    const sourceType = generalizeType(
+      safeGetNodeType(sourceExpression, this.ast.compilerVersion),
+    )[0];
 
     if (this.checkDims(targetType, sourceType) || this.checkSizes(targetType, sourceType)) {
       return [this.gen(targetExpression, sourceExpression), true];
@@ -92,8 +95,8 @@ export class ImplicitArrayConversion extends StringIndexedFuncGen {
   }
 
   gen(lhs: Expression, rhs: Expression): FunctionCall {
-    const lhsType = getNodeType(lhs, this.ast.compilerVersion);
-    const rhsType = getNodeType(rhs, this.ast.compilerVersion);
+    const lhsType = safeGetNodeType(lhs, this.ast.compilerVersion);
+    const rhsType = safeGetNodeType(rhs, this.ast.compilerVersion);
 
     const name = this.getOrCreate(lhsType, rhsType);
 

--- a/src/cairoUtilFuncGen/enumInputCheck.ts
+++ b/src/cairoUtilFuncGen/enumInputCheck.ts
@@ -6,12 +6,12 @@ import {
   Expression,
   FunctionCall,
   FunctionStateMutability,
-  getNodeType,
   IntType,
   TypeNode,
 } from 'solc-typed-ast';
 import { FunctionStubKind } from '../ast/cairoNodes';
 import { createCairoFunctionStub, createCallToFunction } from '../utils/functionGeneration';
+import { safeGetNodeType } from '../utils/nodeTypeProcessing';
 import { typeNameFromTypeNode } from '../utils/utils';
 import { StringIndexedFuncGen } from './base';
 
@@ -22,8 +22,8 @@ export class EnumInputCheck extends StringIndexedFuncGen {
     enumDef: EnumDefinition,
     nodeInSourceUnit: ASTNode,
   ): FunctionCall {
-    const nodeType = getNodeType(node, this.ast.compilerVersion);
-    const inputType = getNodeType(nodeInput, this.ast.compilerVersion);
+    const nodeType = safeGetNodeType(node, this.ast.compilerVersion);
+    const inputType = safeGetNodeType(nodeInput, this.ast.compilerVersion);
 
     this.sourceUnit = this.ast.getContainingRoot(nodeInSourceUnit);
     const name = this.getOrCreate(inputType, enumDef);

--- a/src/cairoUtilFuncGen/inputArgCheck/inputCheck.ts
+++ b/src/cairoUtilFuncGen/inputArgCheck/inputCheck.ts
@@ -12,7 +12,6 @@ import {
   FunctionCall,
   FunctionStateMutability,
   generalizeType,
-  getNodeType,
   IntType,
   StringType,
   StructDefinition,
@@ -28,7 +27,12 @@ import { createCairoFunctionStub, createCallToFunction } from '../../utils/funct
 import { createIdentifier } from '../../utils/nodeTemplates';
 import { mapRange, narrowBigIntSafe, typeNameFromTypeNode } from '../../utils/utils';
 import { delegateBasedOnType, locationIfComplexType, StringIndexedFuncGen } from '../base';
-import { checkableType, getElementType, isDynamicArray } from '../../utils/nodeTypeProcessing';
+import {
+  checkableType,
+  getElementType,
+  isDynamicArray,
+  safeGetNodeType,
+} from '../../utils/nodeTypeProcessing';
 import { cloneASTNode } from '../../utils/cloning';
 
 export class InputCheckGen extends StringIndexedFuncGen {
@@ -43,7 +47,7 @@ export class InputCheckGen extends StringIndexedFuncGen {
       functionInput = createIdentifier(nodeInput, this.ast);
     } else {
       functionInput = cloneASTNode(nodeInput, this.ast);
-      const inputType = getNodeType(nodeInput, this.ast.compilerVersion);
+      const inputType = safeGetNodeType(nodeInput, this.ast.compilerVersion);
       this.ast.setContextRecursive(functionInput);
       isUint256 = inputType instanceof IntType && inputType.nBits === 256;
       this.requireImport('warplib.maths.utils', 'narrow_safe');
@@ -144,7 +148,7 @@ export class InputCheckGen extends StringIndexedFuncGen {
         `func ${funcName}${implicits}(arg : ${cairoType.toString()}) -> ():`,
         `alloc_locals`,
         ...structDef.vMembers.map((decl) => {
-          const memberType = getNodeType(decl, this.ast.compilerVersion);
+          const memberType = safeGetNodeType(decl, this.ast.compilerVersion);
           this.checkForImport(memberType);
           if (checkableType(memberType)) {
             const memberCheck = this.getOrCreate(memberType);

--- a/src/cairoUtilFuncGen/memory/arrayConcat.ts
+++ b/src/cairoUtilFuncGen/memory/arrayConcat.ts
@@ -3,7 +3,6 @@ import {
   DataLocation,
   FixedBytesType,
   FunctionCall,
-  getNodeType,
   IntType,
   PointerType,
   TypeName,
@@ -14,7 +13,7 @@ import { CairoType } from '../../utils/cairoTypeSystem';
 import { TranspileFailedError } from '../../utils/errors';
 import { createCairoFunctionStub, createCallToFunction } from '../../utils/functionGeneration';
 import { Implicits } from '../../utils/implicits';
-import { isDynamicArray } from '../../utils/nodeTypeProcessing';
+import { isDynamicArray, safeGetNodeType } from '../../utils/nodeTypeProcessing';
 import { mapRange, typeNameFromTypeNode } from '../../utils/utils';
 import { getIntOrFixedByteBitWidth, uint256 } from '../../warplib/utils';
 import { CairoFunction, StringIndexedFuncGen } from '../base';
@@ -23,7 +22,7 @@ export class MemoryArrayConcat extends StringIndexedFuncGen {
   gen(concat: FunctionCall) {
     const args = concat.vArguments;
     args.forEach((expr) => {
-      const exprType = getNodeType(expr, this.ast.compilerVersion);
+      const exprType = safeGetNodeType(expr, this.ast.compilerVersion);
       if (
         !isDynamicArray(exprType) &&
         !(exprType instanceof IntType || exprType instanceof FixedBytesType)
@@ -36,16 +35,16 @@ export class MemoryArrayConcat extends StringIndexedFuncGen {
 
     const inputs: [string, TypeName, DataLocation][] = mapRange(args.length, (n) => [
       `arg_${n}`,
-      typeNameFromTypeNode(getNodeType(args[n], this.ast.compilerVersion), this.ast),
+      typeNameFromTypeNode(safeGetNodeType(args[n], this.ast.compilerVersion), this.ast),
       DataLocation.Memory,
     ]);
     const output: [string, TypeName, DataLocation] = [
       'res_loc',
-      typeNameFromTypeNode(getNodeType(concat, this.ast.compilerVersion), this.ast),
+      typeNameFromTypeNode(safeGetNodeType(concat, this.ast.compilerVersion), this.ast),
       DataLocation.Memory,
     ];
 
-    const argTypes = args.map((e) => getNodeType(e, this.ast.compilerVersion));
+    const argTypes = args.map((e) => safeGetNodeType(e, this.ast.compilerVersion));
     const name = this.getOrCreate(argTypes);
 
     const implicits: Implicits[] = argTypes.some(

--- a/src/cairoUtilFuncGen/memory/arrayLiteral.ts
+++ b/src/cairoUtilFuncGen/memory/arrayLiteral.ts
@@ -6,7 +6,6 @@ import {
   FixedBytesType,
   FunctionCall,
   generalizeType,
-  getNodeType,
   Literal,
   LiteralKind,
   StringType,
@@ -18,7 +17,12 @@ import { CairoType } from '../../utils/cairoTypeSystem';
 import { cloneASTNode } from '../../utils/cloning';
 import { createCairoFunctionStub, createCallToFunction } from '../../utils/functionGeneration';
 import { createNumberLiteral, createStringTypeName } from '../../utils/nodeTemplates';
-import { getElementType, getSize, isDynamicArray } from '../../utils/nodeTypeProcessing';
+import {
+  getElementType,
+  getSize,
+  isDynamicArray,
+  safeGetNodeType,
+} from '../../utils/nodeTypeProcessing';
 import { notNull } from '../../utils/typeConstructs';
 import { mapRange, narrowBigIntSafe, typeNameFromTypeNode } from '../../utils/utils';
 import { uint256 } from '../../warplib/utils';
@@ -65,7 +69,7 @@ export class MemoryArrayLiteralGen extends StringIndexedFuncGen {
     const elements = node.vOriginalComponents.filter(notNull);
     assert(elements.length === node.vOriginalComponents.length);
 
-    const type = generalizeType(getNodeType(node, this.ast.compilerVersion))[0];
+    const type = generalizeType(safeGetNodeType(node, this.ast.compilerVersion))[0];
     assert(type instanceof ArrayType || type instanceof BytesType || type instanceof StringType);
 
     const elementT = getElementType(type);

--- a/src/cairoUtilFuncGen/memory/implicitConversion.ts
+++ b/src/cairoUtilFuncGen/memory/implicitConversion.ts
@@ -8,7 +8,6 @@ import {
   FixedBytesType,
   FunctionCall,
   generalizeType,
-  getNodeType,
   IntType,
   PointerType,
   SourceUnit,
@@ -20,7 +19,7 @@ import { printTypeNode } from '../../utils/astPrinter';
 import { CairoType, TypeConversionContext } from '../../utils/cairoTypeSystem';
 import { NotSupportedYetError, TranspileFailedError } from '../../utils/errors';
 import { createCairoFunctionStub, createCallToFunction } from '../../utils/functionGeneration';
-import { isDynamicArray } from '../../utils/nodeTypeProcessing';
+import { isDynamicArray, safeGetNodeType } from '../../utils/nodeTypeProcessing';
 import { narrowBigIntSafe, typeNameFromTypeNode } from '../../utils/utils';
 import { uint256 } from '../../warplib/utils';
 import { CairoFunction, delegateBasedOnType, StringIndexedFuncGen } from '../base';
@@ -50,7 +49,7 @@ export class MemoryImplicitConversionGen extends StringIndexedFuncGen {
   }
 
   genIfNecesary(sourceExpression: Expression, targetType: TypeNode): [Expression, boolean] {
-    const sourceType = getNodeType(sourceExpression, this.ast.compilerVersion);
+    const sourceType = safeGetNodeType(sourceExpression, this.ast.compilerVersion);
 
     const generalTarget = generalizeType(targetType)[0];
     const generalSource = generalizeType(sourceType)[0];
@@ -100,7 +99,7 @@ export class MemoryImplicitConversionGen extends StringIndexedFuncGen {
   }
 
   gen(source: Expression, targetType: TypeNode): FunctionCall {
-    const sourceType = getNodeType(source, this.ast.compilerVersion);
+    const sourceType = safeGetNodeType(source, this.ast.compilerVersion);
 
     const name = this.getOrCreate(targetType, sourceType);
 

--- a/src/cairoUtilFuncGen/memory/memoryDynArrayLength.ts
+++ b/src/cairoUtilFuncGen/memory/memoryDynArrayLength.ts
@@ -1,15 +1,10 @@
 import { AST } from '../../ast/ast';
-import {
-  MemberAccess,
-  FunctionCall,
-  DataLocation,
-  getNodeType,
-  generalizeType,
-} from 'solc-typed-ast';
+import { MemberAccess, FunctionCall, DataLocation, generalizeType } from 'solc-typed-ast';
 import { createCairoFunctionStub, createCallToFunction } from '../../utils/functionGeneration';
 import { createUint256TypeName } from '../../utils/nodeTemplates';
 import { typeNameFromTypeNode } from '../../utils/utils';
 import { CairoUtilFuncGenBase } from '../base';
+import { safeGetNodeType } from '../../utils/nodeTypeProcessing';
 
 export class MemoryDynArrayLengthGen extends CairoUtilFuncGenBase {
   getGeneratedCode(): string {
@@ -17,7 +12,7 @@ export class MemoryDynArrayLengthGen extends CairoUtilFuncGenBase {
   }
 
   gen(node: MemberAccess, ast: AST): FunctionCall {
-    const arrayType = generalizeType(getNodeType(node.vExpression, ast.compilerVersion))[0];
+    const arrayType = generalizeType(safeGetNodeType(node.vExpression, ast.compilerVersion))[0];
     const arrayTypeName = typeNameFromTypeNode(arrayType, ast);
     const functionStub = createCairoFunctionStub(
       'wm_dyn_array_length',

--- a/src/cairoUtilFuncGen/memory/memoryMemberAccess.ts
+++ b/src/cairoUtilFuncGen/memory/memoryMemberAccess.ts
@@ -3,7 +3,6 @@ import {
   MemberAccess,
   ASTNode,
   FunctionCall,
-  getNodeType,
   PointerType,
   UserDefinedType,
   VariableDeclaration,
@@ -12,6 +11,7 @@ import {
 import { CairoType, TypeConversionContext, CairoStruct } from '../../utils/cairoTypeSystem';
 import { cloneASTNode } from '../../utils/cloning';
 import { createCairoFunctionStub, createCallToFunction } from '../../utils/functionGeneration';
+import { safeGetNodeType } from '../../utils/nodeTypeProcessing';
 import { typeNameFromTypeNode, countNestedMapItems } from '../../utils/utils';
 import { CairoUtilFuncGenBase, CairoFunction, add } from '../base';
 
@@ -35,7 +35,7 @@ export class MemoryMemberAccessGen extends CairoUtilFuncGenBase {
   }
 
   gen(memberAccess: MemberAccess, nodeInSourceUnit?: ASTNode): FunctionCall {
-    const solType = getNodeType(memberAccess.vExpression, this.ast.compilerVersion);
+    const solType = safeGetNodeType(memberAccess.vExpression, this.ast.compilerVersion);
     assert(solType instanceof PointerType);
     assert(solType.to instanceof UserDefinedType);
     const structCairoType = CairoType.fromSol(

--- a/src/cairoUtilFuncGen/memory/memoryRead.ts
+++ b/src/cairoUtilFuncGen/memory/memoryRead.ts
@@ -3,7 +3,6 @@ import {
   TypeName,
   ASTNode,
   FunctionCall,
-  getNodeType,
   DataLocation,
   FunctionStateMutability,
   generalizeType,
@@ -18,7 +17,7 @@ import {
 import { cloneASTNode } from '../../utils/cloning';
 import { createCairoFunctionStub, createCallToFunction } from '../../utils/functionGeneration';
 import { createNumberLiteral, createNumberTypeName } from '../../utils/nodeTemplates';
-import { isDynamicArray } from '../../utils/nodeTypeProcessing';
+import { isDynamicArray, safeGetNodeType } from '../../utils/nodeTypeProcessing';
 import { add, locationIfComplexType, StringIndexedFuncGen } from '../base';
 import { serialiseReads } from '../serialisation';
 
@@ -30,7 +29,7 @@ import { serialiseReads } from '../serialisation';
 
 export class MemoryReadGen extends StringIndexedFuncGen {
   gen(memoryRef: Expression, type: TypeName, nodeInSourceUnit?: ASTNode): FunctionCall {
-    const valueType = generalizeType(getNodeType(memoryRef, this.ast.compilerVersion))[0];
+    const valueType = generalizeType(safeGetNodeType(memoryRef, this.ast.compilerVersion))[0];
     const resultCairoType = CairoType.fromSol(valueType, this.ast);
 
     const params: [string, TypeName, DataLocation][] = [

--- a/src/cairoUtilFuncGen/memory/memoryStruct.ts
+++ b/src/cairoUtilFuncGen/memory/memoryStruct.ts
@@ -2,7 +2,6 @@ import assert = require('assert');
 import {
   DataLocation,
   FunctionCall,
-  getNodeType,
   IdentifierPath,
   PointerType,
   StructDefinition,
@@ -11,7 +10,7 @@ import {
 import { CairoStruct, CairoType, TypeConversionContext } from '../../utils/cairoTypeSystem';
 import { cloneASTNode } from '../../utils/cloning';
 import { createCairoFunctionStub, createCallToFunction } from '../../utils/functionGeneration';
-import { typeNameToSpecializedTypeNode } from '../../utils/nodeTypeProcessing';
+import { safeGetNodeType, typeNameToSpecializedTypeNode } from '../../utils/nodeTypeProcessing';
 import { uint256 } from '../../warplib/utils';
 import { add, StringIndexedFuncGen } from '../base';
 
@@ -25,7 +24,7 @@ export class MemoryStructGen extends StringIndexedFuncGen {
     assert(structDef instanceof StructDefinition);
 
     const cairoType = CairoType.fromSol(
-      getNodeType(node, this.ast.compilerVersion),
+      safeGetNodeType(node, this.ast.compilerVersion),
       this.ast,
       TypeConversionContext.MemoryAllocation,
     );

--- a/src/cairoUtilFuncGen/memory/memoryToCalldata.ts
+++ b/src/cairoUtilFuncGen/memory/memoryToCalldata.ts
@@ -8,7 +8,6 @@ import {
   FunctionCall,
   FunctionStateMutability,
   generalizeType,
-  getNodeType,
   SourceUnit,
   StringType,
   StructDefinition,
@@ -30,6 +29,7 @@ import {
   getSize,
   isDynamicArray,
   isReferenceType,
+  safeGetNodeType,
 } from '../../utils/nodeTypeProcessing';
 import { mapRange, narrowBigIntSafe, typeNameFromTypeNode } from '../../utils/utils';
 import { uint256 } from '../../warplib/utils';
@@ -45,7 +45,7 @@ export class MemoryToCallDataGen extends StringIndexedFuncGen {
     super(ast, sourceUnit);
   }
   gen(node: Expression, nodeInSourceUnit?: ASTNode): FunctionCall {
-    const type = generalizeType(getNodeType(node, this.ast.compilerVersion))[0];
+    const type = generalizeType(safeGetNodeType(node, this.ast.compilerVersion))[0];
 
     if (isDynamicArray(type)) {
       this.dynamicArrayStructGen.gen(node, nodeInSourceUnit);
@@ -107,7 +107,7 @@ export class MemoryToCallDataGen extends StringIndexedFuncGen {
         `func ${funcName}${implicits}(mem_loc : felt) -> (retData: ${outputType.toString()}):`,
         `    alloc_locals`,
         ...structDef.vMembers.map((decl, index) => {
-          const memberType = getNodeType(decl, this.ast.compilerVersion);
+          const memberType = safeGetNodeType(decl, this.ast.compilerVersion);
           if (isReferenceType(memberType)) {
             this.requireImport('warplib.memory', 'wm_read_id');
             const allocSize = isDynamicArray(memberType)

--- a/src/cairoUtilFuncGen/memory/memoryWrite.ts
+++ b/src/cairoUtilFuncGen/memory/memoryWrite.ts
@@ -2,7 +2,6 @@ import {
   Expression,
   FunctionCall,
   TypeNode,
-  getNodeType,
   ASTNode,
   DataLocation,
   PointerType,
@@ -10,6 +9,7 @@ import {
 import { CairoFelt, CairoType, CairoUint256 } from '../../utils/cairoTypeSystem';
 import { cloneASTNode } from '../../utils/cloning';
 import { createCairoFunctionStub, createCallToFunction } from '../../utils/functionGeneration';
+import { safeGetNodeType } from '../../utils/nodeTypeProcessing';
 import { typeNameFromTypeNode } from '../../utils/utils';
 import { add, StringIndexedFuncGen } from '../base';
 
@@ -19,7 +19,7 @@ import { add, StringIndexedFuncGen } from '../base';
 */
 export class MemoryWriteGen extends StringIndexedFuncGen {
   gen(memoryRef: Expression, writeValue: Expression, nodeInSourceUnit?: ASTNode): FunctionCall {
-    const typeToWrite = getNodeType(memoryRef, this.ast.compilerVersion);
+    const typeToWrite = safeGetNodeType(memoryRef, this.ast.compilerVersion);
     const name = this.getOrCreate(typeToWrite);
     const argTypeName = typeNameFromTypeNode(typeToWrite, this.ast);
     const functionStub = createCairoFunctionStub(

--- a/src/cairoUtilFuncGen/storage/copyToStorage.ts
+++ b/src/cairoUtilFuncGen/storage/copyToStorage.ts
@@ -8,7 +8,6 @@ import {
   FixedBytesType,
   FunctionStateMutability,
   generalizeType,
-  getNodeType,
   IntType,
   SourceUnit,
   StringType,
@@ -21,7 +20,12 @@ import { printTypeNode } from '../../utils/astPrinter';
 import { CairoType, TypeConversionContext, WarpLocation } from '../../utils/cairoTypeSystem';
 import { TranspileFailedError } from '../../utils/errors';
 import { createCairoFunctionStub, createCallToFunction } from '../../utils/functionGeneration';
-import { getElementType, getSize, isReferenceType } from '../../utils/nodeTypeProcessing';
+import {
+  getElementType,
+  getSize,
+  isReferenceType,
+  safeGetNodeType,
+} from '../../utils/nodeTypeProcessing';
 import { mapRange, narrowBigIntSafe, typeNameFromTypeNode } from '../../utils/utils';
 import { uint256 } from '../../warplib/utils';
 import { add, CairoFunction, delegateBasedOnType, StringIndexedFuncGen } from '../base';
@@ -45,8 +49,8 @@ export class StorageToStorageGen extends StringIndexedFuncGen {
     super(ast, sourceUnit);
   }
   gen(to: Expression, from: Expression, nodeInSourceUnit?: ASTNode): Expression {
-    const toType = generalizeType(getNodeType(to, this.ast.compilerVersion))[0];
-    const fromType = generalizeType(getNodeType(from, this.ast.compilerVersion))[0];
+    const toType = generalizeType(safeGetNodeType(to, this.ast.compilerVersion))[0];
+    const fromType = generalizeType(safeGetNodeType(from, this.ast.compilerVersion))[0];
 
     const name = this.getOrCreate(toType, fromType);
     const functionStub = createCairoFunctionStub(
@@ -119,7 +123,7 @@ export class StorageToStorageGen extends StringIndexedFuncGen {
   private createStructCopyFunction(funcName: string, type: UserDefinedType): CairoFunction {
     const def = type.definition;
     assert(def instanceof StructDefinition);
-    const members = def.vMembers.map((decl) => getNodeType(decl, this.ast.compilerVersion));
+    const members = def.vMembers.map((decl) => safeGetNodeType(decl, this.ast.compilerVersion));
 
     let offset = 0;
     return {

--- a/src/cairoUtilFuncGen/storage/dynArrayIndexAccess.ts
+++ b/src/cairoUtilFuncGen/storage/dynArrayIndexAccess.ts
@@ -3,7 +3,6 @@ import {
   ASTNode,
   DataLocation,
   FunctionCall,
-  getNodeType,
   IndexAccess,
   PointerType,
   SourceUnit,
@@ -13,7 +12,7 @@ import { AST } from '../../ast/ast';
 import { CairoType, TypeConversionContext } from '../../utils/cairoTypeSystem';
 import { createCairoFunctionStub, createCallToFunction } from '../../utils/functionGeneration';
 import { createUint256TypeName } from '../../utils/nodeTemplates';
-import { isDynamicArray } from '../../utils/nodeTypeProcessing';
+import { isDynamicArray, safeGetNodeType } from '../../utils/nodeTypeProcessing';
 import { typeNameFromTypeNode } from '../../utils/utils';
 import { StringIndexedFuncGen } from '../base';
 import { DynArrayGen } from './dynArray';
@@ -28,8 +27,8 @@ export class DynArrayIndexAccessGen extends StringIndexedFuncGen {
     const index = node.vIndexExpression;
     assert(index !== undefined);
 
-    const nodeType = getNodeType(node, this.ast.compilerVersion);
-    const baseType = getNodeType(base, this.ast.compilerVersion);
+    const nodeType = safeGetNodeType(node, this.ast.compilerVersion);
+    const baseType = safeGetNodeType(base, this.ast.compilerVersion);
 
     assert(baseType instanceof PointerType && isDynamicArray(baseType.to));
     const name = this.getOrCreate(nodeType);

--- a/src/cairoUtilFuncGen/storage/dynArrayPop.ts
+++ b/src/cairoUtilFuncGen/storage/dynArrayPop.ts
@@ -6,7 +6,6 @@ import {
   DataLocation,
   FunctionCall,
   generalizeType,
-  getNodeType,
   MemberAccess,
   SourceUnit,
   StringType,
@@ -15,7 +14,12 @@ import {
 import { AST } from '../../ast/ast';
 import { CairoType, TypeConversionContext } from '../../utils/cairoTypeSystem';
 import { createCairoFunctionStub, createCallToFunction } from '../../utils/functionGeneration';
-import { getElementType, isDynamicArray, isMapping } from '../../utils/nodeTypeProcessing';
+import {
+  getElementType,
+  isDynamicArray,
+  isMapping,
+  safeGetNodeType,
+} from '../../utils/nodeTypeProcessing';
 import { typeNameFromTypeNode } from '../../utils/utils';
 import { StringIndexedFuncGen } from '../base';
 import { DynArrayGen } from './dynArray';
@@ -34,7 +38,7 @@ export class DynArrayPopGen extends StringIndexedFuncGen {
   gen(pop: FunctionCall, nodeInSourceUnit?: ASTNode): FunctionCall {
     assert(pop.vExpression instanceof MemberAccess);
     const arrayType = generalizeType(
-      getNodeType(pop.vExpression.vExpression, this.ast.compilerVersion),
+      safeGetNodeType(pop.vExpression.vExpression, this.ast.compilerVersion),
     )[0];
     assert(
       arrayType instanceof ArrayType ||

--- a/src/cairoUtilFuncGen/storage/dynArrayPushWithArg.ts
+++ b/src/cairoUtilFuncGen/storage/dynArrayPushWithArg.ts
@@ -7,7 +7,6 @@ import {
   DataLocation,
   FunctionCall,
   generalizeType,
-  getNodeType,
   MemberAccess,
   SourceUnit,
   StringType,
@@ -24,7 +23,12 @@ import { StorageWriteGen } from './storageWrite';
 import { StorageToStorageGen } from './copyToStorage';
 import { CalldataToStorageGen } from '../calldata/calldataToStorage';
 import { Implicits } from '../../utils/implicits';
-import { getElementType, isDynamicArray, specializeType } from '../../utils/nodeTypeProcessing';
+import {
+  getElementType,
+  isDynamicArray,
+  safeGetNodeType,
+  specializeType,
+} from '../../utils/nodeTypeProcessing';
 import { ImplicitArrayConversion } from '../calldata/implicitArrayConversion';
 
 export class DynArrayPushWithArgGen extends StringIndexedFuncGen {
@@ -44,7 +48,7 @@ export class DynArrayPushWithArgGen extends StringIndexedFuncGen {
   gen(push: FunctionCall, nodeInSourceUnit?: ASTNode): FunctionCall {
     assert(push.vExpression instanceof MemberAccess);
     const arrayType = generalizeType(
-      getNodeType(push.vExpression.vExpression, this.ast.compilerVersion),
+      safeGetNodeType(push.vExpression.vExpression, this.ast.compilerVersion),
     )[0];
     assert(
       arrayType instanceof ArrayType ||
@@ -57,7 +61,7 @@ export class DynArrayPushWithArgGen extends StringIndexedFuncGen {
       `Attempted to treat push without argument as push with argument`,
     );
     const [argType, argLoc] = generalizeType(
-      getNodeType(push.vArguments[0], this.ast.compilerVersion),
+      safeGetNodeType(push.vArguments[0], this.ast.compilerVersion),
     );
 
     const name = this.getOrCreate(

--- a/src/cairoUtilFuncGen/storage/dynArrayPushWithoutArg.ts
+++ b/src/cairoUtilFuncGen/storage/dynArrayPushWithoutArg.ts
@@ -1,15 +1,9 @@
 import assert from 'assert';
-import {
-  ASTNode,
-  DataLocation,
-  FunctionCall,
-  getNodeType,
-  MemberAccess,
-  SourceUnit,
-} from 'solc-typed-ast';
+import { ASTNode, DataLocation, FunctionCall, MemberAccess, SourceUnit } from 'solc-typed-ast';
 import { AST } from '../../ast/ast';
 import { CairoType, TypeConversionContext } from '../../utils/cairoTypeSystem';
 import { createCairoFunctionStub, createCallToFunction } from '../../utils/functionGeneration';
+import { safeGetNodeType } from '../../utils/nodeTypeProcessing';
 import { typeNameFromTypeNode } from '../../utils/utils';
 import { StringIndexedFuncGen } from '../base';
 import { DynArrayGen } from './dynArray';
@@ -21,8 +15,8 @@ export class DynArrayPushWithoutArgGen extends StringIndexedFuncGen {
 
   gen(push: FunctionCall, nodeInSourceUnit?: ASTNode): FunctionCall {
     assert(push.vExpression instanceof MemberAccess);
-    const arrayType = getNodeType(push.vExpression.vExpression, this.ast.compilerVersion);
-    const elementType = getNodeType(push, this.ast.compilerVersion);
+    const arrayType = safeGetNodeType(push.vExpression.vExpression, this.ast.compilerVersion);
+    const elementType = safeGetNodeType(push, this.ast.compilerVersion);
 
     const name = this.getOrCreate(
       CairoType.fromSol(elementType, this.ast, TypeConversionContext.StorageAllocation),

--- a/src/cairoUtilFuncGen/storage/mappingIndexAccess.ts
+++ b/src/cairoUtilFuncGen/storage/mappingIndexAccess.ts
@@ -5,7 +5,6 @@ import {
   Expression,
   FunctionCall,
   generalizeType,
-  getNodeType,
   IndexAccess,
   MappingType,
   PointerType,
@@ -15,7 +14,7 @@ import { AST } from '../../ast/ast';
 import { CairoType, TypeConversionContext } from '../../utils/cairoTypeSystem';
 import { createCairoFunctionStub, createCallToFunction } from '../../utils/functionGeneration';
 import { createUint8TypeName } from '../../utils/nodeTemplates';
-import { isReferenceType } from '../../utils/nodeTypeProcessing';
+import { isReferenceType, safeGetNodeType } from '../../utils/nodeTypeProcessing';
 import { typeNameFromTypeNode } from '../../utils/utils';
 import { locationIfComplexType, StringIndexedFuncGen } from '../base';
 import { DynArrayGen } from './dynArray';
@@ -32,8 +31,8 @@ export class MappingIndexAccessGen extends StringIndexedFuncGen {
     let index = node.vIndexExpression;
     assert(index !== undefined);
 
-    const nodeType = getNodeType(node, this.ast.compilerVersion);
-    const baseType = getNodeType(base, this.ast.compilerVersion);
+    const nodeType = safeGetNodeType(node, this.ast.compilerVersion);
+    const baseType = safeGetNodeType(base, this.ast.compilerVersion);
 
     assert(baseType instanceof PointerType && baseType.to instanceof MappingType);
 
@@ -45,7 +44,7 @@ export class MappingIndexAccessGen extends StringIndexedFuncGen {
     );
 
     if (isReferenceType(baseType.to.keyType)) {
-      const stringLoc = generalizeType(getNodeType(index, this.ast.compilerVersion))[1];
+      const stringLoc = generalizeType(safeGetNodeType(index, this.ast.compilerVersion))[1];
       assert(stringLoc !== undefined);
       const call = this.createStringHashFunction(node, stringLoc, indexCairoType);
       index = call;
@@ -121,7 +120,7 @@ export class MappingIndexAccessGen extends StringIndexedFuncGen {
     indexCairoType: CairoType,
   ): FunctionCall {
     assert(node.vIndexExpression instanceof Expression);
-    const indexType = getNodeType(node.vIndexExpression, this.ast.compilerVersion);
+    const indexType = safeGetNodeType(node.vIndexExpression, this.ast.compilerVersion);
     const indexTypeName = typeNameFromTypeNode(indexType, this.ast);
     if (loc === DataLocation.CallData) {
       const stub = createCairoFunctionStub(

--- a/src/cairoUtilFuncGen/storage/staticArrayIndexAccess.ts
+++ b/src/cairoUtilFuncGen/storage/staticArrayIndexAccess.ts
@@ -4,13 +4,13 @@ import {
   ASTNode,
   DataLocation,
   FunctionCall,
-  getNodeType,
   IndexAccess,
   PointerType,
 } from 'solc-typed-ast';
 import { CairoType, TypeConversionContext } from '../../utils/cairoTypeSystem';
 import { createCairoFunctionStub, createCallToFunction } from '../../utils/functionGeneration';
 import { createNumberLiteral, createUint256TypeName } from '../../utils/nodeTemplates';
+import { safeGetNodeType } from '../../utils/nodeTypeProcessing';
 import { typeNameFromTypeNode } from '../../utils/utils';
 import { CairoUtilFuncGenBase } from '../base';
 
@@ -26,14 +26,14 @@ export class StorageStaticArrayIndexAccessGen extends CairoUtilFuncGenBase {
 
     const name = this.getOrCreate();
 
-    const arrayType = getNodeType(node.vBaseExpression, this.ast.compilerVersion);
+    const arrayType = safeGetNodeType(node.vBaseExpression, this.ast.compilerVersion);
     assert(
       arrayType instanceof PointerType &&
         arrayType.to instanceof ArrayType &&
         arrayType.to.size !== undefined,
     );
 
-    const valueType = getNodeType(node, this.ast.compilerVersion);
+    const valueType = safeGetNodeType(node, this.ast.compilerVersion);
 
     const functionStub = createCairoFunctionStub(
       name,

--- a/src/cairoUtilFuncGen/storage/storageDelete.ts
+++ b/src/cairoUtilFuncGen/storage/storageDelete.ts
@@ -7,7 +7,6 @@ import {
   Expression,
   FunctionCall,
   generalizeType,
-  getNodeType,
   MappingType,
   PointerType,
   SourceUnit,
@@ -19,7 +18,7 @@ import { AST } from '../../ast/ast';
 import { CairoType, TypeConversionContext } from '../../utils/cairoTypeSystem';
 import { TranspileFailedError } from '../../utils/errors';
 import { createCairoFunctionStub, createCallToFunction } from '../../utils/functionGeneration';
-import { getElementType, isDynamicArray } from '../../utils/nodeTypeProcessing';
+import { getElementType, isDynamicArray, safeGetNodeType } from '../../utils/nodeTypeProcessing';
 import { typeNameFromTypeNode, mapRange, narrowBigIntSafe } from '../../utils/utils';
 import { uint256 } from '../../warplib/utils';
 import { add, CairoFunction, delegateBasedOnType, StringIndexedFuncGen } from '../base';
@@ -39,7 +38,7 @@ export class StorageDeleteGen extends StringIndexedFuncGen {
   }
 
   gen(node: Expression, nodeInSourceUnit?: ASTNode): FunctionCall {
-    const nodeType = dereferenceType(getNodeType(node, this.ast.compilerVersion));
+    const nodeType = dereferenceType(safeGetNodeType(node, this.ast.compilerVersion));
 
     const functionName = this.getOrCreate(nodeType);
 
@@ -240,7 +239,7 @@ export class StorageDeleteGen extends StringIndexedFuncGen {
       `func ${funcName}${implicits}(loc : felt):`,
       `   alloc_locals`,
       ...this.generateStructDeletionCode(
-        structDef.vMembers.map((varDecl) => getNodeType(varDecl, this.ast.compilerVersion)),
+        structDef.vMembers.map((varDecl) => safeGetNodeType(varDecl, this.ast.compilerVersion)),
       ),
       `   return ()`,
       `end`,

--- a/src/cairoUtilFuncGen/storage/storageMemberAccess.ts
+++ b/src/cairoUtilFuncGen/storage/storageMemberAccess.ts
@@ -3,7 +3,6 @@ import {
   MemberAccess,
   ASTNode,
   FunctionCall,
-  getNodeType,
   PointerType,
   UserDefinedType,
   VariableDeclaration,
@@ -12,6 +11,7 @@ import {
 import { CairoType, TypeConversionContext, CairoStruct } from '../../utils/cairoTypeSystem';
 import { cloneASTNode } from '../../utils/cloning';
 import { createCairoFunctionStub, createCallToFunction } from '../../utils/functionGeneration';
+import { safeGetNodeType } from '../../utils/nodeTypeProcessing';
 import { typeNameFromTypeNode, countNestedMapItems } from '../../utils/utils';
 import { CairoUtilFuncGenBase, CairoFunction, add } from '../base';
 
@@ -27,7 +27,7 @@ export class StorageMemberAccessGen extends CairoUtilFuncGenBase {
   }
 
   gen(memberAccess: MemberAccess, nodeInSourceUnit?: ASTNode): FunctionCall {
-    const solType = getNodeType(memberAccess.vExpression, this.ast.compilerVersion);
+    const solType = safeGetNodeType(memberAccess.vExpression, this.ast.compilerVersion);
     assert(solType instanceof PointerType);
     assert(solType.to instanceof UserDefinedType);
     const structCairoType = CairoType.fromSol(

--- a/src/cairoUtilFuncGen/storage/storageRead.ts
+++ b/src/cairoUtilFuncGen/storage/storageRead.ts
@@ -2,7 +2,6 @@ import {
   Expression,
   TypeName,
   FunctionCall,
-  getNodeType,
   DataLocation,
   FunctionStateMutability,
   TypeNode,
@@ -11,12 +10,13 @@ import {
 import { CairoType, TypeConversionContext } from '../../utils/cairoTypeSystem';
 import { cloneASTNode } from '../../utils/cloning';
 import { createCairoFunctionStub, createCallToFunction } from '../../utils/functionGeneration';
+import { safeGetNodeType } from '../../utils/nodeTypeProcessing';
 import { add, locationIfComplexType, StringIndexedFuncGen } from '../base';
 import { serialiseReads } from '../serialisation';
 
 export class StorageReadGen extends StringIndexedFuncGen {
   gen(storageLocation: Expression, type: TypeName, nodeInSourceUnit?: ASTNode): FunctionCall {
-    const valueType = getNodeType(storageLocation, this.ast.compilerVersion);
+    const valueType = safeGetNodeType(storageLocation, this.ast.compilerVersion);
     const resultCairoType = CairoType.fromSol(
       valueType,
       this.ast,

--- a/src/cairoUtilFuncGen/storage/storageToCalldata.ts
+++ b/src/cairoUtilFuncGen/storage/storageToCalldata.ts
@@ -5,7 +5,6 @@ import {
   DataLocation,
   Expression,
   generalizeType,
-  getNodeType,
   SourceUnit,
   StringType,
   StructDefinition,
@@ -17,7 +16,7 @@ import { printTypeNode } from '../../utils/astPrinter';
 import { CairoDynArray, CairoType, TypeConversionContext } from '../../utils/cairoTypeSystem';
 import { NotSupportedYetError } from '../../utils/errors';
 import { createCairoFunctionStub, createCallToFunction } from '../../utils/functionGeneration';
-import { getElementType } from '../../utils/nodeTypeProcessing';
+import { getElementType, safeGetNodeType } from '../../utils/nodeTypeProcessing';
 import { mapRange, narrowBigIntSafe, typeNameFromTypeNode } from '../../utils/utils';
 import { add, delegateBasedOnType, StringIndexedFuncGen } from '../base';
 import { ExternalDynArrayStructConstructor } from '../calldata/externalDynArray/externalDynArrayStructConstructor';
@@ -36,7 +35,9 @@ export class StorageToCalldataGen extends StringIndexedFuncGen {
   }
 
   gen(storageLocation: Expression) {
-    const storageType = generalizeType(getNodeType(storageLocation, this.ast.compilerVersion))[0];
+    const storageType = generalizeType(
+      safeGetNodeType(storageLocation, this.ast.compilerVersion),
+    )[0];
 
     const name = this.getOrCreate(storageType);
     const functionStub = createCairoFunctionStub(
@@ -87,7 +88,7 @@ export class StorageToCalldataGen extends StringIndexedFuncGen {
     const structName = `struct_${cairoStruct.toString()}`;
 
     const [copyInstructions, members] = this.generateStructCopyInstructions(
-      structDef.vMembers.map((varDecl) => getNodeType(varDecl, this.ast.compilerVersion)),
+      structDef.vMembers.map((varDecl) => safeGetNodeType(varDecl, this.ast.compilerVersion)),
       'member',
     );
 

--- a/src/cairoUtilFuncGen/storage/storageToMemory.ts
+++ b/src/cairoUtilFuncGen/storage/storageToMemory.ts
@@ -7,7 +7,6 @@ import {
   Expression,
   FunctionStateMutability,
   generalizeType,
-  getNodeType,
   SourceUnit,
   StringType,
   StructDefinition,
@@ -19,7 +18,7 @@ import { printTypeNode } from '../../utils/astPrinter';
 import { CairoType, TypeConversionContext } from '../../utils/cairoTypeSystem';
 import { NotSupportedYetError } from '../../utils/errors';
 import { createCairoFunctionStub, createCallToFunction } from '../../utils/functionGeneration';
-import { getElementType, isDynamicArray } from '../../utils/nodeTypeProcessing';
+import { getElementType, isDynamicArray, safeGetNodeType } from '../../utils/nodeTypeProcessing';
 import { mapRange, narrowBigIntSafe, typeNameFromTypeNode } from '../../utils/utils';
 import { uint256 } from '../../warplib/utils';
 import { add, delegateBasedOnType, StringIndexedFuncGen } from '../base';
@@ -37,7 +36,7 @@ export class StorageToMemoryGen extends StringIndexedFuncGen {
     super(ast, sourceUnit);
   }
   gen(node: Expression, nodeInSourceUnit?: ASTNode): Expression {
-    const type = generalizeType(getNodeType(node, this.ast.compilerVersion))[0];
+    const type = generalizeType(safeGetNodeType(node, this.ast.compilerVersion))[0];
 
     const name = this.getOrCreate(type);
     const functionStub = createCairoFunctionStub(
@@ -336,7 +335,7 @@ function generateCopyInstructions(type: TypeNode, ast: AST): CopyInstruction[] {
   let members: TypeNode[];
 
   if (type instanceof UserDefinedType && type.definition instanceof StructDefinition) {
-    members = type.definition.vMembers.map((decl) => getNodeType(decl, ast.compilerVersion));
+    members = type.definition.vMembers.map((decl) => safeGetNodeType(decl, ast.compilerVersion));
   } else if (type instanceof ArrayType && type.size !== undefined) {
     const narrowedWidth = narrowBigIntSafe(type.size, `Array size ${type.size} not supported`);
     members = mapRange(narrowedWidth, () => type.elementT);

--- a/src/cairoUtilFuncGen/storage/storageWrite.ts
+++ b/src/cairoUtilFuncGen/storage/storageWrite.ts
@@ -2,7 +2,6 @@ import {
   Expression,
   FunctionCall,
   TypeNode,
-  getNodeType,
   ASTNode,
   DataLocation,
   PointerType,
@@ -10,6 +9,7 @@ import {
 import { CairoType, TypeConversionContext } from '../../utils/cairoTypeSystem';
 import { cloneASTNode } from '../../utils/cloning';
 import { createCairoFunctionStub, createCallToFunction } from '../../utils/functionGeneration';
+import { safeGetNodeType } from '../../utils/nodeTypeProcessing';
 import { typeNameFromTypeNode } from '../../utils/utils';
 import { add, StringIndexedFuncGen } from '../base';
 
@@ -19,7 +19,7 @@ export class StorageWriteGen extends StringIndexedFuncGen {
     writeValue: Expression,
     nodeInSourceUnit?: ASTNode,
   ): FunctionCall {
-    const typeToWrite = getNodeType(storageLocation, this.ast.compilerVersion);
+    const typeToWrite = safeGetNodeType(storageLocation, this.ast.compilerVersion);
     const name = this.getOrCreate(typeToWrite);
     const argTypeName = typeNameFromTypeNode(typeToWrite, this.ast);
     const functionStub = createCairoFunctionStub(

--- a/src/cairoUtilFuncGen/utils/encodeToFelt.ts
+++ b/src/cairoUtilFuncGen/utils/encodeToFelt.ts
@@ -6,7 +6,6 @@ import {
   Expression,
   FunctionCall,
   generalizeType,
-  getNodeType,
   SourceUnit,
   StringType,
   StructDefinition,
@@ -31,6 +30,7 @@ import {
   isDynamicArray,
   isStruct,
   isValueType,
+  safeGetNodeType,
 } from '../../utils/nodeTypeProcessing';
 import { mapRange, narrowBigIntSafe, typeNameFromTypeNode } from '../../utils/utils';
 import { CairoFunction, delegateBasedOnType, StringIndexedFuncGen } from '../base';
@@ -273,7 +273,7 @@ export class EncodeAsFelt extends StringIndexedFuncGen {
     assert(type.definition instanceof StructDefinition);
 
     const encodeCode = type.definition.vMembers.map((varDecl, index) => {
-      const varType = getNodeType(varDecl, this.ast.compilerVersion);
+      const varType = safeGetNodeType(varDecl, this.ast.compilerVersion);
       return [
         `let member_${index} = from_struct.${varDecl.name}`,
         ...this.generateEncodeCode(varType, `member_${index}`),

--- a/src/passes/ReturnVariableInitializer.ts
+++ b/src/passes/ReturnVariableInitializer.ts
@@ -1,9 +1,10 @@
-import { FunctionDefinition, getNodeType, VariableDeclarationStatement } from 'solc-typed-ast';
+import { FunctionDefinition, VariableDeclarationStatement } from 'solc-typed-ast';
 import { AST } from '../ast/ast';
 import { ASTMapper } from '../ast/mapper';
 import { cloneASTNode } from '../utils/cloning';
 import { getDefaultValue } from '../utils/defaultValueNodes';
 import { collectUnboundVariables } from '../utils/functionGeneration';
+import { safeGetNodeType } from '../utils/nodeTypeProcessing';
 
 export class ReturnVariableInitializer extends ASTMapper {
   // Function to add passes that should have been run before this pass
@@ -26,7 +27,7 @@ export class ReturnVariableInitializer extends ASTMapper {
           '',
           [newDecl.id],
           [newDecl],
-          getDefaultValue(getNodeType(decl, ast.compilerVersion), newDecl, ast),
+          getDefaultValue(safeGetNodeType(decl, ast.compilerVersion), newDecl, ast),
         );
         identifiers.forEach((identifier) => {
           identifier.referencedDeclaration = newDecl.id;

--- a/src/passes/abiExtractor.ts
+++ b/src/passes/abiExtractor.ts
@@ -1,14 +1,7 @@
 import assert from 'assert';
 import { readFileSync } from 'fs';
 import prompts from 'prompts';
-import {
-  ArrayType,
-  ArrayTypeName,
-  generalizeType,
-  getNodeType,
-  Literal,
-  SourceUnit,
-} from 'solc-typed-ast';
+import { ArrayType, ArrayTypeName, generalizeType, Literal, SourceUnit } from 'solc-typed-ast';
 import Web3 from 'web3';
 import { AST } from '../ast/ast';
 import { ASTMapper } from '../ast/mapper';
@@ -18,6 +11,7 @@ import { CLIError } from '../utils/errors';
 import { parse } from '../utils/functionSignatureParser';
 import { generateLiteralTypeString } from '../utils/getTypeString';
 import { createDefaultConstructor, createNumberLiteral } from '../utils/nodeTemplates';
+import { safeGetNodeType } from '../utils/nodeTypeProcessing';
 import { isExternallyVisible } from '../utils/utils';
 
 type Input = (string | number | Input)[];
@@ -64,7 +58,7 @@ export class ABIExtractor extends ASTMapper {
     this.commonVisit(node, ast);
 
     if (node.vLength !== undefined && !(node.vLength instanceof Literal)) {
-      const type = generalizeType(getNodeType(node, ast.compilerVersion))[0];
+      const type = generalizeType(safeGetNodeType(node, ast.compilerVersion))[0];
       assert(
         type instanceof ArrayType,
         `${printNode(node)} ${node.typeString} has non-array type ${printTypeNode(type, true)}`,

--- a/src/passes/argBoundChecker.ts
+++ b/src/passes/argBoundChecker.ts
@@ -4,7 +4,6 @@ import {
   ContractKind,
   FunctionDefinition,
   FunctionCall,
-  getNodeType,
   FunctionCallKind,
   EnumDefinition,
   IntType,
@@ -13,7 +12,7 @@ import { ASTMapper } from '../ast/mapper';
 import { isExternallyVisible } from '../utils/utils';
 import assert from 'assert';
 import { createExpressionStatement } from '../utils/nodeTemplates';
-import { checkableType } from '../utils/nodeTypeProcessing';
+import { checkableType, safeGetNodeType } from '../utils/nodeTypeProcessing';
 export class ArgBoundChecker extends ASTMapper {
   // Function to add passes that should have been run before this pass
   addInitialPassPrerequisites(): void {
@@ -31,7 +30,7 @@ export class ArgBoundChecker extends ASTMapper {
   visitFunctionDefinition(node: FunctionDefinition, ast: AST): void {
     if (isExternallyVisible(node) && node.vBody !== undefined) {
       node.vParameters.vParameters.forEach((decl) => {
-        const type = getNodeType(decl, ast.compilerVersion);
+        const type = safeGetNodeType(decl, ast.compilerVersion);
         if (checkableType(type)) {
           const functionCall = ast
             .getUtilFuncGen(node)
@@ -56,7 +55,7 @@ export class ArgBoundChecker extends ASTMapper {
     if (
       node.kind === FunctionCallKind.TypeConversion &&
       node.vReferencedDeclaration instanceof EnumDefinition &&
-      getNodeType(node.vArguments[0], ast.compilerVersion) instanceof IntType
+      safeGetNodeType(node.vArguments[0], ast.compilerVersion) instanceof IntType
     ) {
       const enumDef = node.vReferencedDeclaration;
       const enumCheckFuncCall = ast

--- a/src/passes/builtinHandler/explicitConversionToFunc.ts
+++ b/src/passes/builtinHandler/explicitConversionToFunc.ts
@@ -9,7 +9,6 @@ import {
   FunctionCall,
   FunctionCallKind,
   generalizeType,
-  getNodeType,
   IntLiteralType,
   IntType,
   Literal,
@@ -29,13 +28,14 @@ import { functionaliseIntConversion } from '../../warplib/implementations/conver
 import { createCairoFunctionStub, createCallToFunction } from '../../utils/functionGeneration';
 import { functionaliseFixedBytesConversion } from '../../warplib/implementations/conversions/fixedBytes';
 import { functionaliseBytesToFixedBytes } from '../../warplib/implementations/conversions/dynBytesToFixed';
+import { safeGetNodeType } from '../../utils/nodeTypeProcessing';
 
 export class ExplicitConversionToFunc extends ASTMapper {
   visitFunctionCall(node: FunctionCall, ast: AST): void {
     this.commonVisit(node, ast);
     if (node.kind !== FunctionCallKind.TypeConversion) return;
 
-    const typeNameType = getNodeType(node.vExpression, ast.compilerVersion);
+    const typeNameType = safeGetNodeType(node.vExpression, ast.compilerVersion);
 
     assert(node.vArguments.length === 1, `Expecting typeconversion to have one child`);
 
@@ -62,7 +62,7 @@ export class ExplicitConversionToFunc extends ASTMapper {
       `Unexpected node type ${node.vExpression.type}`,
     );
     const typeTo = generalizeType(typeNameType.type)[0];
-    const argType = generalizeType(getNodeType(node.vArguments[0], ast.compilerVersion))[0];
+    const argType = generalizeType(safeGetNodeType(node.vArguments[0], ast.compilerVersion))[0];
 
     if (typeTo instanceof IntType) {
       if (argType instanceof FixedBytesType) {

--- a/src/passes/builtinHandler/thisKeyword.ts
+++ b/src/passes/builtinHandler/thisKeyword.ts
@@ -2,7 +2,6 @@ import {
   ContractDefinition,
   ContractKind,
   FunctionCall,
-  getNodeType,
   Identifier,
   MemberAccess,
   SourceUnit,
@@ -17,6 +16,7 @@ import {
   getTemporaryInterfaceName,
 } from '../externalContractHandler/externalContractInterfaceInserter';
 import { assert } from 'console';
+import { safeGetNodeType } from '../../utils/nodeTypeProcessing';
 
 export class ThisKeyword extends ASTMapper {
   visitIdentifier(node: Identifier, ast: AST): void {
@@ -25,7 +25,7 @@ export class ThisKeyword extends ASTMapper {
         createCairoFunctionStub(
           'get_contract_address',
           [],
-          [['address', typeNameFromTypeNode(getNodeType(node, ast.compilerVersion), ast)]],
+          [['address', typeNameFromTypeNode(safeGetNodeType(node, ast.compilerVersion), ast)]],
           ['syscall_ptr'],
           ast,
           node,

--- a/src/passes/cairoUtilImporter.ts
+++ b/src/passes/cairoUtilImporter.ts
@@ -1,7 +1,8 @@
-import { ElementaryTypeName, getNodeType, IntType, Literal } from 'solc-typed-ast';
+import { ElementaryTypeName, IntType, Literal } from 'solc-typed-ast';
 import { AST } from '../ast/ast';
 import { CairoFunctionDefinition } from '../ast/cairoNodes';
 import { ASTMapper } from '../ast/mapper';
+import { safeGetNodeType } from '../utils/nodeTypeProcessing';
 import { isExternallyVisible, primitiveTypeToCairo } from '../utils/utils';
 
 /*
@@ -24,7 +25,7 @@ export class CairoUtilImporter extends ASTMapper {
   }
 
   visitLiteral(node: Literal, ast: AST): void {
-    const type = getNodeType(node, ast.compilerVersion);
+    const type = safeGetNodeType(node, ast.compilerVersion);
     if (type instanceof IntType && type.nBits > 251) {
       ast.registerImport(node, 'starkware.cairo.common.uint256', 'Uint256');
     }

--- a/src/passes/constantHandler.ts
+++ b/src/passes/constantHandler.ts
@@ -35,7 +35,7 @@ export class ConstantHandler extends ASTMapper {
     const typeTo = safeGetNodeType(node, ast.compilerVersion);
 
     ast.replaceNode(node, constant);
-    insertConversionIfNecessary(constant, typeTo, node, ast);
+    insertConversionIfNecessary(constant, typeTo, constant, ast);
   }
 
   visitIdentifier(node: Identifier, ast: AST): void {

--- a/src/passes/constantHandler.ts
+++ b/src/passes/constantHandler.ts
@@ -35,7 +35,7 @@ export class ConstantHandler extends ASTMapper {
     const typeTo = safeGetNodeType(node, ast.compilerVersion);
 
     ast.replaceNode(node, constant);
-    insertConversionIfNecessary(constant, typeTo, ast);
+    insertConversionIfNecessary(constant, typeTo, node, ast);
   }
 
   visitIdentifier(node: Identifier, ast: AST): void {

--- a/src/passes/constantHandler.ts
+++ b/src/passes/constantHandler.ts
@@ -1,14 +1,8 @@
-import {
-  getNodeType,
-  Identifier,
-  Literal,
-  MemberAccess,
-  Mutability,
-  VariableDeclaration,
-} from 'solc-typed-ast';
+import { Identifier, Literal, MemberAccess, Mutability, VariableDeclaration } from 'solc-typed-ast';
 import { AST } from '../ast/ast';
 import { ASTMapper } from '../ast/mapper';
 import { cloneASTNode } from '../utils/cloning';
+import { safeGetNodeType } from '../utils/nodeTypeProcessing';
 import { insertConversionIfNecessary } from './implicitConversionToExplicit';
 
 export class ConstantHandler extends ASTMapper {
@@ -38,7 +32,7 @@ export class ConstantHandler extends ASTMapper {
     }
 
     const constant = cloneASTNode(referencedDeclaration.vValue, ast);
-    const typeTo = getNodeType(node, ast.compilerVersion);
+    const typeTo = safeGetNodeType(node, ast.compilerVersion);
 
     ast.replaceNode(node, constant);
     insertConversionIfNecessary(constant, typeTo, ast);

--- a/src/passes/deleteHandler.ts
+++ b/src/passes/deleteHandler.ts
@@ -2,7 +2,6 @@ import {
   Assignment,
   DataLocation,
   ExpressionStatement,
-  getNodeType,
   Identifier,
   PointerType,
   Return,
@@ -14,6 +13,7 @@ import { AST } from '../ast/ast';
 import { ASTMapper } from '../ast/mapper';
 import { cloneDocumentation } from '../utils/cloning';
 import { getDefaultValue } from '../utils/defaultValueNodes';
+import { safeGetNodeType } from '../utils/nodeTypeProcessing';
 
 export class DeleteHandler extends ASTMapper {
   // Function to add passes that should have been run before this pass
@@ -27,7 +27,7 @@ export class DeleteHandler extends ASTMapper {
       return this.commonVisit(node, ast);
     }
 
-    const nodeType = getNodeType(node.vSubExpression, ast.compilerVersion);
+    const nodeType = safeGetNodeType(node.vSubExpression, ast.compilerVersion);
     // Deletetion from storage is handled in References
     if (
       (nodeType instanceof PointerType && nodeType.location === DataLocation.Storage) ||
@@ -56,7 +56,7 @@ export class DeleteHandler extends ASTMapper {
   visitReturn(node: Return, ast: AST): void {
     let visited = false;
     if (node.vExpression) {
-      const nodeType = getNodeType(node.vExpression, ast.compilerVersion);
+      const nodeType = safeGetNodeType(node.vExpression, ast.compilerVersion);
       if (nodeType instanceof TupleType && nodeType.getChildren().length === 0) {
         const statement = new ExpressionStatement(
           ast.reserveId(),

--- a/src/passes/expressionSplitter/conditionalFunctionaliser.ts
+++ b/src/passes/expressionSplitter/conditionalFunctionaliser.ts
@@ -25,7 +25,7 @@ import {
   createParameterList,
   createReturn,
 } from '../../utils/nodeTemplates';
-import { safeGetNodeType } from '../../utils/nodeTypeProcessing';
+import { safeGetNodeTypeInCtx } from '../../utils/nodeTypeProcessing';
 
 // The returns should be both the values returned by the conditional itself,
 // as well as the variables that got captured, as they could have been modified
@@ -147,7 +147,7 @@ export function addStatementsToCallFunction(
       [conditionalResult.id],
       [conditionalResult],
       getDefaultValue(
-        safeGetNodeType(conditionalResult, ast.compilerVersion),
+        safeGetNodeTypeInCtx(conditionalResult, ast.compilerVersion, node),
         conditionalResult,
         ast,
       ),

--- a/src/passes/expressionSplitter/conditionalFunctionaliser.ts
+++ b/src/passes/expressionSplitter/conditionalFunctionaliser.ts
@@ -7,7 +7,6 @@ import {
   Expression,
   ExpressionStatement,
   FunctionCall,
-  getNodeType,
   Identifier,
   IfStatement,
   Mutability,
@@ -26,6 +25,7 @@ import {
   createParameterList,
   createReturn,
 } from '../../utils/nodeTemplates';
+import { safeGetNodeType } from '../../utils/nodeTypeProcessing';
 
 // The returns should be both the values returned by the conditional itself,
 // as well as the variables that got captured, as they could have been modified
@@ -146,7 +146,11 @@ export function addStatementsToCallFunction(
       '',
       [conditionalResult.id],
       [conditionalResult],
-      getDefaultValue(getNodeType(conditionalResult, ast.compilerVersion), conditionalResult, ast),
+      getDefaultValue(
+        safeGetNodeType(conditionalResult, ast.compilerVersion),
+        conditionalResult,
+        ast,
+      ),
     ),
     createOuterCall(node, [conditionalResult, ...variables], funcToCall, ast),
   ];

--- a/src/passes/expressionSplitter/expressionSplitter.ts
+++ b/src/passes/expressionSplitter/expressionSplitter.ts
@@ -15,7 +15,6 @@ import {
   VariableDeclaration,
   VariableDeclarationStatement,
   generalizeType,
-  getNodeType,
   FunctionKind,
 } from 'solc-typed-ast';
 import { AST } from '../../ast/ast';
@@ -26,6 +25,7 @@ import { TranspileFailedError } from '../../utils/errors';
 import { createCallToFunction, fixParameterScopes } from '../../utils/functionGeneration';
 import { SPLIT_EXPRESSION_PREFIX } from '../../utils/nameModifiers';
 import { createEmptyTuple, createIdentifier } from '../../utils/nodeTemplates';
+import { safeGetNodeType } from '../../utils/nodeTypeProcessing';
 import { counterGenerator, getContainingFunction } from '../../utils/utils';
 import {
   addStatementsToCallFunction,
@@ -182,7 +182,7 @@ function createVariableDeclarationStatement(
   ast: AST,
 ): VariableDeclarationStatement {
   const location =
-    generalizeType(getNodeType(initalValue, ast.compilerVersion))[1] ?? DataLocation.Default;
+    generalizeType(safeGetNodeType(initalValue, ast.compilerVersion))[1] ?? DataLocation.Default;
   const varDecl = new VariableDeclaration(
     ast.reserveId(),
     '',

--- a/src/passes/expressionSplitter/expressionSplitter.ts
+++ b/src/passes/expressionSplitter/expressionSplitter.ts
@@ -66,21 +66,19 @@ export class ExpressionSplitter extends ASTMapper {
         return;
       }
 
-      const leftHandSide = cloneASTNode(node.vLeftHandSide, ast);
-      const rightHandSide = cloneASTNode(node.vRightHandSide, ast);
-
       const tempVarStatement = createVariableDeclarationStatement(
         this.eGen.next().value,
-        rightHandSide,
+        node.vRightHandSide,
         ast.getContainingScope(node),
         ast,
       );
       const tempVar = tempVarStatement.vDeclarations[0];
 
+      const leftHandSide = cloneASTNode(node.vLeftHandSide, ast);
       const updateVal = createAssignmentStatement(
         '=',
         leftHandSide,
-        createIdentifier(tempVar, ast),
+        createIdentifier(tempVar, ast, undefined, node),
         ast,
       );
 
@@ -177,12 +175,12 @@ function identifierReferenceStateVar(id: Identifier) {
 
 function createVariableDeclarationStatement(
   name: string,
-  initalValue: Expression,
+  initialValue: Expression,
   scope: number,
   ast: AST,
 ): VariableDeclarationStatement {
   const location =
-    generalizeType(safeGetNodeType(initalValue, ast.compilerVersion))[1] ?? DataLocation.Default;
+    generalizeType(safeGetNodeType(initialValue, ast.compilerVersion))[1] ?? DataLocation.Default;
   const varDecl = new VariableDeclaration(
     ast.reserveId(),
     '',
@@ -194,7 +192,7 @@ function createVariableDeclarationStatement(
     location,
     StateVariableVisibility.Internal,
     Mutability.Constant,
-    initalValue.typeString,
+    initialValue.typeString,
   );
   ast.setContextRecursive(varDecl);
 
@@ -203,7 +201,7 @@ function createVariableDeclarationStatement(
     '',
     [varDecl.id],
     [varDecl],
-    initalValue,
+    cloneASTNode(initialValue, ast),
   );
   return varDeclStatement;
 }

--- a/src/passes/externalArgModifier/dynamicArrayModifier.ts
+++ b/src/passes/externalArgModifier/dynamicArrayModifier.ts
@@ -99,18 +99,21 @@ export class DynArrayModifier extends ASTMapper {
             memoryArray.name = memoryArray.name + '_mem';
             const memArrayStatement = createVariableDeclarationStatement(
               [memoryArray],
-              createIdentifier(dArrayStruct, ast),
+              createIdentifier(dArrayStruct, ast, undefined, varDecl),
               ast,
             );
             ids.forEach((identifier) =>
-              ast.replaceNode(identifier, createIdentifier(memoryArray, ast, DataLocation.Memory)),
+              ast.replaceNode(
+                identifier,
+                createIdentifier(memoryArray, ast, DataLocation.Memory, varDecl),
+              ),
             );
             body.insertAfter(memArrayStatement, structArrayStatement);
           } else {
             ids.forEach((identifier) =>
               ast.replaceNode(
                 identifier,
-                createIdentifier(dArrayStruct, ast, DataLocation.CallData),
+                createIdentifier(dArrayStruct, ast, DataLocation.CallData, varDecl),
               ),
             );
           }

--- a/src/passes/externalArgModifier/dynamicArrayModifier.ts
+++ b/src/passes/externalArgModifier/dynamicArrayModifier.ts
@@ -4,7 +4,6 @@ import {
   DataLocation,
   FunctionCall,
   FunctionDefinition,
-  getNodeType,
   VariableDeclaration,
 } from 'solc-typed-ast';
 import { AST } from '../../ast/ast';
@@ -13,7 +12,7 @@ import { ASTMapper } from '../../ast/mapper';
 import { cloneASTNode } from '../../utils/cloning';
 import { collectUnboundVariables } from '../../utils/functionGeneration';
 import { createIdentifier, createVariableDeclarationStatement } from '../../utils/nodeTemplates';
-import { isDynamicArray } from '../../utils/nodeTypeProcessing';
+import { isDynamicArray, safeGetNodeType } from '../../utils/nodeTypeProcessing';
 import { isExternallyVisible } from '../../utils/utils';
 
 export class DynArrayModifier extends ASTMapper {
@@ -78,7 +77,7 @@ export class DynArrayModifier extends ASTMapper {
             node.vParameters.vParameters.includes(decl) &&
             (decl.storageLocation === DataLocation.Memory ||
               decl.storageLocation == DataLocation.CallData) &&
-            isDynamicArray(getNodeType(decl, ast.compilerVersion)),
+            isDynamicArray(safeGetNodeType(decl, ast.compilerVersion)),
         )
         .forEach(([varDecl, ids]) => {
           // Irrespective of the whether the storage location is Memory or Calldata a struct is created to store the len & ptr

--- a/src/passes/externalArgModifier/memoryRefInputModifier.ts
+++ b/src/passes/externalArgModifier/memoryRefInputModifier.ts
@@ -1,11 +1,11 @@
-import { DataLocation, FunctionDefinition, getNodeType } from 'solc-typed-ast';
+import { DataLocation, FunctionDefinition } from 'solc-typed-ast';
 import { AST } from '../../ast/ast';
 import { ASTMapper } from '../../ast/mapper';
 import { cloneASTNode } from '../../utils/cloning';
 import { collectUnboundVariables } from '../../utils/functionGeneration';
 import { CALLDATA_TO_MEMORY_FUNCTION_PARAMETER_PREFIX } from '../../utils/nameModifiers';
 import { createIdentifier, createVariableDeclarationStatement } from '../../utils/nodeTemplates';
-import { isDynamicArray, isReferenceType } from '../../utils/nodeTypeProcessing';
+import { isDynamicArray, isReferenceType, safeGetNodeType } from '../../utils/nodeTypeProcessing';
 import { isExternallyVisible } from '../../utils/utils';
 
 export class RefTypeModifier extends ASTMapper {
@@ -51,8 +51,8 @@ export class RefTypeModifier extends ASTMapper {
           ([decl]) =>
             node.vParameters.vParameters.includes(decl) &&
             decl.storageLocation === DataLocation.Memory &&
-            isReferenceType(getNodeType(decl, ast.compilerVersion)) &&
-            !isDynamicArray(getNodeType(decl, ast.compilerVersion)),
+            isReferenceType(safeGetNodeType(decl, ast.compilerVersion)) &&
+            !isDynamicArray(safeGetNodeType(decl, ast.compilerVersion)),
         )
         .forEach(([decl, ids]) => {
           const wmDecl = cloneASTNode(decl, ast);

--- a/src/passes/externalContractHandler/externalContractInterfaceInserter.ts
+++ b/src/passes/externalContractHandler/externalContractInterfaceInserter.ts
@@ -3,7 +3,6 @@ import {
   ContractDefinition,
   ContractKind,
   FunctionKind,
-  getNodeType,
   Identifier,
   MemberAccess,
   SourceUnit,
@@ -15,6 +14,7 @@ import {
 import { AST } from '../../ast/ast';
 import { ASTMapper } from '../../ast/mapper';
 import { cloneASTNode } from '../../utils/cloning';
+import { safeGetNodeType } from '../../utils/nodeTypeProcessing';
 import { isExternallyVisible } from '../../utils/utils';
 
 export class ExternalContractInterfaceInserter extends ASTMapper {
@@ -44,7 +44,7 @@ export class ExternalContractInterfaceInserter extends ASTMapper {
   }
 
   visitMemberAccess(node: MemberAccess, ast: AST): void {
-    const nodeType = getNodeType(node.vExpression, ast.compilerVersion);
+    const nodeType = safeGetNodeType(node.vExpression, ast.compilerVersion);
     if (nodeType instanceof UserDefinedType && nodeType.definition instanceof ContractDefinition) {
       importExternalContract(
         nodeType.definition,

--- a/src/passes/functionTypeStringMatcher/functionDefinitionTypestringMatcher.ts
+++ b/src/passes/functionTypeStringMatcher/functionDefinitionTypestringMatcher.ts
@@ -6,10 +6,10 @@ import {
   FunctionCall,
   FunctionDefinition,
   PointerType,
-  getNodeType,
   FunctionType,
   VariableDeclaration,
 } from 'solc-typed-ast';
+import { safeGetNodeType } from '../../utils/nodeTypeProcessing';
 
 export class FunctionDefinitionMatcher extends ASTMapper {
   constructor(private declarations: Map<VariableDeclaration, boolean>) {
@@ -17,7 +17,7 @@ export class FunctionDefinitionMatcher extends ASTMapper {
   }
 
   visitFunctionCall(node: FunctionCall, ast: AST): void {
-    const functionNodeType = getNodeType(node.vExpression, ast.compilerVersion);
+    const functionNodeType = safeGetNodeType(node.vExpression, ast.compilerVersion);
     if (
       node.vArguments.length === 0 ||
       node.kind === FunctionCallKind.TypeConversion ||

--- a/src/passes/generateGetters/gettersGenerator.ts
+++ b/src/passes/generateGetters/gettersGenerator.ts
@@ -12,7 +12,6 @@ import {
   FunctionKind,
   FunctionStateMutability,
   FunctionVisibility,
-  getNodeType,
   IndexAccess,
   Mapping,
   MemberAccess,
@@ -37,7 +36,7 @@ import {
   createUint256TypeName,
 } from '../../utils/nodeTemplates';
 import { toSingleExpression } from '../../utils/utils';
-import { isReferenceType } from '../../utils/nodeTypeProcessing';
+import { isReferenceType, safeGetNodeType } from '../../utils/nodeTypeProcessing';
 import { locationIfComplexType } from '../../cairoUtilFuncGen/base';
 
 /**
@@ -146,7 +145,7 @@ function genReturnParameters(
     );
   };
   if (vType instanceof ElementaryTypeName) {
-    if (isReferenceType(getNodeType(vType, ast.compilerVersion))) {
+    if (isReferenceType(safeGetNodeType(vType, ast.compilerVersion))) {
       return [newVarDecl(vType, DataLocation.Memory)];
     } else {
       return [newVarDecl(vType)];
@@ -170,7 +169,7 @@ function genReturnParameters(
         returnVariables.push(
           newVarDecl(
             v.vType,
-            isReferenceType(getNodeType(memberTypeName, ast.compilerVersion))
+            isReferenceType(safeGetNodeType(memberTypeName, ast.compilerVersion))
               ? DataLocation.Memory
               : DataLocation.Default,
           ),
@@ -231,7 +230,7 @@ function genFunctionParams(
         `_i${varCount}`,
         funcDefID,
         false,
-        locationIfComplexType(getNodeType(vType, ast.compilerVersion), DataLocation.Memory),
+        locationIfComplexType(safeGetNodeType(vType, ast.compilerVersion), DataLocation.Memory),
         StateVariableVisibility.Internal,
         Mutability.Mutable,
         vType.vKeyType.typeString,

--- a/src/passes/inheritanceInliner/constructorInheritance.ts
+++ b/src/passes/inheritanceInliner/constructorInheritance.ts
@@ -335,7 +335,7 @@ function transformConstructor(
   removeNonModifierInvocations(currentCons);
 
   const argList = newConstructor.vParameters.vParameters.map((v) => {
-    return createIdentifier(v, ast);
+    return createIdentifier(v, ast, undefined, node);
   });
   statements.push(
     new ExpressionStatement(ast.reserveId(), '', createCallToFunction(currentCons, argList, ast)),

--- a/src/passes/newToDeploy.ts
+++ b/src/passes/newToDeploy.ts
@@ -113,7 +113,7 @@ export class NewToDeploy extends ASTMapper {
       const bytes32Salt = parent.vOptionsMap.get('salt');
       assert(bytes32Salt !== undefined);
       // Narrow salt to a felt range
-      salt = createElementaryConversionCall(createBytesNTypeName(30, ast), bytes32Salt, ast);
+      salt = createElementaryConversionCall(createBytesNTypeName(30, ast), bytes32Salt, node, ast);
       ast.replaceNode(bytes32Salt, salt, parent);
     } else {
       throw new TranspileFailedError(

--- a/src/passes/orderNestedStructs.ts
+++ b/src/passes/orderNestedStructs.ts
@@ -1,7 +1,6 @@
 import {
   ArrayType,
   ContractDefinition,
-  getNodeType,
   SourceUnit,
   StructDefinition,
   TypeNode,
@@ -9,6 +8,7 @@ import {
 } from 'solc-typed-ast';
 import { AST } from '../ast/ast';
 import { ASTMapper } from '../ast/mapper';
+import { safeGetNodeType } from '../utils/nodeTypeProcessing';
 
 export class OrderNestedStructs extends ASTMapper {
   // Cairo does not permit to use struct definitions which are yet to be defined.
@@ -101,7 +101,7 @@ export function makeStructTree(
 
   structs.forEach((struct) => {
     struct.vMembers.forEach((varDecl) => {
-      const nestedStruct = findStruct(getNodeType(varDecl, ast.compilerVersion));
+      const nestedStruct = findStruct(safeGetNodeType(varDecl, ast.compilerVersion));
       // second check to avoid adding imported structs to contract defintion
       if (nestedStruct !== null && structs.has(nestedStruct)) {
         roots.delete(nestedStruct);

--- a/src/passes/publicFunctionSplitter/internalFunctionCallCollector.ts
+++ b/src/passes/publicFunctionSplitter/internalFunctionCallCollector.ts
@@ -5,12 +5,12 @@ import {
   FunctionCallKind,
   FunctionDefinition,
   FunctionType,
-  getNodeType,
   MemberAccess,
   UserDefinedType,
 } from 'solc-typed-ast';
 import { AST } from '../../ast/ast';
 import { ASTMapper } from '../../ast/mapper';
+import { safeGetNodeType } from '../../utils/nodeTypeProcessing';
 
 export class InternalFunctionCallCollector extends ASTMapper {
   /*
@@ -33,7 +33,7 @@ export class InternalFunctionCallCollector extends ASTMapper {
       isInternalFuncCall(node, ast)
     ) {
       if (node.vExpression instanceof MemberAccess) {
-        const typeNode = getNodeType(node.vExpression.vExpression, ast.compilerVersion);
+        const typeNode = safeGetNodeType(node.vExpression.vExpression, ast.compilerVersion);
         if (
           typeNode instanceof UserDefinedType &&
           typeNode.definition instanceof ContractDefinition
@@ -49,7 +49,7 @@ export class InternalFunctionCallCollector extends ASTMapper {
 }
 
 export function isInternalFuncCall(node: FunctionCall, ast: AST): boolean {
-  const type = getNodeType(node.vExpression, ast.compilerVersion);
+  const type = safeGetNodeType(node.vExpression, ast.compilerVersion);
   assert(type instanceof FunctionType);
   return type.visibility === 'internal';
 }

--- a/src/passes/references/actualLocationAnalyser.ts
+++ b/src/passes/references/actualLocationAnalyser.ts
@@ -6,7 +6,6 @@ import {
   FunctionCall,
   FunctionDefinition,
   FunctionVisibility,
-  getNodeType,
   Identifier,
   IndexAccess,
   MemberAccess,
@@ -15,6 +14,7 @@ import {
 } from 'solc-typed-ast';
 import { AST } from '../../ast/ast';
 import { ASTMapper } from '../../ast/mapper';
+import { safeGetNodeType } from '../../utils/nodeTypeProcessing';
 
 /*
   Analyses all expressions in the AST to determine which datalocation (if any)
@@ -28,7 +28,7 @@ export class ActualLocationAnalyser extends ASTMapper {
   }
 
   visitExpression(node: Expression, ast: AST): void {
-    const type = getNodeType(node, ast.compilerVersion);
+    const type = safeGetNodeType(node, ast.compilerVersion);
     if (type instanceof PointerType) {
       this.actualLocations.set(node, type.location);
     } else {
@@ -61,7 +61,7 @@ export class ActualLocationAnalyser extends ASTMapper {
     const baseLocation = this.actualLocations.get(node.vExpression);
 
     if (baseLocation !== undefined) {
-      const baseType = getNodeType(node.vExpression, ast.compilerVersion);
+      const baseType = safeGetNodeType(node.vExpression, ast.compilerVersion);
       if (baseType instanceof FixedBytesType) {
         this.actualLocations.set(node, DataLocation.Default);
       } else {
@@ -77,7 +77,7 @@ export class ActualLocationAnalyser extends ASTMapper {
     const baseLocation = this.actualLocations.get(node.vBaseExpression);
 
     if (baseLocation !== undefined) {
-      const baseType = getNodeType(node.vBaseExpression, ast.compilerVersion);
+      const baseType = safeGetNodeType(node.vBaseExpression, ast.compilerVersion);
       if (baseType instanceof FixedBytesType) {
         this.actualLocations.set(node, DataLocation.Default);
       } else {
@@ -97,7 +97,7 @@ export class ActualLocationAnalyser extends ASTMapper {
     } else if (
       node.vReferencedDeclaration instanceof FunctionDefinition &&
       node.vReferencedDeclaration.visibility === FunctionVisibility.External &&
-      getNodeType(node, ast.compilerVersion) instanceof PointerType
+      safeGetNodeType(node, ast.compilerVersion) instanceof PointerType
     ) {
       this.actualLocations.set(node, DataLocation.CallData);
       this.commonVisit(node, ast);

--- a/src/passes/references/arrayFunctions.ts
+++ b/src/passes/references/arrayFunctions.ts
@@ -7,14 +7,18 @@ import {
   FunctionCall,
   FunctionStateMutability,
   generalizeType,
-  getNodeType,
   MemberAccess,
   PointerType,
 } from 'solc-typed-ast';
 import { AST } from '../../ast/ast';
 import { FunctionStubKind } from '../../ast/cairoNodes';
 import { createCairoFunctionStub, createCallToFunction } from '../../utils/functionGeneration';
-import { getSize, isDynamicArray, isDynamicCallDataArray } from '../../utils/nodeTypeProcessing';
+import {
+  getSize,
+  isDynamicArray,
+  isDynamicCallDataArray,
+  safeGetNodeType,
+} from '../../utils/nodeTypeProcessing';
 import { createNumberLiteral } from '../../utils/nodeTemplates';
 import { expressionHasSideEffects, typeNameFromTypeNode } from '../../utils/utils';
 import { ReferenceSubPass } from './referenceSubPass';
@@ -54,7 +58,7 @@ export class ArrayFunctions extends ReferenceSubPass {
           this.expectedDataLocations.set(node.vArguments[0], actualArgLoc);
         }
       } else {
-        const type = getNodeType(node, ast.compilerVersion);
+        const type = safeGetNodeType(node, ast.compilerVersion);
         replacement = utilGen.storage.dynArrayPush.withoutArg.gen(node);
         this.replace(node, replacement, node.parent, DataLocation.Storage, expectedLoc, ast);
         if (isDynamicArray(type)) {
@@ -85,7 +89,7 @@ export class ArrayFunctions extends ReferenceSubPass {
 
     const expectedLoc = this.getLocations(node)[1];
 
-    const baseType = getNodeType(node.vExpression, ast.compilerVersion);
+    const baseType = safeGetNodeType(node.vExpression, ast.compilerVersion);
     if (baseType instanceof FixedBytesType) {
       const literal = createNumberLiteral(baseType.size, ast, 'uint8');
       if (expressionHasSideEffects(node.vExpression)) {
@@ -102,7 +106,7 @@ export class ArrayFunctions extends ReferenceSubPass {
     ) {
       if (isDynamicCallDataArray(baseType)) {
         const parent = node.parent;
-        const type = generalizeType(getNodeType(node, ast.compilerVersion))[0];
+        const type = generalizeType(safeGetNodeType(node, ast.compilerVersion))[0];
 
         const funcStub = createCairoFunctionStub(
           'felt_to_uint256',

--- a/src/passes/references/memoryAllocations.ts
+++ b/src/passes/references/memoryAllocations.ts
@@ -6,7 +6,6 @@ import {
   FunctionCall,
   FunctionCallKind,
   generalizeType,
-  getNodeType,
   Literal,
   NewExpression,
   StringType,
@@ -19,7 +18,7 @@ import { CairoType, TypeConversionContext } from '../../utils/cairoTypeSystem';
 import { NotSupportedYetError } from '../../utils/errors';
 import { createCairoFunctionStub, createCallToFunction } from '../../utils/functionGeneration';
 import { createNumberLiteral, createUint256TypeName } from '../../utils/nodeTemplates';
-import { getElementType } from '../../utils/nodeTypeProcessing';
+import { getElementType, safeGetNodeType } from '../../utils/nodeTypeProcessing';
 
 /*
   Handles expressions that directly insert data into memory: struct constructors, news, and inline arrays
@@ -49,7 +48,7 @@ export class MemoryAllocations extends ReferenceSubPass {
         );
       }
     } else if (node.kind === FunctionCallKind.TypeConversion) {
-      const type = generalizeType(getNodeType(node, ast.compilerVersion))[0];
+      const type = generalizeType(safeGetNodeType(node, ast.compilerVersion))[0];
       const arg = node.vArguments[0];
       if ((type instanceof BytesType || type instanceof StringType) && arg instanceof Literal) {
         const replacement = ast.getUtilFuncGen(node).memory.arrayLiteral.stringGen(arg);
@@ -91,7 +90,7 @@ export class MemoryAllocations extends ReferenceSubPass {
       node,
     );
 
-    const arrayType = generalizeType(getNodeType(node, ast.compilerVersion))[0];
+    const arrayType = generalizeType(safeGetNodeType(node, ast.compilerVersion))[0];
     assert(
       arrayType instanceof ArrayType ||
         arrayType instanceof BytesType ||

--- a/src/passes/references/storedPointerDereference.ts
+++ b/src/passes/references/storedPointerDereference.ts
@@ -3,7 +3,6 @@ import {
   DataLocation,
   Expression,
   FunctionCall,
-  getNodeType,
   IndexAccess,
   MemberAccess,
 } from 'solc-typed-ast';
@@ -13,6 +12,7 @@ import {
   isDynamicArray,
   isMapping,
   isReferenceType,
+  safeGetNodeType,
 } from '../../utils/nodeTypeProcessing';
 import { typeNameFromTypeNode } from '../../utils/utils';
 import { ReferenceSubPass } from './referenceSubPass';
@@ -28,7 +28,7 @@ export class StoredPointerDereference extends ReferenceSubPass {
 
     const utilFuncGen = ast.getUtilFuncGen(node);
     const parent = node.parent;
-    const nodeType = getNodeType(node, ast.compilerVersion);
+    const nodeType = safeGetNodeType(node, ast.compilerVersion);
 
     // Next, if the node is a type that requires an extra read, insert this first
     let readFunc: FunctionCall | null = null;
@@ -59,7 +59,7 @@ export class StoredPointerDereference extends ReferenceSubPass {
   }
 
   visitAssignment(node: Assignment, ast: AST): void {
-    const lhsType = getNodeType(node.vLeftHandSide, ast.compilerVersion);
+    const lhsType = safeGetNodeType(node.vLeftHandSide, ast.compilerVersion);
 
     if (isComplexMemoryType(lhsType)) {
       this.visitExpression(node.vLeftHandSide, ast);

--- a/src/passes/storageAllocator.ts
+++ b/src/passes/storageAllocator.ts
@@ -10,7 +10,6 @@ import {
   FunctionStateMutability,
   FunctionVisibility,
   generalizeType,
-  getNodeType,
   Literal,
   LiteralKind,
   MappingType,
@@ -28,7 +27,11 @@ import {
   createParameterList,
   createVariableDeclarationStatement,
 } from '../utils/nodeTemplates';
-import { isDynamicArray, typeNameToSpecializedTypeNode } from '../utils/nodeTypeProcessing';
+import {
+  isDynamicArray,
+  safeGetNodeType,
+  typeNameToSpecializedTypeNode,
+} from '../utils/nodeTypeProcessing';
 import { isCairoConstant } from '../utils/utils';
 
 export class StorageAllocator extends ASTMapper {
@@ -46,7 +49,7 @@ export class StorageAllocator extends ASTMapper {
     const dynamicAllocations: Map<VariableDeclaration, number> = new Map();
     const staticAllocations: Map<VariableDeclaration, number> = new Map();
     node.vStateVariables.forEach((v) => {
-      const type = getNodeType(v, ast.compilerVersion);
+      const type = safeGetNodeType(v, ast.compilerVersion);
       if (generalizeType(type)[0] instanceof MappingType || isDynamicArray(type)) {
         const width = CairoType.fromSol(type, ast, TypeConversionContext.StorageAllocation).width;
         dynamicAllocations.set(v, ++usedNames);

--- a/src/passes/storageAllocator.ts
+++ b/src/passes/storageAllocator.ts
@@ -153,7 +153,7 @@ function extractInitialisation(node: VariableDeclaration, initialisationBlock: B
     initialisationBlock.appendChild(
       createVariableDeclarationStatement([memoryVariableDeclaration], value, ast),
     );
-    value = createIdentifier(memoryVariableDeclaration, ast, DataLocation.Memory);
+    value = createIdentifier(memoryVariableDeclaration, ast, DataLocation.Memory, node);
   }
   initialisationBlock.appendChild(
     createExpressionStatement(

--- a/src/passes/tupleAssignmentSplitter.ts
+++ b/src/passes/tupleAssignmentSplitter.ts
@@ -6,7 +6,6 @@ import {
   Expression,
   ExpressionStatement,
   generalizeType,
-  getNodeType,
   IntLiteralType,
   Mutability,
   Return,
@@ -24,6 +23,7 @@ import { printNode } from '../utils/astPrinter';
 import { cloneASTNode } from '../utils/cloning';
 import { TUPLE_VALUE_PREFIX } from '../utils/nameModifiers';
 import { createBlock, createIdentifier } from '../utils/nodeTemplates';
+import { safeGetNodeType } from '../utils/nodeTypeProcessing';
 import { notNull } from '../utils/typeConstructs';
 import { typeNameFromTypeNode } from '../utils/utils';
 
@@ -97,7 +97,7 @@ export class TupleAssignmentSplitter extends ASTMapper {
       lhs instanceof TupleExpression,
       `Split tuple assignment was called on non-tuple assignment ${node.type} # ${node.id}`,
     );
-    const rhsType = getNodeType(rhs, ast.compilerVersion);
+    const rhsType = safeGetNodeType(rhs, ast.compilerVersion);
     assert(
       rhsType instanceof TupleType,
       `Expected rhs of tuple assignment to be tuple type ${printNode(node)}`,
@@ -107,7 +107,7 @@ export class TupleAssignmentSplitter extends ASTMapper {
 
     const tempVars = new Map<Expression, VariableDeclaration>(
       lhs.vOriginalComponents.filter(notNull).map((child, index) => {
-        const lhsElementType = getNodeType(child, ast.compilerVersion);
+        const lhsElementType = safeGetNodeType(child, ast.compilerVersion);
         const rhsElementType = rhsType.elements[index];
 
         // We need to calculate a type and location for the temporary variable

--- a/src/passes/tupleFixes/tupleFiller.ts
+++ b/src/passes/tupleFixes/tupleFiller.ts
@@ -5,7 +5,6 @@ import {
   Expression,
   FunctionDefinition,
   generalizeType,
-  getNodeType,
   ModifierDefinition,
   Mutability,
   StateVariableVisibility,
@@ -19,6 +18,7 @@ import { printNode, printTypeNode } from '../../utils/astPrinter';
 import { getDefaultValue } from '../../utils/defaultValueNodes';
 import { TUPLE_FILLER_PREFIX } from '../../utils/nameModifiers';
 import { createIdentifier, createVariableDeclarationStatement } from '../../utils/nodeTemplates';
+import { safeGetNodeType } from '../../utils/nodeTypeProcessing';
 import { notNull } from '../../utils/typeConstructs';
 import { expressionHasSideEffects, typeNameFromTypeNode } from '../../utils/utils';
 
@@ -47,7 +47,7 @@ export class TupleFiller extends ASTMapper {
       .filter(notNull)
       .forEach((emptyIndex) => {
         if (shouldRemove(node.vRightHandSide, emptyIndex)) return;
-        const tupleType = getNodeType(node.vRightHandSide, ast.compilerVersion);
+        const tupleType = safeGetNodeType(node.vRightHandSide, ast.compilerVersion);
         assert(
           tupleType instanceof TupleType,
           `Expected rhs of tuple assignment to be tuple type, got ${printTypeNode(

--- a/src/passes/typeInformationCalculator.ts
+++ b/src/passes/typeInformationCalculator.ts
@@ -7,7 +7,6 @@ import {
   EnumValue,
   Expression,
   FunctionCall,
-  getNodeType,
   Identifier,
   IntType,
   MemberAccess,
@@ -20,6 +19,7 @@ import { ASTMapper } from '../ast/mapper';
 import { printTypeNode } from '../utils/astPrinter';
 import { WillNotSupportError } from '../utils/errors';
 import { createNumberLiteral, createStringLiteral } from '../utils/nodeTemplates';
+import { safeGetNodeType } from '../utils/nodeTypeProcessing';
 
 function calculateIntMin(type: IntType): bigint {
   if (type.signed) {
@@ -89,7 +89,7 @@ export class TypeInformationCalculator extends ASTMapper {
     typestring: string,
     ast: AST,
   ): ASTNode | null {
-    let nodeType = getNodeType(node, ast.compilerVersion);
+    let nodeType = safeGetNodeType(node, ast.compilerVersion);
     assert(
       nodeType instanceof TypeNameType,
       `Expected TypeNameType, found ${printTypeNode(nodeType)}`,

--- a/src/passes/typeNameRemover.ts
+++ b/src/passes/typeNameRemover.ts
@@ -1,7 +1,6 @@
 import {
   ElementaryTypeNameExpression,
   ExpressionStatement,
-  getNodeType,
   Identifier,
   IndexAccess,
   MemberAccess,
@@ -13,6 +12,7 @@ import { ASTMapper } from '../ast/mapper';
 import assert from 'assert';
 import { TupleExpression } from 'solc-typed-ast';
 import { notNull } from '../utils/typeConstructs';
+import { safeGetNodeType } from '../utils/nodeTypeProcessing';
 
 export class TypeNameRemover extends ASTMapper {
   // Function to add passes that should have been run before this pass
@@ -27,7 +27,7 @@ export class TypeNameRemover extends ASTMapper {
         node.vExpression instanceof MemberAccess ||
         node.vExpression instanceof Identifier ||
         node.vExpression instanceof ElementaryTypeNameExpression) &&
-      getNodeType(node.vExpression, ast.compilerVersion) instanceof TypeNameType
+      safeGetNodeType(node.vExpression, ast.compilerVersion) instanceof TypeNameType
     ) {
       ast.removeStatement(node);
     } else if (node.vExpression instanceof TupleExpression) {
@@ -79,7 +79,9 @@ export class TypeNameRemover extends ASTMapper {
   isTypeNameType(rhs: TupleExpression | null, index: number, ast: AST): boolean {
     if (!(rhs instanceof TupleExpression)) return false;
     const elem = rhs.vOriginalComponents[index];
-    return elem !== null ? getNodeType(elem, ast.compilerVersion) instanceof TypeNameType : false;
+    return elem !== null
+      ? safeGetNodeType(elem, ast.compilerVersion) instanceof TypeNameType
+      : false;
   }
 }
 

--- a/src/passes/unloadingAssignment.ts
+++ b/src/passes/unloadingAssignment.ts
@@ -4,7 +4,6 @@ import {
   BinaryOperation,
   Expression,
   FunctionCall,
-  getNodeType,
   IndexAccess,
   Literal,
   MemberAccess,
@@ -18,6 +17,7 @@ import { printNode } from '../utils/astPrinter';
 import { cloneASTNode } from '../utils/cloning';
 import { COMPOUND_ASSIGNMENT_SUBEXPRESSION_PREFIX } from '../utils/nameModifiers';
 import { createNumberLiteral } from '../utils/nodeTemplates';
+import { safeGetNodeType } from '../utils/nodeTypeProcessing';
 import { typeNameFromTypeNode } from '../utils/utils';
 
 export class UnloadingAssignment extends ASTMapper {
@@ -128,7 +128,7 @@ export class UnloadingAssignment extends ASTMapper {
   private extractIndividualSubExpression(node: Expression, ast: AST): VariableDeclarationStatement {
     return ast.extractToConstant(
       node,
-      typeNameFromTypeNode(getNodeType(node, ast.compilerVersion), ast),
+      typeNameFromTypeNode(safeGetNodeType(node, ast.compilerVersion), ast),
       `${COMPOUND_ASSIGNMENT_SUBEXPRESSION_PREFIX}${this.counter++}`,
     )[1];
   }

--- a/src/passes/variableDeclarationExpressionSplitter.ts
+++ b/src/passes/variableDeclarationExpressionSplitter.ts
@@ -8,7 +8,6 @@ import {
   Statement,
   UncheckedBlock,
   ExpressionStatement,
-  getNodeType,
   TupleType,
   VariableDeclaration,
   StateVariableVisibility,
@@ -20,6 +19,7 @@ import { printNode } from '../utils/astPrinter';
 import { TranspileFailedError } from '../utils/errors';
 import { SPLIT_VARIABLE_PREFIX } from '../utils/nameModifiers';
 import { createIdentifier } from '../utils/nodeTemplates';
+import { safeGetNodeType } from '../utils/nodeTypeProcessing';
 import { notNull } from '../utils/typeConstructs';
 import { typeNameFromTypeNode } from '../utils/utils';
 
@@ -82,7 +82,7 @@ export class VariableDeclarationExpressionSplitter extends ASTMapper {
       'Expected variables to be initialised when running variable declaration expression splitter (did you run variable declaration initialiser?)',
     );
 
-    const initialValueType = getNodeType(initialValue, ast.compilerVersion);
+    const initialValueType = safeGetNodeType(initialValue, ast.compilerVersion);
 
     if (!(initialValueType instanceof TupleType)) {
       return [node];

--- a/src/passes/variableDeclarationInitialiser.ts
+++ b/src/passes/variableDeclarationInitialiser.ts
@@ -1,8 +1,9 @@
-import { VariableDeclarationStatement, getNodeType } from 'solc-typed-ast';
+import { VariableDeclarationStatement } from 'solc-typed-ast';
 import { AST } from '../ast/ast';
 import { ASTMapper } from '../ast/mapper';
 import { getDefaultValue } from '../utils/defaultValueNodes';
 import { TranspileFailedError } from '../utils/errors';
+import { safeGetNodeType } from '../utils/nodeTypeProcessing';
 
 export class VariableDeclarationInitialiser extends ASTMapper {
   // Function to add passes that should have been run before this pass
@@ -26,7 +27,7 @@ export class VariableDeclarationInitialiser extends ASTMapper {
     }
 
     node.vInitialValue = getDefaultValue(
-      getNodeType(declaration, ast.compilerVersion),
+      safeGetNodeType(declaration, ast.compilerVersion),
       declaration,
       ast,
     );

--- a/src/utils/astChecking.ts
+++ b/src/utils/astChecking.ts
@@ -26,7 +26,6 @@ import {
   FunctionDefinition,
   FunctionKind,
   FunctionTypeName,
-  getNodeType,
   Identifier,
   IdentifierPath,
   IfStatement,
@@ -69,6 +68,7 @@ import { AST } from '../ast/ast';
 import { CairoAssert } from '../ast/cairoNodes';
 import { ASTMapper } from '../ast/mapper';
 import { printNode } from './astPrinter';
+import { safeGetNodeType } from './nodeTypeProcessing';
 import { isNameless } from './utils';
 
 // This is the solc-typed-ast AST checking code, with additions for CairoAssert and CairoContract
@@ -758,7 +758,7 @@ class NodeTypeResolutionChecker extends ASTMapper {
           child instanceof Expression || child instanceof VariableDeclaration,
       )
       .filter((child) => child.parent !== undefined && !(child.parent instanceof ImportDirective))
-      .forEach((child) => getNodeType(child, ast.compilerVersion));
+      .forEach((child) => safeGetNodeType(child, ast.compilerVersion));
   }
 }
 

--- a/src/utils/cairoTypeSystem.ts
+++ b/src/utils/cairoTypeSystem.ts
@@ -17,13 +17,13 @@ import {
   EnumDefinition,
   enumToIntType,
   StructDefinition,
-  getNodeType,
   FixedBytesType,
   UserDefinedValueTypeDefinition,
 } from 'solc-typed-ast';
 import { AST } from '../ast/ast';
 import { printTypeNode } from './astPrinter';
 import { NotSupportedYetError, TranspileFailedError } from './errors';
+import { safeGetNodeType } from './nodeTypeProcessing';
 import { mangleStructName, narrowBigIntSafe } from './utils';
 
 export enum TypeConversionContext {
@@ -118,7 +118,7 @@ export abstract class CairoType {
               tp.definition.vMembers.map((decl) => [
                 decl.name,
                 CairoType.fromSol(
-                  getNodeType(decl, ast.compilerVersion),
+                  safeGetNodeType(decl, ast.compilerVersion),
                   ast,
                   TypeConversionContext.Ref,
                 ),
@@ -131,7 +131,7 @@ export abstract class CairoType {
             new Map(
               tp.definition.vMembers.map((decl) => [
                 decl.name,
-                CairoType.fromSol(getNodeType(decl, ast.compilerVersion), ast, context),
+                CairoType.fromSol(safeGetNodeType(decl, ast.compilerVersion), ast, context),
               ]),
             ),
           );
@@ -140,7 +140,7 @@ export abstract class CairoType {
         return new CairoFelt();
       } else if (tp.definition instanceof UserDefinedValueTypeDefinition) {
         return CairoType.fromSol(
-          getNodeType(tp.definition.underlyingType, ast.compilerVersion),
+          safeGetNodeType(tp.definition.underlyingType, ast.compilerVersion),
           ast,
           context,
         );

--- a/src/utils/defaultValueNodes.ts
+++ b/src/utils/defaultValueNodes.ts
@@ -11,7 +11,6 @@ import {
   FixedBytesType,
   FunctionCall,
   FunctionCallKind,
-  getNodeType,
   Identifier,
   IntType,
   MemberAccess,
@@ -35,7 +34,7 @@ import {
   createNumberLiteral,
   createStringLiteral,
 } from './nodeTemplates';
-import { isStorageSpecificType } from './nodeTypeProcessing';
+import { isStorageSpecificType, safeGetNodeType } from './nodeTypeProcessing';
 import { typeNameFromTypeNode } from './utils';
 
 export function getDefaultValue(
@@ -210,7 +209,7 @@ function userDefDefault(
     );
   if (nodeType.definition instanceof UserDefinedValueTypeDefinition)
     return getDefaultValue(
-      getNodeType(nodeType.definition.underlyingType, ast.compilerVersion),
+      safeGetNodeType(nodeType.definition.underlyingType, ast.compilerVersion),
       parentNode,
       ast,
     );
@@ -244,7 +243,7 @@ function structDefault(
 ): Expression {
   const argsList: Expression[] = [];
   for (const member of structNode.vMembers) {
-    const tNode = getNodeType(member, ast.compilerVersion);
+    const tNode = safeGetNodeType(member, ast.compilerVersion);
     argsList.push(getDefaultValue(tNode, node, ast));
   }
   return new FunctionCall(

--- a/src/utils/functionGeneration.ts
+++ b/src/utils/functionGeneration.ts
@@ -169,7 +169,7 @@ export function createOuterCall(
   functionToCall: FunctionCall,
   ast: AST,
 ): ExpressionStatement {
-  const resultIdentifiers = variables.map((k) => createIdentifier(k, ast));
+  const resultIdentifiers = variables.map((k) => createIdentifier(k, ast, undefined, node));
   const assignmentValue = toSingleExpression(resultIdentifiers, ast);
 
   return new ExpressionStatement(

--- a/src/utils/functionGeneration.ts
+++ b/src/utils/functionGeneration.ts
@@ -13,7 +13,6 @@ import {
   FunctionKind,
   FunctionStateMutability,
   FunctionVisibility,
-  getNodeType,
   Identifier,
   Mutability,
   StateVariableVisibility,
@@ -25,7 +24,7 @@ import { CairoFunctionDefinition, FunctionStubKind } from '../ast/cairoNodes';
 import { getFunctionTypeString, getReturnTypeString } from './getTypeString';
 import { Implicits } from './implicits';
 import { createIdentifier, createParameterList } from './nodeTemplates';
-import { isDynamicArray } from './nodeTypeProcessing';
+import { isDynamicArray, safeGetNodeType } from './nodeTypeProcessing';
 import { toSingleExpression } from './utils';
 
 export function createCallToFunction(
@@ -139,7 +138,7 @@ export function createElementaryConversionCall(
   expression: Expression,
   ast: AST,
 ): FunctionCall {
-  const isDynArray = isDynamicArray(getNodeType(typeTo, ast.compilerVersion));
+  const isDynArray = isDynamicArray(safeGetNodeType(typeTo, ast.compilerVersion));
   const innerTypeString = isDynArray
     ? `type(${typeTo.typeString} storage pointer)`
     : `type(${typeTo.typeString})`;

--- a/src/utils/functionGeneration.ts
+++ b/src/utils/functionGeneration.ts
@@ -24,7 +24,7 @@ import { CairoFunctionDefinition, FunctionStubKind } from '../ast/cairoNodes';
 import { getFunctionTypeString, getReturnTypeString } from './getTypeString';
 import { Implicits } from './implicits';
 import { createIdentifier, createParameterList } from './nodeTemplates';
-import { isDynamicArray, safeGetNodeType } from './nodeTypeProcessing';
+import { isDynamicArray, safeGetNodeTypeInCtx } from './nodeTypeProcessing';
 import { toSingleExpression } from './utils';
 
 export function createCallToFunction(
@@ -136,9 +136,10 @@ export function createCairoFunctionStub(
 export function createElementaryConversionCall(
   typeTo: ElementaryTypeName,
   expression: Expression,
+  context: ASTNode,
   ast: AST,
 ): FunctionCall {
-  const isDynArray = isDynamicArray(safeGetNodeType(typeTo, ast.compilerVersion));
+  const isDynArray = isDynamicArray(safeGetNodeTypeInCtx(typeTo, ast.compilerVersion, context));
   const innerTypeString = isDynArray
     ? `type(${typeTo.typeString} storage pointer)`
     : `type(${typeTo.typeString})`;

--- a/src/utils/getTypeString.ts
+++ b/src/utils/getTypeString.ts
@@ -16,7 +16,6 @@ import {
   FunctionType,
   FunctionVisibility,
   generalizeType,
-  getNodeTypeInCtx,
   ImportRefType,
   IntLiteralType,
   IntType,
@@ -39,6 +38,7 @@ import { AST } from '../ast/ast';
 import { RationalLiteral } from '../passes/literalExpressionEvaluator/rationalLiteral';
 import { printNode, printTypeNode } from './astPrinter';
 import { NotSupportedYetError, TranspileFailedError } from './errors';
+import { safeGetNodeTypeInCtx } from './nodeTypeProcessing';
 
 export function getDeclaredTypeString(declaration: VariableDeclarationStatement): string {
   if (declaration.assignments.length === 1) {
@@ -81,7 +81,7 @@ export function getFunctionTypeString(
 ): string {
   const inputs = node.vParameters.vParameters
     .map((decl) => {
-      const baseType = getNodeTypeInCtx(decl, compilerVersion, nodeInSourceUnit ?? decl);
+      const baseType = safeGetNodeTypeInCtx(decl, compilerVersion, nodeInSourceUnit ?? decl);
       if (
         baseType instanceof ArrayType ||
         baseType instanceof BytesType ||
@@ -127,7 +127,7 @@ export function getReturnTypeString(
   const retParams = node.vReturnParameters.vParameters;
   const parametersTypeString = retParams
     .map((decl) => {
-      const type = getNodeTypeInCtx(decl, ast.compilerVersion, nodeInSourceUnit ?? decl);
+      const type = safeGetNodeTypeInCtx(decl, ast.compilerVersion, nodeInSourceUnit ?? decl);
       return type instanceof PointerType
         ? type
         : specializeType(generalizeType(type)[0], decl.storageLocation);

--- a/src/utils/nodeTemplates.ts
+++ b/src/utils/nodeTemplates.ts
@@ -12,7 +12,6 @@ import {
   FunctionKind,
   FunctionStateMutability,
   FunctionVisibility,
-  getNodeTypeInCtx,
   Identifier,
   Literal,
   LiteralKind,
@@ -27,7 +26,7 @@ import {
 } from 'solc-typed-ast';
 import { AST } from '../ast/ast';
 import { generateExpressionTypeString, generateLiteralTypeString } from './getTypeString';
-import { specializeType } from './nodeTypeProcessing';
+import { safeGetNodeTypeInCtx, specializeType } from './nodeTypeProcessing';
 import { notNull } from './typeConstructs';
 import { toHexString, toSingleExpression } from './utils';
 
@@ -125,7 +124,7 @@ export function createIdentifier(
   lookupNode?: ASTNode,
 ): Identifier {
   const type = specializeType(
-    getNodeTypeInCtx(variable, ast.compilerVersion, lookupNode ?? variable),
+    safeGetNodeTypeInCtx(variable, ast.compilerVersion, lookupNode ?? variable),
     dataLocation ?? (variable.stateVariable ? DataLocation.Storage : variable.storageLocation),
   );
   const node = new Identifier(

--- a/src/utils/nodeTypeProcessing.ts
+++ b/src/utils/nodeTypeProcessing.ts
@@ -42,7 +42,7 @@ getting the expected types of their arguments, this centralises that process
 Does not handle type conversion functions, as they don't have a specific input type
 */
 export function getParameterTypes(functionCall: FunctionCall, ast: AST): TypeNode[] {
-  const functionType = getNodeType(functionCall.vExpression, ast.compilerVersion);
+  const functionType = safeGetNodeType(functionCall.vExpression, ast.compilerVersion);
   switch (functionCall.kind) {
     case FunctionCallKind.FunctionCall:
       assert(
@@ -263,7 +263,7 @@ export function isStorageSpecificType(
   ) {
     visitedStructs.push(type.definition.id);
     return type.definition.vMembers.some((m) =>
-      isStorageSpecificType(getNodeType(m, ast.compilerVersion), ast, visitedStructs),
+      isStorageSpecificType(safeGetNodeType(m, ast.compilerVersion), ast, visitedStructs),
     );
   }
   return false;

--- a/src/utils/nodeTypeProcessing.ts
+++ b/src/utils/nodeTypeProcessing.ts
@@ -2,16 +2,19 @@ import assert from 'assert';
 import {
   AddressType,
   ArrayType,
+  ASTNode,
   BoolType,
   BytesType,
   DataLocation,
   EnumDefinition,
+  Expression,
   FixedBytesType,
   FunctionCall,
   FunctionCallKind,
   FunctionType,
   generalizeType,
   getNodeType,
+  getNodeTypeInCtx,
   IntType,
   MappingType,
   PackedArrayType,
@@ -24,12 +27,14 @@ import {
   TypeNameType,
   TypeNode,
   UserDefinedType,
+  VariableDeclaration,
   variableDeclarationToTypeNode,
 } from 'solc-typed-ast';
 import { AST } from '../ast/ast';
 import { printNode, printTypeNode } from './astPrinter';
 import { TranspileFailedError } from './errors';
 import { error } from './formatting';
+import { getContainingSourceUnit } from './utils';
 
 /*
 Normal function calls and struct constructors require different methods for
@@ -262,4 +267,18 @@ export function isStorageSpecificType(
     );
   }
   return false;
+}
+
+export function safeGetNodeType(node: Expression | VariableDeclaration, version: string): TypeNode {
+  getContainingSourceUnit(node);
+  return getNodeType(node, version);
+}
+
+export function safeGetNodeTypeInCtx(
+  arg: string | VariableDeclaration | Expression,
+  version: string,
+  ctx: ASTNode,
+): TypeNode {
+  getContainingSourceUnit(ctx);
+  return getNodeTypeInCtx(arg, version, ctx);
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -20,7 +20,6 @@ import {
   FunctionStateMutability,
   FunctionVisibility,
   generalizeType,
-  getNodeType,
   Identifier,
   IdentifierPath,
   IndexAccess,
@@ -63,7 +62,7 @@ import {
   createBytesTypeName,
   createNumberLiteral,
 } from './nodeTemplates';
-import { isDynamicArray, isDynamicCallDataArray } from './nodeTypeProcessing';
+import { isDynamicArray, isDynamicCallDataArray, safeGetNodeType } from './nodeTypeProcessing';
 import { Class } from './typeConstructs';
 
 const uint128 = BigInt('0x100000000000000000000000000000000');
@@ -430,7 +429,7 @@ export function isExternalMemoryDynArray(node: Identifier, compilerVersion: stri
     return false;
 
   const declarationLocation = declaration.storageLocation;
-  const [nodeType, typeLocation] = generalizeType(getNodeType(node, compilerVersion));
+  const [nodeType, typeLocation] = generalizeType(safeGetNodeType(node, compilerVersion));
 
   return (
     isDynamicArray(nodeType) &&
@@ -442,7 +441,7 @@ export function isExternalMemoryDynArray(node: Identifier, compilerVersion: stri
 // Detects when an identifier represents a calldata dynamic array in solidity
 export function isCalldataDynArrayStruct(node: Identifier, compilerVersion: string): boolean {
   return (
-    isDynamicCallDataArray(getNodeType(node, compilerVersion)) &&
+    isDynamicCallDataArray(safeGetNodeType(node, compilerVersion)) &&
     ((node.getClosestParentByType(Return) !== undefined &&
       node.getClosestParentByType(IndexAccess) === undefined &&
       node.getClosestParentByType(FunctionDefinition)?.visibility === FunctionVisibility.External &&

--- a/src/warplib/implementations/conversions/fixedBytes.ts
+++ b/src/warplib/implementations/conversions/fixedBytes.ts
@@ -1,21 +1,22 @@
 import assert from 'assert';
-import { FixedBytesType, FunctionCall, generalizeType, getNodeType } from 'solc-typed-ast';
+import { FixedBytesType, FunctionCall, generalizeType } from 'solc-typed-ast';
 import { AST } from '../../../ast/ast';
 import { printTypeNode, printNode } from '../../../utils/astPrinter';
 import { createCairoFunctionStub, createCallToFunction } from '../../../utils/functionGeneration';
 import { createNumberLiteral, createUint8TypeName } from '../../../utils/nodeTemplates';
+import { safeGetNodeType } from '../../../utils/nodeTypeProcessing';
 import { typeNameFromTypeNode } from '../../../utils/utils';
 
 export function functionaliseFixedBytesConversion(conversion: FunctionCall, ast: AST): void {
   const arg = conversion.vArguments[0];
-  const fromType = generalizeType(getNodeType(arg, ast.compilerVersion))[0];
+  const fromType = generalizeType(safeGetNodeType(arg, ast.compilerVersion))[0];
   assert(
     fromType instanceof FixedBytesType,
     `Argument of fixed bytes conversion expected to be fixed bytes type. Got ${printTypeNode(
       fromType,
     )} at ${printNode(conversion)}`,
   );
-  const toType = getNodeType(conversion, ast.compilerVersion);
+  const toType = safeGetNodeType(conversion, ast.compilerVersion);
   assert(
     toType instanceof FixedBytesType,
     `Fixed bytes conversion expected to be fixed bytes type. Got ${printTypeNode(

--- a/src/warplib/implementations/conversions/int.ts
+++ b/src/warplib/implementations/conversions/int.ts
@@ -1,8 +1,9 @@
 import assert from 'assert';
-import { FunctionCall, generalizeType, getNodeType, IntType } from 'solc-typed-ast';
+import { FunctionCall, generalizeType, IntType } from 'solc-typed-ast';
 import { AST } from '../../../ast/ast';
 import { printNode, printTypeNode } from '../../../utils/astPrinter';
 import { Implicits } from '../../../utils/implicits';
+import { safeGetNodeType } from '../../../utils/nodeTypeProcessing';
 import { bound, forAllWidths, generateFile, IntFunction, mask, msb, uint256 } from '../../utils';
 
 export function int_conversions(): void {
@@ -91,14 +92,14 @@ function sign_extend_value(from: number, to: number): bigint {
 
 export function functionaliseIntConversion(conversion: FunctionCall, ast: AST): void {
   const arg = conversion.vArguments[0];
-  const fromType = generalizeType(getNodeType(arg, ast.compilerVersion))[0];
+  const fromType = generalizeType(safeGetNodeType(arg, ast.compilerVersion))[0];
   assert(
     fromType instanceof IntType,
     `Argument of int conversion expected to be int type. Got ${printTypeNode(
       fromType,
     )} at ${printNode(conversion)}`,
   );
-  const toType = getNodeType(conversion, ast.compilerVersion);
+  const toType = safeGetNodeType(conversion, ast.compilerVersion);
   assert(
     toType instanceof IntType,
     `Int conversion expected to be int type. Got ${printTypeNode(toType)} at ${printNode(

--- a/src/warplib/implementations/maths/exp.ts
+++ b/src/warplib/implementations/maths/exp.ts
@@ -3,13 +3,13 @@ import {
   BinaryOperation,
   FunctionCall,
   FunctionCallKind,
-  getNodeType,
   Identifier,
   IntType,
 } from 'solc-typed-ast';
 import { AST } from '../../../ast/ast';
 import { printNode, printTypeNode } from '../../../utils/astPrinter';
 import { createCairoFunctionStub } from '../../../utils/functionGeneration';
+import { safeGetNodeType } from '../../../utils/nodeTypeProcessing';
 import { mapRange, typeNameFromTypeNode } from '../../../utils/utils';
 import { forAllWidths, generateFile, getIntOrFixedByteBitWidth, mask } from '../../utils';
 
@@ -177,9 +177,9 @@ function getNegativeOneShortcutCode(signed: boolean, lhsWidth: number, rhsWide: 
 }
 
 export function functionaliseExp(node: BinaryOperation, unsafe: boolean, ast: AST) {
-  const lhsType = getNodeType(node.vLeftExpression, ast.compilerVersion);
-  const rhsType = getNodeType(node.vRightExpression, ast.compilerVersion);
-  const retType = getNodeType(node, ast.compilerVersion);
+  const lhsType = safeGetNodeType(node.vLeftExpression, ast.compilerVersion);
+  const rhsType = safeGetNodeType(node.vRightExpression, ast.compilerVersion);
+  const retType = safeGetNodeType(node, ast.compilerVersion);
   assert(
     retType instanceof IntType,
     `${printNode(node)} has type ${printTypeNode(retType)}, which is not compatible with **`,

--- a/src/warplib/implementations/maths/shl.ts
+++ b/src/warplib/implementations/maths/shl.ts
@@ -4,13 +4,13 @@ import {
   FixedBytesType,
   FunctionCall,
   FunctionCallKind,
-  getNodeType,
   Identifier,
   IntType,
 } from 'solc-typed-ast';
 import { AST } from '../../../ast/ast';
 import { printNode, printTypeNode } from '../../../utils/astPrinter';
 import { createCairoFunctionStub } from '../../../utils/functionGeneration';
+import { safeGetNodeType } from '../../../utils/nodeTypeProcessing';
 import { typeNameFromTypeNode } from '../../../utils/utils';
 import { generateFile, forAllWidths, getIntOrFixedByteBitWidth } from '../../utils';
 
@@ -72,9 +72,9 @@ export function shl(): void {
 }
 
 export function functionaliseShl(node: BinaryOperation, ast: AST): void {
-  const lhsType = getNodeType(node.vLeftExpression, ast.compilerVersion);
-  const rhsType = getNodeType(node.vRightExpression, ast.compilerVersion);
-  const retType = getNodeType(node, ast.compilerVersion);
+  const lhsType = safeGetNodeType(node.vLeftExpression, ast.compilerVersion);
+  const rhsType = safeGetNodeType(node.vRightExpression, ast.compilerVersion);
+  const retType = safeGetNodeType(node, ast.compilerVersion);
 
   assert(
     lhsType instanceof IntType || lhsType instanceof FixedBytesType,

--- a/src/warplib/implementations/maths/shr.ts
+++ b/src/warplib/implementations/maths/shr.ts
@@ -4,13 +4,13 @@ import {
   FixedBytesType,
   FunctionCall,
   FunctionCallKind,
-  getNodeType,
   Identifier,
   IntType,
 } from 'solc-typed-ast';
 import { AST } from '../../../ast/ast';
 import { printNode, printTypeNode } from '../../../utils/astPrinter';
 import { createCairoFunctionStub } from '../../../utils/functionGeneration';
+import { safeGetNodeType } from '../../../utils/nodeTypeProcessing';
 import { mapRange, typeNameFromTypeNode } from '../../../utils/utils';
 import {
   generateFile,
@@ -218,9 +218,9 @@ export function shr_signed(): void {
 }
 
 export function functionaliseShr(node: BinaryOperation, ast: AST): void {
-  const lhsType = getNodeType(node.vLeftExpression, ast.compilerVersion);
-  const rhsType = getNodeType(node.vRightExpression, ast.compilerVersion);
-  const retType = getNodeType(node, ast.compilerVersion);
+  const lhsType = safeGetNodeType(node.vLeftExpression, ast.compilerVersion);
+  const rhsType = safeGetNodeType(node.vRightExpression, ast.compilerVersion);
+  const retType = safeGetNodeType(node, ast.compilerVersion);
 
   assert(
     lhsType instanceof IntType || lhsType instanceof FixedBytesType,

--- a/src/warplib/implementations/maths/sub.ts
+++ b/src/warplib/implementations/maths/sub.ts
@@ -1,8 +1,9 @@
 import assert from 'assert';
-import { BinaryOperation, getNodeType, IntType } from 'solc-typed-ast';
+import { BinaryOperation, IntType } from 'solc-typed-ast';
 import { AST } from '../../../ast/ast';
 import { printTypeNode } from '../../../utils/astPrinter';
 import { Implicits } from '../../../utils/implicits';
+import { safeGetNodeType } from '../../../utils/nodeTypeProcessing';
 import {
   generateFile,
   forAllWidths,
@@ -174,7 +175,7 @@ export function functionaliseSub(node: BinaryOperation, unsafe: boolean, ast: AS
       }
     }
   };
-  const typeNode = getNodeType(node, ast.compilerVersion);
+  const typeNode = safeGetNodeType(node, ast.compilerVersion);
   assert(
     typeNode instanceof IntType,
     `Expected IntType for subtraction, got ${printTypeNode(typeNode)}`,

--- a/tests/behaviour/expectations/semantic.ts
+++ b/tests/behaviour/expectations/semantic.ts
@@ -20,7 +20,6 @@ import {
   VariableDeclaration,
   compileSol,
   resolveAny,
-  getNodeType,
   CompileResult,
   UserDefinedValueTypeDefinition,
   StructDefinition,
@@ -43,6 +42,7 @@ import { notNull } from '../../../src/utils/typeConstructs';
 import assert from 'assert';
 import { AST } from '../../../src/ast/ast';
 import { createDefaultConstructor } from '../../../src/utils/nodeTemplates';
+import { safeGetNodeType } from '../../../src/utils/nodeTypeProcessing';
 
 // this format will cause problems with overloading
 export interface Parameter {
@@ -185,11 +185,11 @@ function transcodeTest(
 
   const inputTypeNodes =
     funcDef instanceof FunctionDefinition
-      ? funcDef.vParameters.vParameters.map((cd) => getNodeType(cd, compilerVersion))
+      ? funcDef.vParameters.vParameters.map((cd) => safeGetNodeType(cd, compilerVersion))
       : funcDef.getterFunType().parameters;
   const outputTypeNodes =
     funcDef instanceof FunctionDefinition
-      ? funcDef.vReturnParameters.vParameters.map((cd) => getNodeType(cd, compilerVersion))
+      ? funcDef.vReturnParameters.vParameters.map((cd) => safeGetNodeType(cd, compilerVersion))
       : funcDef.getterFunType().returns;
 
   let removePrefix = 10;
@@ -297,7 +297,7 @@ export function encodeValue(tp: TypeNode, value: SolValue, compilerVersion: stri
     const definition = tp.definition;
     if (definition instanceof UserDefinedValueTypeDefinition) {
       return encodeValue(
-        getNodeType(definition.underlyingType, compilerVersion),
+        safeGetNodeType(definition.underlyingType, compilerVersion),
         value,
         compilerVersion,
       );
@@ -307,7 +307,7 @@ export function encodeValue(tp: TypeNode, value: SolValue, compilerVersion: stri
       }
       const membersEncoding: string[][] = [];
       for (let index = 0; index < value.length; index++) {
-        const memberTypeNode = getNodeType(definition.vMembers[index], compilerVersion);
+        const memberTypeNode = safeGetNodeType(definition.vMembers[index], compilerVersion);
         const memberValue = value[index];
         membersEncoding.push(encodeValue(memberTypeNode, memberValue, compilerVersion));
       }
@@ -369,7 +369,7 @@ async function encodeConstructors(
       'Constructor must be of type functionDefinition',
     );
     const typeNodes = constrDef.vParameters.vParameters.map((cd) =>
-      getNodeType(cd, ast.compilerVersion),
+      safeGetNodeType(cd, ast.compilerVersion),
     );
     constructorArgs = encode(constrAbi.inputs, typeNodes, firstTest.callData, ast.compilerVersion);
   }


### PR DESCRIPTION
- Check that the node to parse the `typestring` is attached to a `SourceUnit` node, using `getContainingSourceUnit` method, which already has an assertion to check the result is not undefined
- Replace every use of `getNodeType` and `getNodeTypeInCtx` with the new functions