### PR TITLE
Update error logging

### DIFF
--- a/src/passes/rejectUnsupportedFeatures.ts
+++ b/src/passes/rejectUnsupportedFeatures.ts
@@ -34,7 +34,7 @@ import {
 import { AST } from '../ast/ast';
 import { ASTMapper } from '../ast/mapper';
 import { printNode } from '../utils/astPrinter';
-import { TranspilationError } from '../utils/errors';
+import { WillNotSupportError } from '../utils/errors';
 import { error } from '../utils/formatting';
 import { isDynamicArray, safeGetNodeType } from '../utils/nodeTypeProcessing';
 import { getSourceFromLocations, isExternalCall, isExternallyVisible } from '../utils/utils';
@@ -75,7 +75,7 @@ export class RejectUnsupportedFeatures extends ASTMapper {
         },
         error(`Detected ${unsupportedDetected} Unsupported Features:\n`),
       );
-      throw new TranspilationError(errorMsg);
+      throw new WillNotSupportError(errorMsg, undefined, false);
     }
 
     return ast;

--- a/src/passes/rejectUnsupportedFeatures.ts
+++ b/src/passes/rejectUnsupportedFeatures.ts
@@ -43,32 +43,37 @@ export class RejectUnsupportedFeatures extends ASTMapper {
   unsupportedFeatures: [string, ASTNode][] = [];
 
   static map(ast: AST): AST {
-    const unsopportedPerSource = new Map<string, [string, ASTNode][]>();
-    ast.roots.forEach((sourceUnit) => {
+    const unsupportedPerSource = new Map<string, [string, ASTNode][]>();
+
+    const unsupportedDetected = ast.roots.reduce((unsupported, sourceUnit) => {
       const mapper = new this();
       mapper.dispatchVisit(sourceUnit, ast);
       if (mapper.unsupportedFeatures.length > 0) {
-        unsopportedPerSource.set(sourceUnit.absolutePath, mapper.unsupportedFeatures);
+        unsupportedPerSource.set(sourceUnit.absolutePath, mapper.unsupportedFeatures);
+        return unsupported + mapper.unsupportedFeatures.length;
       }
-    });
+      return unsupported;
+    }, 0);
 
-    if (unsopportedPerSource.size > 0) {
-      const errorMsg = [...unsopportedPerSource.entries()].reduce(
+    if (unsupportedDetected > 0) {
+      let errorNum = 0;
+      const errorMsg = [...unsupportedPerSource.entries()].reduce(
         (fullMsg, [filePath, unsopported]) => {
           const content = fs.readFileSync(filePath, { encoding: 'utf8' });
-          const newMessage = unsopported.reduce((newMessage, [errorMsg, node], errorNum) => {
+          const newMessage = unsopported.reduce((newMessage, [errorMsg, node]) => {
             const errorCode = getSourceFromLocations(
               content,
               [parseSourceLocation(node.src)],
               error,
               4,
             );
-            return newMessage + `\n${error(`${errorNum + 1}. ` + errorMsg)}:\n\n${errorCode}\n`;
-          }, `File ${filePath}:\n`);
+            errorNum += 1;
+            return newMessage + `\n${error(`${errorNum}. ` + errorMsg)}:\n\n${errorCode}\n`;
+          }, `\nFile ${filePath}:\n`);
 
           return fullMsg + newMessage;
         },
-        error('Unsupported Features Detected:\n\n'),
+        error(`Detected ${unsupportedDetected} Unsupported Features:\n`),
       );
       throw new TranspilationError(errorMsg);
     }

--- a/src/passes/rejectUnsupportedFeatures.ts
+++ b/src/passes/rejectUnsupportedFeatures.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import {
   AddressType,
   ArrayType,
@@ -21,6 +22,7 @@ import {
   InlineAssembly,
   MemberAccess,
   ParameterList,
+  parseSourceLocation,
   PointerType,
   RevertStatement,
   StructDefinition,
@@ -33,10 +35,47 @@ import { AST } from '../ast/ast';
 import { ASTMapper } from '../ast/mapper';
 import { printNode } from '../utils/astPrinter';
 import { WillNotSupportError } from '../utils/errors';
+import { error } from '../utils/formatting';
 import { isDynamicArray, safeGetNodeType } from '../utils/nodeTypeProcessing';
-import { isExternalCall, isExternallyVisible } from '../utils/utils';
+import { getSourceFromLocations, isExternalCall, isExternallyVisible } from '../utils/utils';
 
 export class RejectUnsupportedFeatures extends ASTMapper {
+  unsupportedFeatures: [string, ASTNode][] = [];
+
+  static map(ast: AST): AST {
+    const unsopportedPerSource = new Map<string, [string, ASTNode][]>();
+    ast.roots.forEach((sourceUnit) => {
+      const mapper = new this();
+      mapper.dispatchVisit(sourceUnit, ast);
+      if (mapper.unsupportedFeatures.length > 0) {
+        unsopportedPerSource.set(sourceUnit.absolutePath, mapper.unsupportedFeatures);
+      }
+    });
+
+    if (unsopportedPerSource.size > 0) {
+      const errorMsg = [...unsopportedPerSource.entries()].reduce(
+        (fullMsg, [filePath, unsopported]) => {
+          const content = fs.readFileSync(filePath, { encoding: 'utf8' });
+          const newMessage = unsopported.reduce((newMessage, [errorMsg, node]) => {
+            const errorCode = getSourceFromLocations(
+              content,
+              [parseSourceLocation(node.src)],
+              error,
+            );
+            return newMessage + `${errorMsg}:\n ${errorCode}\n`;
+          }, `File ${filePath}:\n`);
+
+          return fullMsg + newMessage;
+        },
+        'Unsupported Features Detected:\n',
+      );
+
+      throw new WillNotSupportError(errorMsg);
+    }
+
+    return ast;
+  }
+
   // Function to add passes that should have been run before this pass
   addInitialPassPrerequisites(): void {
     const passKeys: Set<string> = new Set<string>([]);
@@ -45,27 +84,21 @@ export class RejectUnsupportedFeatures extends ASTMapper {
 
   visitIndexAccess(node: IndexAccess, ast: AST): void {
     if (node.vIndexExpression === undefined) {
-      throw new WillNotSupportError(
-        `Undefined index access not supported. Is this in abi.decode?`,
-        node,
-      );
+      this.addUnsupported(`Undefined index access not supported. Is this in abi.decode?`, node);
     }
     this.visitExpression(node, ast);
   }
   visitInlineAssembly(node: InlineAssembly, _ast: AST): void {
-    throw new WillNotSupportError('Yul blocks are not supported', node);
+    this.addUnsupported('Yul blocks are not supported', node);
   }
   visitRevertStatement(node: RevertStatement, _ast: AST): void {
-    throw new WillNotSupportError('Reverts with custom errors are not supported', node);
+    this.addUnsupported('Reverts with custom errors are not supported', node);
   }
   visitErrorDefinition(node: ErrorDefinition, _ast: AST): void {
-    throw new WillNotSupportError('User defined Errors are not supported', node);
+    this.addUnsupported('User defined Errors are not supported', node);
   }
   visitConditional(node: Conditional, _ast: AST): void {
-    throw new WillNotSupportError(
-      'Conditional expressions (ternary operator, node) are not supported',
-      node,
-    );
+    this.addUnsupported('Conditional expressions (ternary operator, node) are not supported', node);
   }
   visitFunctionCallOptions(node: FunctionCallOptions, ast: AST): void {
     // Allow options only when passing salt values for contract creation
@@ -78,7 +111,7 @@ export class RejectUnsupportedFeatures extends ASTMapper {
       return this.visitExpression(node, ast);
     }
 
-    throw new WillNotSupportError(
+    this.addUnsupported(
       'Function call options (other than `salt` when creating a contract), such as {gas:X} and {value:X} are not supported',
       node,
     );
@@ -86,21 +119,21 @@ export class RejectUnsupportedFeatures extends ASTMapper {
   visitVariableDeclaration(node: VariableDeclaration, ast: AST): void {
     const typeNode = safeGetNodeType(node, ast.compilerVersion);
     if (typeNode instanceof FunctionType)
-      throw new WillNotSupportError('Function objects are not supported', node);
+      this.addUnsupported('Function objects are not supported', node);
     this.commonVisit(node, ast);
   }
 
   visitExpressionStatement(node: ExpressionStatement, ast: AST): void {
     const typeNode = safeGetNodeType(node.vExpression, ast.compilerVersion);
     if (typeNode instanceof FunctionType)
-      throw new WillNotSupportError('Function objects are not supported', node);
+      this.addUnsupported('Function objects are not supported', node);
     this.commonVisit(node, ast);
   }
 
   visitIdentifier(node: Identifier, _ast: AST): void {
     if (node.name === 'msg' && node.vIdentifierType === ExternalReferenceType.Builtin) {
       if (!(node.parent instanceof MemberAccess && node.parent.memberName === 'sender')) {
-        throw new WillNotSupportError(`msg object not supported outside of 'msg.sender'`, node);
+        this.addUnsupported(`msg object not supported outside of 'msg.sender'`, node);
       }
     }
   }
@@ -122,7 +155,7 @@ export class RejectUnsupportedFeatures extends ASTMapper {
       'staticcall',
     ];
     if (members.includes(node.memberName))
-      throw new WillNotSupportError(
+      this.addUnsupported(
         `Members of addresses are not supported. Found at ${printNode(node)}`,
         node,
       );
@@ -132,7 +165,7 @@ export class RejectUnsupportedFeatures extends ASTMapper {
   visitParameterList(node: ParameterList, ast: AST): void {
     // any of node.vParameters has indexed flag true then throw error
     if (node.vParameters.some((param) => param.indexed)) {
-      throw new WillNotSupportError(`Indexed parameters are not supported`, node);
+      this.addUnsupported(`Indexed parameters are not supported`, node);
     }
     this.commonVisit(node, ast);
   }
@@ -147,7 +180,7 @@ export class RejectUnsupportedFeatures extends ASTMapper {
       node.vReferencedDeclaration === undefined &&
       [...unsupportedMath, ...unsupportedAbi, ...unsupportedMisc].includes(funcName)
     ) {
-      throw new WillNotSupportError(`Solidity builtin ${funcName} is not supported`, node);
+      this.addUnsupported(`Solidity builtin ${funcName} is not supported`, node);
     }
 
     this.visitExpression(node, ast);
@@ -157,68 +190,100 @@ export class RejectUnsupportedFeatures extends ASTMapper {
     if (!(node.vScope instanceof ContractDefinition && node.vScope.kind === ContractKind.Library)) {
       [...node.vParameters.vParameters, ...node.vReturnParameters.vParameters].forEach((decl) => {
         const type = safeGetNodeType(decl, ast.compilerVersion);
-        functionArgsCheck(type, ast, isExternallyVisible(node), decl.storageLocation, node);
+        this.functionArgsCheck(type, ast, isExternallyVisible(node), decl.storageLocation, node);
       });
     }
     if (node.kind === FunctionKind.Fallback) {
       if (node.vParameters.vParameters.length > 0)
-        throw new WillNotSupportError(`${node.kind} with arguments is not supported`, node);
+        this.addUnsupported(`${node.kind} with arguments is not supported`, node);
     } else if (node.kind === FunctionKind.Receive) {
-      throw new WillNotSupportError(`Receive functions are not supported`, node);
+      this.addUnsupported(`Receive functions are not supported`, node);
     }
 
     //checks for the pattern if "this" keyword is used to call the external functions during the contract construction
-    checkExternalFunctionCallWithThisOnConstruction(node);
+    this.checkExternalFunctionCallWithThisOnConstruction(node);
 
     this.commonVisit(node, ast);
   }
 
   visitTryStatement(node: TryStatement, _ast: AST): void {
-    throw new WillNotSupportError(`Try/Catch statements are not supported`, node);
+    this.addUnsupported(`Try/Catch statements are not supported`, node);
   }
-}
 
-// Cases not allowed:
-// Dynarray inside structs to/from external functions
-// Dynarray inside dynarray to/from external functions
-// Dynarray as direct child of static array to/from external functions
-function functionArgsCheck(
-  type: TypeNode,
-  ast: AST,
-  externallyVisible: boolean,
-  dataLocation: DataLocation,
-  node: ASTNode,
-): void {
-  if (type instanceof UserDefinedType && type.definition instanceof StructDefinition) {
-    if (externallyVisible && findDynArrayRecursive(type, ast)) {
-      throw new WillNotSupportError(
-        `Dynamic arrays are not allowed as (indirect) children of structs passed to/from external functions`,
-        node,
+  // Cases not allowed:
+  // Dynarray inside structs to/from external functions
+  // Dynarray inside dynarray to/from external functions
+  // Dynarray as direct child of static array to/from external functions
+  private functionArgsCheck(
+    type: TypeNode,
+    ast: AST,
+    externallyVisible: boolean,
+    dataLocation: DataLocation,
+    node: ASTNode,
+  ): void {
+    if (type instanceof UserDefinedType && type.definition instanceof StructDefinition) {
+      if (externallyVisible && findDynArrayRecursive(type, ast)) {
+        this.addUnsupported(
+          `Dynamic arrays are not allowed as (indirect) children of structs passed to/from external functions`,
+          node,
+        );
+        return;
+      }
+      type.definition.vMembers.forEach((member) =>
+        this.functionArgsCheck(
+          safeGetNodeType(member, ast.compilerVersion),
+          ast,
+          externallyVisible,
+          dataLocation,
+          member,
+        ),
       );
+    } else if (type instanceof ArrayType && type.size === undefined) {
+      if (externallyVisible && findDynArrayRecursive(type.elementT, ast)) {
+        this.addUnsupported(
+          `Dynamic arrays are not allowed as (indirect) children of dynamic arrays passed to/from external functions`,
+          node,
+        );
+        return;
+      }
+      this.functionArgsCheck(type.elementT, ast, externallyVisible, dataLocation, node);
+    } else if (type instanceof ArrayType) {
+      if (isDynamicArray(type.elementT)) {
+        this.addUnsupported(
+          `Dynamic arrays are not allowed as children of static arrays passed to/from external functions`,
+          node,
+        );
+        return;
+      }
+      this.functionArgsCheck(type.elementT, ast, externallyVisible, dataLocation, node);
     }
-    type.definition.vMembers.forEach((member) =>
-      functionArgsCheck(
-        safeGetNodeType(member, ast.compilerVersion),
-        ast,
-        externallyVisible,
-        dataLocation,
-        member,
-      ),
-    );
-  } else if (type instanceof ArrayType && type.size === undefined) {
-    if (externallyVisible && findDynArrayRecursive(type.elementT, ast)) {
-      throw new WillNotSupportError(
-        `Dynamic arrays are not allowed as (indirect) children of dynamic arrays passed to/from external functions`,
-      );
+  }
+
+  // Checking that if the function definition is constructor then there is no usage of
+  // the `this` keyword for calling any contract function
+  private checkExternalFunctionCallWithThisOnConstruction(node: FunctionDefinition) {
+    if (node.kind === FunctionKind.Constructor) {
+      const nodesWithThisIdentifier = node.vBody
+        ?.getChildren()
+        .filter((childNode, _) => childNode instanceof Identifier && childNode.name === 'this');
+
+      nodesWithThisIdentifier?.forEach((identifierNode: ASTNode) => {
+        const parentNode = identifierNode?.parent;
+        if (
+          parentNode instanceof MemberAccess &&
+          parentNode?.parent instanceof FunctionCall &&
+          isExternalCall(parentNode.parent)
+        ) {
+          this.addUnsupported(
+            `External function calls using "this" keyword are not supported in contract's constructor function`,
+            node,
+          );
+        }
+      });
     }
-    functionArgsCheck(type.elementT, ast, externallyVisible, dataLocation, node);
-  } else if (type instanceof ArrayType) {
-    if (isDynamicArray(type.elementT)) {
-      throw new WillNotSupportError(
-        `Dynamic arrays are not allowed as children of static arrays passed to/from external functions`,
-      );
-    }
-    functionArgsCheck(type.elementT, ast, externallyVisible, dataLocation, node);
+  }
+  private addUnsupported(message: string, node: ASTNode) {
+    this.unsupportedFeatures.push([message, node]);
   }
 }
 
@@ -237,30 +302,5 @@ function findDynArrayRecursive(type: TypeNode, ast: AST): boolean {
     );
   } else {
     return false;
-  }
-}
-
-//Checking if the function defination is constructor and
-// if it is, checking if 'this' keyword is used to call
-// the external/public functions of the contract
-function checkExternalFunctionCallWithThisOnConstruction(node: FunctionDefinition) {
-  if (node.kind === FunctionKind.Constructor) {
-    const nodesWithThisIdentifier = node.vBody
-      ?.getChildren()
-      .filter((childNode, _) => childNode instanceof Identifier && childNode.name === 'this');
-
-    nodesWithThisIdentifier?.forEach((identifierNode: ASTNode) => {
-      const parentNode = identifierNode?.parent;
-      if (
-        parentNode instanceof MemberAccess &&
-        parentNode?.parent instanceof FunctionCall &&
-        isExternalCall(parentNode.parent)
-      ) {
-        throw new WillNotSupportError(
-          `external function calls using "this" keyword not supported in contract's constructor function`,
-          node,
-        );
-      }
-    });
   }
 }

--- a/src/transpiler.ts
+++ b/src/transpiler.ts
@@ -63,7 +63,7 @@ import {
 import { CairoToSolASTWriterMapping } from './solWriter';
 import { DefaultASTPrinter } from './utils/astPrinter';
 import { createPassMap, parsePassOrder } from './utils/cli';
-import { TranspilationError, TranspileFailedError } from './utils/errors';
+import { TranspilationAbandonedError, TranspileFailedError } from './utils/errors';
 import { error, removeExcessNewlines } from './utils/formatting';
 import { printCompileErrors, runSanityCheck } from './utils/utils';
 
@@ -182,7 +182,7 @@ export function handleTranspilationError(e: unknown) {
   if (e instanceof CompileFailedError) {
     printCompileErrors(e);
     console.error('Cannot start transpilation');
-  } else if (e instanceof TranspilationError) {
+  } else if (e instanceof TranspilationAbandonedError) {
     console.error(`Transpilation abandoned ${e.message}`);
   } else {
     console.error('Unexpected error during transpilation');

--- a/src/transpiler.ts
+++ b/src/transpiler.ts
@@ -63,7 +63,7 @@ import {
 import { CairoToSolASTWriterMapping } from './solWriter';
 import { DefaultASTPrinter } from './utils/astPrinter';
 import { createPassMap, parsePassOrder } from './utils/cli';
-import { TranspilationAbandonedError, TranspileFailedError } from './utils/errors';
+import { TranspilationError, TranspileFailedError } from './utils/errors';
 import { error, removeExcessNewlines } from './utils/formatting';
 import { printCompileErrors, runSanityCheck } from './utils/utils';
 
@@ -182,7 +182,7 @@ export function handleTranspilationError(e: unknown) {
   if (e instanceof CompileFailedError) {
     printCompileErrors(e);
     console.error('Cannot start transpilation');
-  } else if (e instanceof TranspilationAbandonedError) {
+  } else if (e instanceof TranspilationError) {
     console.error(`Transpilation abandoned ${e.message}`);
   } else {
     console.error('Unexpected error during transpilation');

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -13,11 +13,10 @@ export class CLIError extends Error {
   }
 }
 
-export class TranspilationError extends Error {}
-
-export class TranspilationAbandonedError extends TranspilationError {
-  constructor(message: string, node?: ASTNode) {
-    super(`${error(message)}${`\n\n${getSourceCode(node)}\n`}`);
+export class TranspilationAbandonedError extends Error {
+  constructor(message: string, node?: ASTNode, highlight = true) {
+    message = highlight ? `${error(message)}${`\n\n${getSourceCode(node)}\n`}` : message;
+    super(message);
   }
 }
 

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -13,7 +13,9 @@ export class CLIError extends Error {
   }
 }
 
-export class TranspilationAbandonedError extends Error {
+export class TranspilationError extends Error {}
+
+export class TranspilationAbandonedError extends TranspilationError {
   constructor(message: string, node?: ASTNode) {
     super(`${error(message)}${`\n\n${getSourceCode(node)}\n`}`);
   }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -468,6 +468,9 @@ export function getSourceFromLocations(
   highlightFunc: (text: string) => string,
   surroundingLines = 2,
 ): string {
+  // Sort locations
+  locations.sort((s1, s2) => s1.offset - s2.offset);
+
   let textWalked = 0;
   let locIndex = 0;
   const lines = source.split('\n').reduce((lines, currentLine, lineNum) => {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -474,21 +474,34 @@ export function getSourceFromLocations(
     const maxWalk = textWalked + currentLine.length + 1;
     let marked = false;
     let newLine = `${lineNum}\t`;
-    while (
-      locIndex < locations.length &&
-      textWalked + currentLine.length >= locations[locIndex].offset + locations[locIndex].length
-    ) {
-      const currentLocation = locations[locIndex];
-      newLine =
-        newLine +
-        source.substring(textWalked, currentLocation.offset) +
-        highlightFunc(
-          source.substring(currentLocation.offset, currentLocation.offset + currentLocation.length),
-        );
-
-      textWalked = currentLocation.offset + currentLocation.length;
-      locIndex += 1;
+    while (locIndex < locations.length && maxWalk >= locations[locIndex].offset) {
+      // Mark the line as a highlited line
       marked = true;
+      const currentLocation = locations[locIndex];
+      if (currentLocation.offset + currentLocation.length > maxWalk) {
+        // Case when node source spans accross multiple lines
+        newLine =
+          newLine +
+          source.substring(textWalked, currentLocation.offset) +
+          highlightFunc(source.substring(currentLocation.offset, maxWalk));
+        currentLocation.length = currentLocation.length - (maxWalk - currentLocation.offset);
+        currentLocation.offset = maxWalk;
+        textWalked = maxWalk;
+        break;
+      } else {
+        // Case when node source is a substring of a line
+        newLine =
+          newLine +
+          source.substring(textWalked, currentLocation.offset) +
+          highlightFunc(
+            source.substring(
+              currentLocation.offset,
+              currentLocation.offset + currentLocation.length,
+            ),
+          );
+        locIndex += 1;
+        textWalked = currentLocation.offset + currentLocation.length;
+      }
     }
 
     newLine = newLine + source.substring(textWalked, maxWalk);


### PR DESCRIPTION
- Fix bug when erroing a node source with multiple lines
- Add multiple error logging to RejectUnsupportedPass. Now after a transpilation attempt, all unsuported features are shown, instead of the first one found