### PR TITLE
execution test for anonymous parameters

### DIFF
--- a/tests/behaviour/contracts/anonymous_parameters/func_override.sol
+++ b/tests/behaviour/contracts/anonymous_parameters/func_override.sol
@@ -1,0 +1,33 @@
+pragma solidity ^0.8.14;
+
+//SPDX-License-Identifier: MIT
+
+contract A {
+
+    function f8(uint8, uint8) virtual external pure returns (uint8) {
+        return 10;
+    }
+
+    function f256(uint256, uint256) virtual external pure returns (uint256) {
+        return 10;
+    }
+}
+
+contract B is A {
+
+    function f8(uint8 x0, uint8 x1 ) override external pure returns (uint8) {
+        return x0 + x1;
+    }
+
+    function f256(uint256 x0, uint256 x1 ) override external pure returns (uint256) {
+        return x0 + x1;
+    }
+
+    function one_argument8(uint8 x0, uint8) external pure returns (uint8) {
+        return x0 + 7;
+    }
+
+    function one_argument256(uint256 x0, uint256) external pure returns (uint256) {
+        return x0 + 7;
+    }
+}

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -22,6 +22,28 @@ export const expectations = flatten(
             ),
           ]),
         ]),
+        new Dir('anonymous_parameters', [
+          new File(
+            'func_override',
+            'A',
+            [],
+            [
+              Expect.Simple('f8', ['1', '2'], ['10']),
+              Expect.Simple('f256', ['1', '0', '2', '0'], ['10', '0']),
+            ],
+          ),
+          new File(
+            'func_override',
+            'B',
+            [],
+            [
+              Expect.Simple('f8', ['3', '2'], ['5']),
+              Expect.Simple('f256', ['5', '0', '4', '0'], ['9', '0']),
+              Expect.Simple('one_argument8', ['5', '4'], ['12']),
+              Expect.Simple('one_argument256', ['7', '0', '90', '725'], ['14', '0']),
+            ],
+          ),
+        ]),
         new Dir('array_len', [
           File.Simple('memoryArray', [Expect.Simple('dynMemArrayLen', [], ['45', '0'])]),
           File.Simple('storageArray', [Expect.Simple('dynStorageArrayLen', [], ['1', '0'])]),


### PR DESCRIPTION
No error in tests using anonymous parameters. Added tests that use uint256