### PR TITLE
Minor docs update

### DIFF
--- a/docs/docs/features/cairo_stubs.mdx
+++ b/docs/docs/features/cairo_stubs.mdx
@@ -105,7 +105,7 @@ end
 # Original soldity abi: ["constructor()","recursiveAdd(uint8,uint8)"]
 ```
 
-The contract above now has the CairoBlock present and it's corresponding Solidity function removed.
+The contract above now has the CairoBlock present and its corresponding Solidity function removed.
 
 ## Additional examples of using Cairo Blocks:
 

--- a/docs/docs/features/cairo_stubs.mdx
+++ b/docs/docs/features/cairo_stubs.mdx
@@ -107,40 +107,7 @@ end
 
 The contract above now has the CairoBlock present and it's corresponding Solidity function removed.
 
-Please note that this is a powerful feature that should be used with care.
-There is a known bug with implicit arguments missing from some Cairo Blocks, preventing compilation. Right now this can be solved by placing some
-Solidity in the stubbed contract that when transpiled will require the implicit argument. As an example doing bitwise comparisons in the
-Solidity function to have the BitwiseBuiltin passed to functions that call the Cairo Block.
-
-For example:
-
-```
-pragma solidity ^0.8.14;
-
-contract C {
-
-    ///warp-cairo
-    ///func CURRENTFUNC(){bitwise_ptr : BitwiseBuiltin*}(lhs : felt, rhs : felt) -> (res : felt):
-    ///from starkware.cairo.common.bitwise import bitwise_or
-    ///    let (res) = bitwise_or(lhs, rhs)
-    ///    return (res)
-    ///end
-    function f(uint8 a, uint8 b) internal pure {
-        a & b;
-    }
-
-    function g() external pure {
-        f(10, 12);
-    }
-}
-```
-
-The bitwise `&` comparison of `a` and `b` adds the implicit to the function `g()` which is calling `f()` , but has no effect on the actual CairoBlock.
-
-A MACRO for passing implicit arguments
-is being developed at the moment.
-
-Additional examples of using Cairo Blocks:
+## Additional examples of using Cairo Blocks:
 
 ```
 pragma solidity ^0.8.10;

--- a/docs/docs/solidity_equivalents/abi_encode.mdx
+++ b/docs/docs/solidity_equivalents/abi_encode.mdx
@@ -3,18 +3,17 @@ title: ABI Encode
 ---
 
 When transpiling solidity code which uses ABI encoding, cairo functions are generated to mimic this behaviour.
-This functions returns a felt array where each element is between 0 and 255, a representation of Solidity's bytes array.
+These functions return a felt array where each element is between 0 and 255, a representation of Solidity's bytes array.
 
-ABI Encoding and packed encoding on both solidity and warped contract will be similar except for addresses.
-Due to cairo addresses being able to occupy the whole felt space and solidity's only being 160 bits (considerably smaller) creates
-compatibility issues, such as:
+ABI Encoding and Packed Encoding on both solidity and warped contracts will be similar except for addresses.
+Due to cairo addresses being able to occupy the whole felt space and solidity's being only 160 bits (considerably smaller) it creates compatibility issues, such as:
 
-- When ABI encoding:
+- When ABI Encoding:
   although each data type occupies 32 bytes slot, and a `felt` fits perfectly inside,
   an address encoded on a warped contract on StarkNet and later decoded on a L1 will
-  cause a `revert` if the address is bigger than 20 bytes. If you wish to decode an address on L1
-  you must substitute the address type for uint256 e.g `abi.decode(data, (address))` -> `abi.decode(data, (uint256))`
+  cause a `revert` if the address is bigger than 20 bytes. If you wish to decode a cairo address on L1 you must
+  substitute the address type for `uint256` (or other similar size type) e.g `abi.decode(data, (address))` -> `abi.decode(data, (uint256))`
 
-- When ABI packed encoding: instead of storing the cairo address inside 20 bytes and having a potential
+- When ABI Packed Encoding: instead of storing the cairo address inside 20 bytes and having a potential
   information lost, they are stored as 32 bytes. As a consequence, the packed encoding in a warped contract
   and the solidity contract will always differ if addresses are one of the included types.

--- a/docs/docs/solidity_equivalents/abi_encode.mdx
+++ b/docs/docs/solidity_equivalents/abi_encode.mdx
@@ -2,11 +2,19 @@
 title: ABI Encode
 ---
 
-When transpiling solidity code which uses ABI encoding, cairo functions are generated to mimic this behaviour. This functions returns a felt array where each element is between 0 and 255, a representation of Solidity's bytes array.
+When transpiling solidity code which uses ABI encoding, cairo functions are generated to mimic this behaviour.
+This functions returns a felt array where each element is between 0 and 255, a representation of Solidity's bytes array.
 
-ABI Encoding and packed encoding on both soldity and warped contract will be similar except for addresses.
-Due to cairo addresses being able to occupy the whole felt space and solidity's only being 160 bits (considerably smaller) brings out compatibility issues, such as:
+ABI Encoding and packed encoding on both solidity and warped contract will be similar except for addresses.
+Due to cairo addresses being able to occupy the whole felt space and solidity's only being 160 bits (considerably smaller) creates
+compatibility issues, such as:
 
-- When ABI encoding: although each data type occupies 32 bytes slot, and a `felt` fits perfectly inside, an address encoded on a warped contract on Starknet and later decoded on a L1 will cause a `revert` if the address is bigger than 20 bytes.
+- When ABI encoding:
+  although each data type occupies 32 bytes slot, and a `felt` fits perfectly inside,
+  an address encoded on a warped contract on StarkNet and later decoded on a L1 will
+  cause a `revert` if the address is bigger than 20 bytes. If you wish to decode an address on L1
+  you must substitute the address type for uint256 e.g `abi.decode(data, (address))` -> `abi.decode(data, (uint256))`
 
-- When ABI packed encoding: instead of storing the cairo address inside 20 bytes and having a potential information lost, they are stored as 32 bytes. As a consecuence, the packed encoding in a warped contract and the solidity contract will always differ if addresses are involved.
+- When ABI packed encoding: instead of storing the cairo address inside 20 bytes and having a potential
+  information lost, they are stored as 32 bytes. As a consequence, the packed encoding in a warped contract
+  and the solidity contract will always differ if addresses are one of the included types.

--- a/docs/docs/solidity_equivalents/abi_encode.mdx
+++ b/docs/docs/solidity_equivalents/abi_encode.mdx
@@ -1,3 +1,12 @@
 ---
-title: ABI Encode (WIP)
+title: ABI Encode
 ---
+
+When transpiling solidity code which uses ABI encoding, cairo functions are generated to mimic this behaviour. This functions returns a felt array where each element is between 0 and 255, a representation of Solidity's bytes array.
+
+ABI Encoding and packed encoding on both soldity and warped contract will be similar except for addresses.
+Due to cairo addresses being able to occupy the whole felt space and solidity's only being 160 bits (considerably smaller) brings out compatibility issues, such as:
+
+- When ABI encoding: although each data type occupies 32 bytes slot, and a `felt` fits perfectly inside, an address encoded on a warped contract on Starknet and later decoded on a L1 will cause a `revert` if the address is bigger than 20 bytes.
+
+- When ABI packed encoding: instead of storing the cairo address inside 20 bytes and having a potential information lost, they are stored as 32 bytes. As a consecuence, the packed encoding in a warped contract and the solidity contract will always differ if addresses are involved.


### PR DESCRIPTION
Add small explanation about abi encode and erase an old warning about cairo stubs