### PR TITLE
Detect implicits from Cairo stubs

### DIFF
--- a/example_contracts/implicitsFromStub.sol
+++ b/example_contracts/implicitsFromStub.sol
@@ -1,0 +1,17 @@
+pragma solidity ^0.8.14;
+
+contract C {
+
+    ///warp-cairo
+    ///func CURRENTFUNC(){ bitwise_ptr :BitwiseBuiltin* ,pedersen_ptr: HashBuiltin*,range_check_ptr}(lhs : felt, rhs : felt) -> (res : felt):
+    ///from starkware.cairo.common.bitwise import bitwise_or
+    ///    let (res) = bitwise_or(lhs, rhs)
+    ///    return (res)
+    ///end
+    function f(uint8 a, uint8 b) internal pure {
+    }
+
+    function g() external pure {
+        f(10, 12);
+    }
+}

--- a/src/passes/annotateImplicits.ts
+++ b/src/passes/annotateImplicits.ts
@@ -11,8 +11,10 @@ import { CairoFunctionDefinition, FunctionStubKind } from '../ast/cairoNodes';
 import { ASTMapper } from '../ast/mapper';
 import { ASTVisitor } from '../ast/visitor';
 import { printNode } from '../utils/astPrinter';
+import { TranspileFailedError } from '../utils/errors';
 import { Implicits, registerImportsForImplicit } from '../utils/implicits';
 import { isExternallyVisible, union } from '../utils/utils';
