### PR TITLE
Optimize referenced libraries pass

### DIFF
--- a/src/passes/referencedLibraries.ts
+++ b/src/passes/referencedLibraries.ts
@@ -16,6 +16,24 @@ import { ASTMapper } from '../ast/mapper';
 // linearizedBaselist of a contract/Library.
 
 export class ReferencedLibraries extends ASTMapper {
+  static map(ast: AST): AST {
+    // Collect all library nodes and their ids in the map 'librariesById'
+    const librariesById: Map<number, ContractDefinition> = new Map();
+    ast.context.map.forEach((astNode, id) => {
+      if (astNode instanceof ContractDefinition && astNode.kind === ContractKind.Library) {
+        librariesById.set(id, astNode);
+      }
+    });
+
+    ast.roots.forEach((root) => {
+      const mapper = new LibraryHandler(librariesById);
+      mapper.dispatchVisit(root, ast);
+    });
+    return ast;
+  }
+}
+
+class LibraryHandler extends ASTMapper {
   librariesById: Map<number, ContractDefinition>;
 
   constructor(libraries: Map<number, ContractDefinition>) {
@@ -55,22 +73,6 @@ export class ReferencedLibraries extends ASTMapper {
       }
     }
     this.commonVisit(node, ast);
-  }
-
-  static map(ast: AST): AST {
-    // Collect all library nodes and their ids in the map 'librariesById'
-    const librariesById: Map<number, ContractDefinition> = new Map();
-    ast.context.map.forEach((astNode, id) => {
-      if (astNode instanceof ContractDefinition && astNode.kind === ContractKind.Library) {
-        librariesById.set(id, astNode);
-      }
-    });
-
-    ast.roots.forEach((root) => {
-      const mapper = new this(librariesById);
-      mapper.dispatchVisit(root, ast);
-    });
-    return ast;
   }
 }
 


### PR DESCRIPTION
The `ReferencedLibraries` pass adds all libraries referenced by a contract. To do so, when it encountered a function call, it would check to see if it was calling a declaration in a library, and then recursively check all function calls within that library, adding more libraries to the list. As a consequence, the resulting list might contain extra libraries, which were not actually being referenced.

The modification in the code of this pass corrects this situation. Instead of going through all the function calls inside the library, it goes through the function calls inside the referenced declaration only.