### PR TITLE
DeclarationNameMangler_audit_fixes

### DIFF
--- a/docs/docs/getting_started/a-usage-and-installation.mdx
+++ b/docs/docs/getting_started/a-usage-and-installation.mdx
@@ -209,18 +209,18 @@ namespace foo:
 
     # Static variables
 
-    const __warp_usrid0_x = 0
+    const __warp_usrid_0_x = 0
 
     @constructor
     func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr : felt}(
-        __warp_usrid1__x : Uint256
+        __warp_usrid_1__x : Uint256
     ):
         alloc_locals
         WARP_USED_STORAGE.write(2)
 
-        warp_external_input_check_int256(__warp_usrid1__x)
+        warp_external_input_check_int256(__warp_usrid_1__x)
 
-        WS_WRITE0(__warp_usrid0_x, __warp_usrid1__x)
+        WS_WRITE0(__warp_usrid_0_x, __warp_usrid_1__x)
 
         return ()
     end

--- a/example_contracts/multiple_variables.sol
+++ b/example_contracts/multiple_variables.sol
@@ -1,0 +1,20 @@
+pragma solidity ^0.8.14;
+
+// SDPX-License-Identifier: MIT
+
+contract WARP {
+  function f() public {
+    address a0;
+    address a1;
+    address a2;
+    address a3;
+    address a4;
+    address a5;
+    address a6;
+    address a7;
+    address a8;
+    address a9;
+    address a10;
+    address a11;
+  }
+}

--- a/src/passes/cairoStubProcessor.ts
+++ b/src/passes/cairoStubProcessor.ts
@@ -8,6 +8,7 @@ import {
   TranspileFailedError,
   WillNotSupportError,
 } from '../utils/errors';
