### PR TITLE
Library import bug

### DIFF
--- a/example_contracts/using_for/complex_libraries.sol
+++ b/example_contracts/using_for/complex_libraries.sol
@@ -1,0 +1,27 @@
+pragma solidity ^0.8.10;
+
+library SafeCast {
+  function toUint160(uint256 y) internal pure returns (uint160 z) {
+    require((z = uint160(y)) == y);
+  }
+}
+
+library lib1 {
+  using SafeCast for uint256;
+
+  function f(uint256 x) external pure {
+    uint160 f0 = x.toUint160();
+  }
+}
+
+library lib2 {
+  function g(uint256 x) external pure {
+    lib1.f(x);
+  }
+}
+
+contract C {
+  function fCaller() external pure {
+    lib2.g(5);
+  }
+}

--- a/src/passes/referencedLibraries.ts
+++ b/src/passes/referencedLibraries.ts
@@ -2,6 +2,7 @@ import assert from 'assert';
 import { ContractDefinition, ContractKind, FunctionCall, MemberAccess } from 'solc-typed-ast';
 import { AST } from '../ast/ast';
 import { ASTMapper } from '../ast/mapper';
+import { NotSupportedYetError } from '../utils/errors';
 
 // Library calls in solidity are delegate calls
 // i.e  libraries can be seen as implicit base contracts of the contracts that use them
@@ -33,7 +34,11 @@ export class ReferencedLibraries extends ASTMapper {
 
       // Free functions calling library functions are not yet supported
       const parent = node.getClosestParentByType(ContractDefinition);
-      if (parent === undefined) return;
+      if (parent === undefined) {
+        throw new NotSupportedYetError(
+          'Free functions calling library functions are not yet supported',
+        );
+      }
 
       // Checks if the Function is a referenced Library function,
       // if yes add it to the linearizedBaseContract list of parent ContractDefinition node.

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -213,6 +213,7 @@ const expectedResults = new Map<string, ResultType>(
     ['example_contracts/using_for/imports/user_defined', 'Success'],
     // global_directive.sol cannot resolve struct when file imported as identifier
     ['example_contracts/using_for/imports/global_directive', 'Success'],
+    ['example_contracts/using_for/complex_libraries', 'Success'],
     ['example_contracts/using_for/function', 'WillNotSupport'],
     ['example_contracts/using_for/private', 'Success'],
     ['example_contracts/using_for/library', 'Success'],


### PR DESCRIPTION
The `ReferencedLibraries` pass was modified to correctly handle the case in which the referenced library refers to another and this in turn to another and so on