+import { getDocString, isCairoStub } from './cairoStubProcessor';
 
 export class AnnotateImplicits extends ASTMapper {
   // Function to add passes that should have been run before this pass
@@ -89,6 +91,10 @@ class ImplicitCollector extends ASTVisitor<Set<Implicits>> {
 
   visitFunctionDefinition(node: FunctionDefinition, ast: AST): Set<Implicits> {
     const result: Set<Implicits> = new Set();
+    if (isCairoStub(node)) {
+      extractImplicitFromStubs(node, result);
+      return node === this.root ? result : union(result, this.commonVisit(node, ast));
+    }
     if (node.implemented && isExternallyVisible(node)) {
       result.add('range_check_ptr');
       result.add('syscall_ptr');
@@ -98,6 +104,7 @@ class ImplicitCollector extends ASTVisitor<Set<Implicits>> {
       result.add('pedersen_ptr');
       result.add('range_check_ptr');
     }
+
     if (node === this.root) return result;
     return union(result, this.commonVisit(node, ast));
   }
@@ -128,4 +135,48 @@ class ImplicitCollector extends ASTVisitor<Set<Implicits>> {
     result.add('range_check_ptr');
     return result;
   }
+}
+
+function extractImplicitFromStubs(node: FunctionDefinition, result: Set<Implicits>) {
+  const cairoCode = getDocString(node.documentation);
+  assert(cairoCode !== undefined);
+  const funcSignature = cairoCode.match(/func .+\{(.+)\}/);
+  if (funcSignature === null) return;
+
+  // implicits -> impl1 : type1, impl2, ..., impln : typen
+  const implicits = funcSignature[1];
+
+  // implicitsList -> [impl1 : type1, impl2, ...., impln : typen]
+  const implicitsList = [...implicits.matchAll(/[A-Za-z][A-Za-z_: 0-9]*/g)].map((w) => w[0]);
+
+  // implicitsNameList -> [impl1, impl2, ..., impln]
+  const implicitsNameList = implicitsList.map((i) => i.match(/[A-Za-z][A-Za-z_0-9]*/));
+  if (!notContainsNull(implicitsNameList)) return;
+
+  // Check that implicits are valid and add them to result
+  implicitsNameList.forEach((i) => {
+    const impl = i[0];
+    if (!elementIsImplicit(impl)) {
+      throw new TranspileFailedError(
+        `Implicit ${impl} defined on function stub (${printNode(node)}) is not known`,
+      );
+    }
+    result.add(impl);
+  });
+}
+
+function elementIsImplicit(e: string): e is Implicits {
+  const knownImplicits = [
+    'bitwise_ptr',
+    'pedersen_ptr',
+    'range_check_ptr',
+    'syscall_ptr',
+    'warp_memory',
+    'keccak_ptr',
+  ];
+  return knownImplicits.includes(e);
+}
+
+function notContainsNull<T>(l: (T | null)[]): l is T[] {
+  return !l.some((e) => e === null);
 }

--- a/src/passes/annotateImplicits.ts
+++ b/src/passes/annotateImplicits.ts
@@ -12,7 +12,7 @@ import { ASTMapper } from '../ast/mapper';
 import { ASTVisitor } from '../ast/visitor';
 import { printNode } from '../utils/astPrinter';
 import { TranspileFailedError } from '../utils/errors';
-import { Implicits, registerImportsForImplicit } from '../utils/implicits';
+import { Implicits, implicitTypes, registerImportsForImplicit } from '../utils/implicits';
 import { isExternallyVisible, union } from '../utils/utils';
 import { getDocString, isCairoStub } from './cairoStubProcessor';
 
@@ -166,15 +166,7 @@ function extractImplicitFromStubs(node: FunctionDefinition, result: Set<Implicit
 }
 
 function elementIsImplicit(e: string): e is Implicits {
-  const knownImplicits = [
-    'bitwise_ptr',
-    'pedersen_ptr',
-    'range_check_ptr',
-    'syscall_ptr',
-    'warp_memory',
-    'keccak_ptr',
-  ];
-  return knownImplicits.includes(e);
+  return Object.keys(implicitTypes).includes(e);
 }
 
 function notContainsNull<T>(l: (T | null)[]): l is T[] {

--- a/src/passes/cairoStubProcessor.ts
+++ b/src/passes/cairoStubProcessor.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import { ASTNode, FunctionDefinition, StructuredDocumentation } from 'solc-typed-ast';
 import { AST } from '../ast/ast';
 import { CairoContract } from '../ast/cairoNodes';
@@ -11,10 +12,10 @@ import { isExternallyVisible } from '../utils/utils';
 
 export class CairoStubProcessor extends ASTMapper {
   visitFunctionDefinition(node: FunctionDefinition, _ast: AST): void {
-    let documentation = getDocString(node.documentation);
-    if (documentation === undefined) return;
+    if (!isCairoStub(node)) return;
 
-    if (documentation.split('\n')[0]?.trim() !== 'warp-cairo') return;
+    let documentation = getDocString(node.documentation);
+    assert(documentation !== undefined);
 
     documentation = processDecoratorTags(documentation);
     documentation = processStateVarTags(documentation, node);
@@ -117,12 +118,6 @@ function processMacro(
   }, documentation);
 }
 
-function getDocString(doc: StructuredDocumentation | string | undefined): string | undefined {
-  if (doc === undefined) return undefined;
-  if (typeof doc === 'string') return doc;
-  return doc.text;
-}
-
 function setDocString(node: FunctionDefinition, docString: string): void {
   const existingDoc = node.documentation;
   if (existingDoc instanceof StructuredDocumentation) {
@@ -130,4 +125,17 @@ function setDocString(node: FunctionDefinition, docString: string): void {
   } else {
     node.documentation = docString;
   }
+}
+
+export function getDocString(
+  doc: StructuredDocumentation | string | undefined,
+): string | undefined {
+  if (doc === undefined) return undefined;
+  if (typeof doc === 'string') return doc;
+  return doc.text;
+}
+
+export function isCairoStub(node: FunctionDefinition): boolean {
+  const documentation = getDocString(node.documentation);
+  return documentation !== undefined && documentation.split('\n')[0]?.trim() === 'warp-cairo';
 }

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -114,6 +114,7 @@ const expectedResults = new Map<string, ResultType>(
     ['example_contracts/idManglingTest8', 'Success'],
     ['example_contracts/idManglingTest9', 'Success'],
     ['example_contracts/if_flattening', 'Success'],
+    ['example_contracts/implicitsFromStub.sol', 'Success'],
     ['example_contracts/imports/importContract', 'Success'],
     ['example_contracts/imports/importEnum', 'Success'],
     ['example_contracts/imports/importfrom', 'Success'],

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -114,7 +114,7 @@ const expectedResults = new Map<string, ResultType>(
     ['example_contracts/idManglingTest8', 'Success'],
     ['example_contracts/idManglingTest9', 'Success'],
     ['example_contracts/if_flattening', 'Success'],
-    ['example_contracts/implicitsFromStub.sol', 'Success'],
+    ['example_contracts/implicitsFromStub', 'Success'],
     ['example_contracts/imports/importContract', 'Success'],
     ['example_contracts/imports/importEnum', 'Success'],
     ['example_contracts/imports/importfrom', 'Success'],


### PR DESCRIPTION
Given a function which is used as placeholder for a Cairo stub, its implicits (and the implicits of all the functions who call's it) are determined by the stub definition and not the solidity definition.

For example:
```Solidity
pragma solidity ^0.8.14;

contract C {

    ///warp-cairo
    ///func CURRENTFUNC(){bitwise_ptr : BitwiseBuiltin* }(lhs : felt, rhs : felt) -> (res : felt):
    ///from starkware.cairo.common.bitwise import bitwise_or
    ///    let (res) = bitwise_or(lhs, rhs)
    ///    return (res)
    ///end
    function f(uint8 a, uint8 b) internal pure returns (bytes32) {
        return keccak256(abi.encodePacked(a, b));
    }

    function g() external pure {
        f(10, 12);
    }
}
```
In this case `g` which interacts with `f` will have `bitwise_ptr` instead of `keccak_ptr` as its implicits after transpilation