### PR TITLE
fix audit on declarationNameMangler.ts

### DIFF
--- a/src/passes/identifierManglerPass/declarationNameMangler.ts
+++ b/src/passes/identifierManglerPass/declarationNameMangler.ts
@@ -21,7 +21,7 @@ import { isNameless } from '../../utils/utils';
 
 // Terms grabbed from here
 // https://github.com/starkware-libs/cairo-lang/blob/master/src/starkware/cairo/lang/compiler/cairo.ebnf
-export const reservedTerms = [
+export const reservedTerms = new Set<string>([
   'ret',
   'return',
   'using',
@@ -55,28 +55,39 @@ export const reservedTerms = [
   'const',
   'struct',
   'namespace',
-];
+]);
 
 const unsupportedCharacters = ['$'];
 
 export function checkSourceTerms(term: string, node: ASTNode) {
-  if (reservedTerms.includes(term)) {
+  if (reservedTerms.has(term)) {
     throw new WillNotSupportError(`${printNode(node)} contains ${term} which is a cairo keyword`);
   }
 
-  unsupportedCharacters.forEach((c: string) => {
-    if (term.includes(c)) {
-      throw new WillNotSupportError(
-        `${printNode(node)} ${term} contains unsupported character ${c}`,
-      );
-    }
-  });
+  // Creating the regular expression that match unsupportedCharacters
+  let regex_str = '\\' + unsupportedCharacters[0];
+  for (let index = 1; index < unsupportedCharacters.length; index++) {
+    regex_str += '|\\' + unsupportedCharacters[index];
+  }
+  // Looking for possible matches
+  const regex = RegExp(regex_str, 'g');
+  let match;
+  let unsupported_characters_found: string = '';
+  while ((match = regex.exec(term)) !== null) {
+    unsupported_characters_found += match[0];
+  }
+  if (unsupported_characters_found) {
+    throw new WillNotSupportError(
+      `${printNode(
+        node,
+      )} ${term} contains unsupported character(s) "${unsupported_characters_found}"`,
+      node,
+    );
+  }
 }
 
 export class DeclarationNameMangler extends ASTMapper {
-  lastUsedVariableId = 0;
-  lastUsedFunctionId = 0;
-  lastUsedTypeId = 0;
+  lastUsedId = 0;
 
   // This strategy should allow checked demangling post transpilation for a more readable result
   createNewExternalFunctionName(fd: FunctionDefinition): string {
@@ -85,17 +96,34 @@ export class DeclarationNameMangler extends ASTMapper {
       : fd.name;
   }
 
+  // Format a number to achieve a minimum lenght
+  formatNumber(n: number): string {
+    let s = n.toString();
+    return s.padStart(4, '0');
+  }
+
+  formatString(s: string): string {
+    s = s.padEnd(10, '_');
+    return s.slice(0, 10);
+  }
+
   // This strategy should allow checked demangling post transpilation for a more readable result
   createNewInternalFunctionName(existingName: string): string {
-    return `${MANGLED_INTERNAL_USER_FUNCTION}${this.lastUsedFunctionId++}_${existingName}`;
+    const id = this.formatNumber(this.lastUsedId++);
+    const name = this.formatString(existingName);
+    return `${MANGLED_INTERNAL_USER_FUNCTION}_${id}_${name}`;
   }
 
   createNewTypeName(existingName: string): string {
-    return `${MANGLED_TYPE_NAME}${this.lastUsedTypeId++}_${existingName}`;
+    const id = this.formatNumber(this.lastUsedId++);
+    const name = this.formatString(existingName);
+    return `${MANGLED_TYPE_NAME}_${id}_${name}`;
   }
 
   createNewVariableName(existingName: string): string {
-    return `${MANGLED_LOCAL_VAR}${this.lastUsedVariableId++}_${existingName}`;
+    const id = this.formatNumber(this.lastUsedId++);
+    const name = this.formatString(existingName);
+    return `${MANGLED_LOCAL_VAR}_${id}_${name}`;
   }
 
   visitStructDefinition(_node: StructDefinition, _ast: AST): void {

--- a/src/utils/nameModifiers.ts
+++ b/src/utils/nameModifiers.ts
@@ -13,7 +13,7 @@ export const CONTRACT_INFIX = '__WC__';
 
 // Used in IdentifierManglerPass
 export const MANGLED_INTERNAL_USER_FUNCTION = '__warp_usrfn';
-export const MANGLED_TYPE_NAME = '__warp_usrT';
+export const MANGLED_TYPE_NAME = '__warp_usrTp';
 export const MANGLED_LOCAL_VAR = '__warp_usrid';
 
 // Used in StaticArrayIndexer


### PR DESCRIPTION
- Names of internal functions, new types and new variables are of fixed width unless id value pass over 4 digits (otherwise names should be stored and revisited later). 
- Use a set for reservedTerms to speed up consults.
- Look for unsupported characters in terms using regular experssions.
- Unified counter to create id for external functions. types and variables names.