### PR TITLE
Bug related to libraries and inheritance

### DIFF
--- a/src/passes/inheritanceInliner/inheritanceInliner.ts
+++ b/src/passes/inheritanceInliner/inheritanceInliner.ts
@@ -27,6 +27,9 @@ export class InheritanceInliner extends ASTMapper {
   // Function to add passes that should have been run before this pass
   addInitialPassPrerequisites(): void {
     const passKeys: Set<string> = new Set<string>([
+      // ReferencedLibraries pass adds referenced libraries to the list of
+      // linearized base contracts of each contract.
+      'Rl',
       // StorageAllocator takes care of variable initialization, which
       // are needed when solving constructors
       'Sa',

--- a/src/passes/inheritanceInliner/inheritanceInliner.ts
+++ b/src/passes/inheritanceInliner/inheritanceInliner.ts
@@ -11,6 +11,7 @@ import { TranspileFailedError } from '../../utils/errors';
 import { solveConstructors } from './constructorInheritance';
 import { addEventDefintion } from './eventInheritance';
 import { addNonoverridenPublicFunctions, addPrivateSuperFunctions } from './functionInheritance';
+import { solveLibraryInheritance } from './libraryInheritance';
 import { addNonOverridenModifiers } from './modifiersInheritance';
 import { addStorageVariables } from './storageVariablesInheritance';
 import {
@@ -34,6 +35,11 @@ export class InheritanceInliner extends ASTMapper {
   }
 
   visitCairoContract(node: CairoContract, ast: AST): void {
+    // Referenced libraries pass added the referenced libraries to the
+    // linearized list of base contracts of a certain contract `A`.
+    // All contracts that inherit from `A` need to add those libraries as well.
+    solveLibraryInheritance(node, ast);
+
     // This functions handles:
     //   - the assignment of a constructor to each contract
     //   - calling the functions for variable initialization

--- a/src/passes/inheritanceInliner/libraryInheritance.ts
+++ b/src/passes/inheritanceInliner/libraryInheritance.ts
@@ -1,0 +1,32 @@
+import assert from 'assert';
+import { ContractDefinition, ContractKind } from 'solc-typed-ast';
+import { AST } from '../../ast/ast';
+import { CairoContract } from '../../ast/cairoNodes';
+import { getBaseContracts } from './utils';
+
+export function solveLibraryInheritance(node: CairoContract, ast: AST) {
+  const libraryIds = collectAllLibrariesId(ast);
+  node.linearizedBaseContracts.push(...getLibrariesInInheritanceLine(node, libraryIds));
+}
+
+function getLibrariesInInheritanceLine(node: CairoContract, libraryIds: Set<number>) {
+  const libraries: Set<number> = new Set();
+  getBaseContracts(node).forEach((contract) =>
+    contract.linearizedBaseContracts
+      .filter((id) => !node.linearizedBaseContracts.includes(id))
+      .forEach((contractId) => {
+        assert(libraryIds.has(contractId), `Contract #${contractId} should be a library`);
+        libraries.add(contractId);
+      }),
+  );
+  return libraries;
+}
+
+function collectAllLibrariesId(ast: AST): Set<number> {
+  const librariesById: Set<number> = new Set();
+  ast.context.map.forEach((astNode, id) => {
+    if (astNode instanceof ContractDefinition && astNode.kind === ContractKind.Library)
+      librariesById.add(id);
+  });
+  return librariesById;
+}

--- a/tests/behaviour/contracts/libraries/libraries_in_inheritance.sol
+++ b/tests/behaviour/contracts/libraries/libraries_in_inheritance.sol
@@ -1,0 +1,30 @@
+pragma solidity ^0.8.14;
+
+library A1 {
+  function f(uint256 a, uint256 b) internal view returns (uint256) {
+    return a + b;
+  }
+}
+
+library A2 {
+  function h(uint256 c, uint256 d) internal {}
+}
+
+contract B {
+  using A1 for uint256;
+  uint256 val;
+
+  function g() external returns (uint256) {
+    A2.h(1, 2);
+    return val.f(1);
+  }
+}
+
+contract C is B {
+  using A1 for uint256;
+
+  function debug() external view {
+    uint256 a = 0;
+    a.f(1);
+  }
+}

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -2880,6 +2880,7 @@ export const expectations = flatten(
           ]),
           File.Simple('importLibs', [Expect.Simple('addSub', ['5', '4'], ['9', '1'])]),
           File.Simple('LibInLib', [Expect.Simple('mulDiv', ['5', '2'], ['10', '2', '1'])]),
+          new File('libraries_in_inheritance', 'C', [], [Expect.Simple('g', [], ['1', '0'])]),
           File.Simple('library_call_in_homestead', [
             new Expect('f', [['f', [], [], '234']]),
             new Expect('sender', [['sender', [], ['234'], '465']]),


### PR DESCRIPTION
When the set of referenced libraries was added to the list of linearized contracts of a contract, those libraries were not being added to contracts that inherit from that contract, which should happen.
Solution:
Add a method at the beginning of the inheritanceInliner pass that handles going through the list of linearized contracts of each one of the base contracts looking for all contract ids that were not added in the current linearization list, and add them