+import { MANGLED_INTERNAL_USER_FUNCTION, MANGLED_LOCAL_VAR } from '../utils/nameModifiers';
 import { isExternallyVisible } from '../utils/utils';
 
 export class CairoStubProcessor extends ASTMapper {
@@ -41,7 +42,8 @@ function processStateVarTags(documentation: string, node: FunctionDefinition): s
   return processMacro(documentation, /STATEVAR\((.*?)\)/g, (arg) => {
     const stateVarNames = contract.vStateVariables.map((decl) => decl.name);
     const matchingStateVars = stateVarNames.filter((name) => {
-      return name.replace(/__warp_usrid_[0-9]+_/, '') === arg;
+      const regex = new RegExp(`${MANGLED_LOCAL_VAR}[0-9]+_`);
+      return name.replace(regex, '') === arg;
     });
     if (matchingStateVars.length === 0) {
       throw new TranspilationAbandonedError(`Unable to find matching statevar ${arg}`, errorNode);
@@ -68,7 +70,8 @@ function processInternalFunctionTag(documentation: string, node: FunctionDefinit
   return processMacro(documentation, /INTERNALFUNC\((.*?)\)/g, (arg) => {
     const funcNames = contract.vFunctions.filter((f) => !isExternallyVisible(f)).map((f) => f.name);
     const matchingFuncs = funcNames.filter((name) => {
-      return name.replace(/__warp_usrfn_[0-9]+_/, '') === arg;
+      const regex = new RegExp(`${MANGLED_INTERNAL_USER_FUNCTION}[0-9]+_`);
+      return name.replace(regex, '') === arg;
     });
     if (matchingFuncs.length === 0) {
       throw new TranspilationAbandonedError(

--- a/src/passes/cairoStubProcessor.ts
+++ b/src/passes/cairoStubProcessor.ts
@@ -41,7 +41,7 @@ function processStateVarTags(documentation: string, node: FunctionDefinition): s
   return processMacro(documentation, /STATEVAR\((.*?)\)/g, (arg) => {
     const stateVarNames = contract.vStateVariables.map((decl) => decl.name);
     const matchingStateVars = stateVarNames.filter((name) => {
-      return name.replace(/__warp_usrid[0-9]+_/, '') === arg;
+      return name.replace(/__warp_usrid_[0-9]+_/, '') === arg;
     });
     if (matchingStateVars.length === 0) {
       throw new TranspilationAbandonedError(`Unable to find matching statevar ${arg}`, errorNode);
@@ -68,7 +68,7 @@ function processInternalFunctionTag(documentation: string, node: FunctionDefinit
   return processMacro(documentation, /INTERNALFUNC\((.*?)\)/g, (arg) => {
     const funcNames = contract.vFunctions.filter((f) => !isExternallyVisible(f)).map((f) => f.name);
     const matchingFuncs = funcNames.filter((name) => {
-      return name.replace(/__warp_usrfn[0-9]+_/, '') === arg;
+      return name.replace(/__warp_usrfn_[0-9]+_/, '') === arg;
     });
     if (matchingFuncs.length === 0) {
       throw new TranspilationAbandonedError(

--- a/src/passes/externalArgModifier/memoryRefInputModifier.ts
+++ b/src/passes/externalArgModifier/memoryRefInputModifier.ts
@@ -37,8 +37,8 @@ export class RefTypeModifier extends ASTMapper {
   After pass:
 
   function testReturnMember(structDef calldata structA) external pure returns (uint8) {
-      structDef memory __warp_usrid2_structA_mem = structA;
-      return __warp_usirid1_structA.__warp_usrid0_member1;
+      structDef memory __warp_usrid_2_structA_mem = structA;
+      return __warp_usirid1_structA.__warp_usrid_0_member1;
   }
   */
 

--- a/src/passes/identifierManglerPass/declarationNameMangler.ts
+++ b/src/passes/identifierManglerPass/declarationNameMangler.ts
@@ -65,23 +65,23 @@ export function checkSourceTerms(term: string, node: ASTNode) {
   }
 
   // Creating the regular expression that match unsupportedCharacters
-  const regex_str = unsupportedCharacters.reduce(
+  const regexStr = unsupportedCharacters.reduce(
     (prevVal, val, i) => (i === 0 ? '\\' + val : (prevVal += '|\\' + val)),
     '',
   );
   // Looking for possible matches
-  const regex = RegExp(regex_str, 'g');
+  const regex = RegExp(regexStr, 'g');
   let match;
-  let unsupported_characters_found = '';
+  let unsupportedCharactersFound = '';
   while ((match = regex.exec(term)) !== null) {
     // Saving all chars founded
-    unsupported_characters_found += match[0];
+    unsupportedCharactersFound += match[0];
   }
-  if (unsupported_characters_found) {
+  if (unsupportedCharactersFound) {
     throw new WillNotSupportError(
       `${printNode(
         node,
-      )} ${term} contains unsupported character(s) "${unsupported_characters_found}"`,
+      )} ${term} contains unsupported character(s) "${unsupportedCharactersFound}"`,
     );
   }
 }
@@ -187,7 +187,7 @@ export class DeclarationNameMangler extends ASTMapper {
     if (match === null) {
       throw new TranspileFailedError(`Expected ${pattern} node name: ${name}`);
     }
-    const new_name = `${pattern}${match[1].padStart(lastIdSize, '0')}`;
-    return name.replace(new RegExp(`${pattern}([0-9]+)`), new_name);
+    const newName = `${pattern}${match[1].padStart(lastIdSize, '0')}`;
+    return name.replace(new RegExp(`${pattern}([0-9]+)`), newName);
   }
 }

--- a/src/passes/identifierManglerPass/declarationNameMangler.ts
+++ b/src/passes/identifierManglerPass/declarationNameMangler.ts
@@ -100,7 +100,7 @@ export class DeclarationNameMangler extends ASTMapper {
       : fd.name;
   }
 
-  // Return a new id formatted to achieve the minimum lenght
+  // Return a new id formatted to achieve the minimum length
   getFormattedId(): string {
     return (this.lastUsedId++).toString().padStart(this.initialIdWidth, '0');
   }

--- a/src/passes/identifierManglerPass/declarationNameMangler.ts
+++ b/src/passes/identifierManglerPass/declarationNameMangler.ts
@@ -181,7 +181,7 @@ export class DeclarationNameMangler extends ASTMapper {
     this.nodesNameModified = []; // Lose all references to avoid consuming unnecessary memory
   }
 
-  // Set Id in a node name 'name' that fallows the pattern 'pattern' to a fixed width
+  // Set Id in a node name 'name' that follows the pattern 'pattern' to a fixed width
   updateName(name: string, pattern: string, lastIdSize: number) {
     const match = new RegExp(`${pattern}([0-9]+)`).exec(name);
     if (match === null) {

--- a/src/passes/identifierManglerPass/declarationNameMangler.ts
+++ b/src/passes/identifierManglerPass/declarationNameMangler.ts
@@ -65,10 +65,10 @@ export function checkSourceTerms(term: string, node: ASTNode) {
   }
 
   // Creating the regular expression that match unsupportedCharacters
-  let regex_str = '\\' + unsupportedCharacters[0];
-  for (let index = 1; index < unsupportedCharacters.length; index++) {
-    regex_str += '|\\' + unsupportedCharacters[index];
-  }
+  const regex_str = unsupportedCharacters.reduce(
+    (prevVal, val, i) => (i === 0 ? '\\' + val : (prevVal += '|\\' + val)),
+    '',
+  );
   // Looking for possible matches
   const regex = RegExp(regex_str, 'g');
   let match;
@@ -107,15 +107,15 @@ export class DeclarationNameMangler extends ASTMapper {
 
   // This strategy should allow checked demangling post transpilation for a more readable result
   createNewInternalFunctionName(existingName: string): string {
-    return `${MANGLED_INTERNAL_USER_FUNCTION}_${this.getFormattedId()}_${existingName}`;
+    return `${MANGLED_INTERNAL_USER_FUNCTION}${this.getFormattedId()}_${existingName}`;
   }
 
   createNewTypeName(existingName: string): string {
-    return `${MANGLED_TYPE_NAME}_${this.getFormattedId()}_${existingName}`;
+    return `${MANGLED_TYPE_NAME}${this.getFormattedId()}_${existingName}`;
   }
 
   createNewVariableName(existingName: string): string {
-    return `${MANGLED_LOCAL_VAR}_${this.getFormattedId()}_${existingName}`;
+    return `${MANGLED_LOCAL_VAR}${this.getFormattedId()}_${existingName}`;
   }
 
   visitStructDefinition(_node: StructDefinition, _ast: AST): void {
@@ -183,11 +183,11 @@ export class DeclarationNameMangler extends ASTMapper {
 
   // Set Id in a node name 'name' that fallows the pattern 'pattern' to a fixed width
   updateName(name: string, pattern: string, lastIdSize: number) {
-    const match = new RegExp(`${pattern}_([0-9]+)`).exec(name);
-    if (!match) {
+    const match = new RegExp(`${pattern}([0-9]+)`).exec(name);
+    if (match === null) {
       throw new TranspileFailedError(`Expected ${pattern} node name: ${name}`);
     }
-    const new_name = `${pattern}_${match[1].padStart(lastIdSize, '0')}`;
-    return name.replace(new RegExp(`${pattern}_([0-9]+)`), new_name);
+    const new_name = `${pattern}${match[1].padStart(lastIdSize, '0')}`;
+    return name.replace(new RegExp(`${pattern}([0-9]+)`), new_name);
   }
 }

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -148,6 +148,7 @@ const expectedResults = new Map<string, ResultType>(
     ['example_contracts/memberAccess/staticcall', 'WillNotSupport'],
     ['example_contracts/memberAccess/transfer', 'WillNotSupport'],
     ['example_contracts/msg', 'WillNotSupport'],
+    ['example_contracts/multiple_variables', 'Success'],
     ['example_contracts/mutableReferences/deepDelete', 'Success'],
     ['example_contracts/mutableReferences/memory', 'Success'],
     ['example_contracts/mutableReferences/mutableReferences', 'Success'],

--- a/src/utils/nameModifiers.ts
+++ b/src/utils/nameModifiers.ts
@@ -13,7 +13,7 @@ export const CONTRACT_INFIX = '__WC__';
 
 // Used in IdentifierManglerPass
 export const MANGLED_INTERNAL_USER_FUNCTION = '__warp_usrfn';
-export const MANGLED_TYPE_NAME = '__warp_usrT';
+export const MANGLED_TYPE_NAME = '__warp_usrTp';
 export const MANGLED_LOCAL_VAR = '__warp_usrid';
 
 // Used in StaticArrayIndexer

--- a/src/utils/nameModifiers.ts
+++ b/src/utils/nameModifiers.ts
@@ -11,7 +11,7 @@ export const TUPLE_FILLER_PREFIX = '__warp_tf';
 export const FREE_FILE_SUFFIX = '__WC_FREE';
 export const CONTRACT_INFIX = '__WC__';
 
-// Used in IdentifierManglerPass
+// Used in IdentifierManglerPass and CairoStubProcessor
 export const MANGLED_INTERNAL_USER_FUNCTION = '__warp_usrfn_';
 export const MANGLED_TYPE_NAME = '__warp_usrTp_';
 export const MANGLED_LOCAL_VAR = '__warp_usrid_';

--- a/src/utils/nameModifiers.ts
+++ b/src/utils/nameModifiers.ts
@@ -12,9 +12,9 @@ export const FREE_FILE_SUFFIX = '__WC_FREE';
 export const CONTRACT_INFIX = '__WC__';
 
 // Used in IdentifierManglerPass
-export const MANGLED_INTERNAL_USER_FUNCTION = '__warp_usrfn';
-export const MANGLED_TYPE_NAME = '__warp_usrTp';
-export const MANGLED_LOCAL_VAR = '__warp_usrid';
+export const MANGLED_INTERNAL_USER_FUNCTION = '__warp_usrfn_';
+export const MANGLED_TYPE_NAME = '__warp_usrTp_';
+export const MANGLED_LOCAL_VAR = '__warp_usrid_';
 
 // Used in StaticArrayIndexer
 export const CALLDATA_TO_MEMORY_PREFIX = 'cd_to_wm_';


### PR DESCRIPTION
This pull request fix problems pointed by audit for declarationNameMangler.ts:
- Use a set for reserverdTerms to make queries faster
- Use Regex to find unsupportedCharacters in terms
- Use a unified counter to create id's for variable, internal function and new Type names
- Set a fixed width for id's in variables and internal function names to be able to sort them

Tickets:
https://www.notion.so/nethermind/AUDIT-CVF-35-declarationNameMangler-ts-de23ff0e7679484cb4f89ac58e9805aa
https://www.notion.so/nethermind/AUDIT-CVF-34-declarationNameMangler-ts-70b3c656cffc42efb6da34dce0e51701
https://www.notion.so/nethermind/AUDIT-CVF-33-declarationNameMangler-ts-1f8d615bac8a4994a0d530b97ec3e4ab
https://www.notion.so/nethermind/AUDIT-CVF-32-declarationNameMangler-ts-d69483bfcd5e4f828f1f049257354cc5

- [x] Sem Tests Running
- [x] Sem Tests Passed 