### PR TITLE
Optimization in  ReferencedLibraries pass

### DIFF
--- a/src/passes/referencedLibraries.ts
+++ b/src/passes/referencedLibraries.ts
@@ -8,41 +8,53 @@ import { ASTMapper } from '../ast/mapper';
 // The pass converts external call to a library to an internal call to it
 // by adding the referenced Libraries in the `FunctionCall` to the
 // linearizedBaselist of a contract/Library.
-
 export class ReferencedLibraries extends ASTMapper {
   // Function to add passes that should have been run before this pass
   addInitialPassPrerequisites(): void {
     const passKeys: Set<string> = new Set<string>([
-      // Free Function inliner handles free functions that make library calls
+      // FreeFunctionInliner handles free functions that make library calls
       'Ffi',
     ]);
     passKeys.forEach((key) => this.addPassPrerequisite(key));
   }
 
-  visitFunctionCall(node: FunctionCall, ast: AST): void {
-    const librariesById = new Map<number, ContractDefinition>();
-    if (node.vExpression instanceof MemberAccess) {
-      // Collect all library nodes and their ids in the map 'librariesById'
-      ast.context.map.forEach((astNode, id) => {
-        if (astNode instanceof ContractDefinition && astNode.kind === ContractKind.Library) {
-          librariesById.set(id, astNode);
-        }
-      });
-
-      const calledDeclaration = node.vReferencedDeclaration;
-      if (calledDeclaration === undefined) {
-        return this.visitExpression(node, ast);
+  static map(ast: AST): AST {
+    // Collect all library nodes and their ids in the map 'librariesById'
+    const librariesById: Map<number, ContractDefinition> = new Map();
+    ast.context.map.forEach((astNode, id) => {
+      if (astNode instanceof ContractDefinition && astNode.kind === ContractKind.Library) {
+        librariesById.set(id, astNode);
       }
+    });
 
-      // Free functions calling library functions are not yet supported
+    ast.roots.forEach((root) => new LibraryHandler(librariesById).dispatchVisit(root, ast));
+    return ast;
+  }
+}
+
+class LibraryHandler extends ASTMapper {
+  librariesById: Map<number, ContractDefinition>;
+
+  constructor(libraries: Map<number, ContractDefinition>) {
+    super();
+    this.librariesById = libraries;
+  }
+
+  visitFunctionCall(node: FunctionCall, ast: AST): void {
+    if (node.vExpression instanceof MemberAccess) {
+      const calledDeclaration = node.vReferencedDeclaration;
+      if (calledDeclaration === undefined) return this.commonVisit(node, ast);
+
+      // Free functions calling library functions are not yet supported.
+      // The previous pass handles inlining those functions, so they can be ignored here.
       const parent = node.getClosestParentByType(ContractDefinition);
       if (parent === undefined) return;
 
-      // Checks if the Function is a referenced Library function,
+      // Checks if the calledDeclaration is a referenced Library declaration,
       // if yes add it to the linearizedBaseContract list of parent ContractDefinition node.
-      const library = findFunctionInLibrary(calledDeclaration.id, librariesById);
+      const library = findFunctionInLibrary(calledDeclaration.id, this.librariesById);
       if (library !== undefined) {
-        getLibrariesToInherit(library, librariesById).forEach((id) => {
+        getLibrariesToInherit(library, this.librariesById).forEach((id) => {
           if (!parent.linearizedBaseContracts.includes(id)) {
             parent.linearizedBaseContracts.push(id);
           }
@@ -53,16 +65,6 @@ export class ReferencedLibraries extends ASTMapper {
   }
 }
 
-function getLibrariesToInherit(
-  calledLibrary: ContractDefinition,
-  librariesById: Map<number, ContractDefinition>,
-): number[] {
-  const ids: number[] = [];
-  getAllLibraries(calledLibrary, librariesById, ids);
-
-  return ids;
-}
-
 function findFunctionInLibrary(
   functionId: number,
   librariesById: Map<number, ContractDefinition>,
@@ -71,6 +73,16 @@ function findFunctionInLibrary(
     if (library.vFunctions.some((f) => f.id == functionId)) return library;
   }
   return undefined;
+}
+
+function getLibrariesToInherit(
+  calledLibrary: ContractDefinition,
+  librariesById: Map<number, ContractDefinition>,
+): number[] {
+  const ids: number[] = [];
+  getAllLibraries(calledLibrary, librariesById, ids);
+
+  return ids;
 }
 
 function getAllLibraries(


### PR DESCRIPTION
Code was modified so collecting the libraries of the ast would happen only once at the beginning, instead of every time a `FunctionCall` was visited
- [x] Sem Tests Running
- [x] Sem Tests Passed