### PR TITLE
Audit modifiers

### DIFF
--- a/src/ast/ast.ts
+++ b/src/ast/ast.ts
@@ -104,11 +104,11 @@ export class AST {
     const replacementVariable = new VariableDeclaration(
       this.tempId,
       node.src,
-      true,
-      false,
+      true, // constant
+      false, // indexed
       newName,
       scope,
-      false,
+      false, // stateVariable
       location,
       StateVariableVisibility.Private,
       Mutability.Constant,

--- a/src/passes/annotateImplicits.ts
+++ b/src/passes/annotateImplicits.ts
@@ -44,8 +44,8 @@ export class AnnotateImplicits extends ASTMapper {
       node.vModifiers,
       implicits,
       FunctionStubKind.None,
-      false,
-      false,
+      false, // acceptsRawDArray
+      false, // acceptsUnpackedStructArray
       node.vOverrideSpecifier,
       node.vBody,
       node.documentation,

--- a/src/passes/expressionSplitter/conditionalFunctionaliser.ts
+++ b/src/passes/expressionSplitter/conditionalFunctionaliser.ts
@@ -51,11 +51,11 @@ export function getConditionalReturnVariable(
   return new VariableDeclaration(
     ast.reserveId(),
     '',
-    false,
-    false,
+    false, // constant
+    false, // indexed
     `ret_conditional${id}`,
     funcId,
-    false,
+    false, // stateVariable
     DataLocation.Default,
     StateVariableVisibility.Private,
     Mutability.Mutable,

--- a/src/passes/expressionSplitter/expressionSplitter.ts
+++ b/src/passes/expressionSplitter/expressionSplitter.ts
@@ -76,11 +76,11 @@ export class ExpressionSplitter extends ASTMapper {
       const varDecl = new VariableDeclaration(
         ast.reserveId(),
         '',
-        false,
-        false,
+        false, // constant
+        false, // indexed
         this.eGen.next().value, //name
         ast.getContainingScope(node), //scope
-        false,
+        false, // stateVariable
         location,
         StateVariableVisibility.Internal,
         Mutability.Constant,
@@ -153,10 +153,10 @@ export class ExpressionSplitter extends ASTMapper {
       containingFunction.scope,
       containingFunction.kind === FunctionKind.Free ? FunctionKind.Free : FunctionKind.Function,
       `_conditional${this.funcNameCounter++}`,
-      false,
+      false, // virtual
       FunctionVisibility.Internal,
       containingFunction.stateMutability,
-      false,
+      false, // isConstructor
       params,
       returns,
       [],

--- a/src/passes/externalContractHandler/externalContractInterfaceInserter.ts
+++ b/src/passes/externalContractHandler/externalContractInterfaceInserter.ts
@@ -114,7 +114,7 @@ export function genContractInterface(
     sourceUnit.id,
     ContractKind.Interface,
     contract.abstract,
-    false,
+    false, // fullyImplemented
     contract.linearizedBaseContracts,
     contract.usedErrors,
     new Map(),

--- a/src/passes/functionModifierHandler/functionModifierHandler.ts
+++ b/src/passes/functionModifierHandler/functionModifierHandler.ts
@@ -78,7 +78,7 @@ export class FunctionModifierHandler extends ASTMapper {
 
     const funcDef = cloneASTNode(node, ast);
     const name = node.isConstructor ? `constructor` : `function_${node.name}`;
-    funcDef.name = `${ORIGINAL_FUNCTION_PREFIX}${name}`;
+    funcDef.name = `${ORIGINAL_FUNCTION_PREFIX}${name}_${this.count++}`;
     funcDef.visibility = FunctionVisibility.Internal;
     funcDef.isConstructor = false;
     funcDef.kind = FunctionKind.Function;

--- a/src/passes/functionModifierHandler/functionModifierHandler.ts
+++ b/src/passes/functionModifierHandler/functionModifierHandler.ts
@@ -123,10 +123,10 @@ export class FunctionModifierHandler extends ASTMapper {
       node.scope,
       FunctionKind.Function,
       `${MODIFIER_PREFIX}${modifier.name}_${node.name}_${this.count++}`,
-      node.virtual,
+      false, // virtual
       FunctionVisibility.Internal,
       node.stateMutability,
-      false,
+      false, // isConstructor
       createParameterList(
         [...modifierClone.vParameters.vParameters, ...functionParams],
         ast,

--- a/src/passes/functionModifierHandler/functionModifierHandler.ts
+++ b/src/passes/functionModifierHandler/functionModifierHandler.ts
@@ -150,13 +150,13 @@ export class FunctionModifierHandler extends ASTMapper {
 
   createInputParameter(v: VariableDeclaration, ast: AST): VariableDeclaration {
     const variable = cloneASTNode(v, ast);
-    variable.name = `${MANGLED_PARAMETER}${this.count++}`;
+    variable.name = `${MANGLED_PARAMETER}${v.name}${this.count++}`;
     return variable;
   }
 
   createReturnParameter(v: VariableDeclaration, ast: AST): VariableDeclaration {
     const param = cloneASTNode(v, ast);
-    param.name = `${MANGLED_RETURN_PARAMETER}${this.count++}`;
+    param.name = `${MANGLED_RETURN_PARAMETER}${v.name}${this.count++}`;
     return param;
   }
 }

--- a/src/passes/functionModifierHandler/functionModifierHandler.ts
+++ b/src/passes/functionModifierHandler/functionModifierHandler.ts
@@ -13,7 +13,12 @@ import { AST } from '../../ast/ast';
 import { ASTMapper } from '../../ast/mapper';
 import { cloneASTNode } from '../../utils/cloning';
 import { createCallToFunction } from '../../utils/functionGeneration';
-import { MANGLED_PARAMETER, MANGLED_RETURN_PARAMETER } from '../../utils/nameModifiers';
+import {
+  MANGLED_PARAMETER,
+  MANGLED_RETURN_PARAMETER,
+  MODIFIER_PREFIX,
+  ORIGINAL_FUNCTION_PREFIX,
+} from '../../utils/nameModifiers';
 import {
   createBlock,
   createExpressionStatement,
@@ -73,7 +78,7 @@ export class FunctionModifierHandler extends ASTMapper {
 
     const funcDef = cloneASTNode(node, ast);
     const name = node.isConstructor ? `constructor` : `function_${node.name}`;
-    funcDef.name = `__warp_original_${name}`;
+    funcDef.name = `${ORIGINAL_FUNCTION_PREFIX}${name}`;
     funcDef.visibility = FunctionVisibility.Internal;
     funcDef.isConstructor = false;
     funcDef.kind = FunctionKind.Function;
@@ -117,7 +122,7 @@ export class FunctionModifierHandler extends ASTMapper {
       modifierClone.src,
       node.scope,
       FunctionKind.Function,
-      `__warp_${modifier.name}_${this.count++}`,
+      `${MODIFIER_PREFIX}${modifier.name}_${node.name}_${this.count++}`,
       node.virtual,
       FunctionVisibility.Internal,
       node.stateMutability,

--- a/src/passes/generateGetters/gettersGenerator.ts
+++ b/src/passes/generateGetters/gettersGenerator.ts
@@ -94,10 +94,10 @@ export class GettersGenerator extends ASTMapper {
           node.id,
           FunctionKind.Function,
           v.name,
-          false,
+          false, // virtual
           FunctionVisibility.Public,
           FunctionStateMutability.View,
-          false,
+          false, // isConstructor
           fnParams,
           returnParameterList,
           [],
@@ -131,11 +131,11 @@ function genReturnParameters(
     return new VariableDeclaration(
       ast.reserveId(),
       '',
-      false,
-      false,
+      false, // constant
+      false, // indexed
       '',
       funcDefID,
-      false,
+      false, // stateVariable
       dataLocation,
       StateVariableVisibility.Internal,
       Mutability.Mutable,
@@ -206,11 +206,11 @@ function genFunctionParams(
       new VariableDeclaration(
         ast.reserveId(),
         '',
-        false,
-        false,
+        false, // constant
+        false, // indexed
         `_i${varCount}`,
         funcDefID,
-        false,
+        false, // stateVariable
         DataLocation.Default,
         StateVariableVisibility.Internal,
         Mutability.Mutable,
@@ -225,11 +225,11 @@ function genFunctionParams(
       new VariableDeclaration(
         ast.reserveId(),
         '',
-        false,
-        false,
+        false, // constant
+        false, // indexed
         `_i${varCount}`,
         funcDefID,
-        false,
+        false, // stateVariable
         locationIfComplexType(safeGetNodeType(vType, ast.compilerVersion), DataLocation.Memory),
         StateVariableVisibility.Internal,
         Mutability.Mutable,
@@ -326,11 +326,11 @@ function genReturnBlock(
         const structVarDecl = new VariableDeclaration(
           ast.reserveId(),
           '',
-          false,
-          false,
+          false, // constant
+          false, // indexed
           `_temp${tempCount++}`,
           getter.id,
-          false,
+          false, // stateVariable
           DataLocation.Storage,
           StateVariableVisibility.Internal,
           Mutability.Mutable,

--- a/src/passes/ifFunctionaliser.ts
+++ b/src/passes/ifFunctionaliser.ts
@@ -175,10 +175,10 @@ function createSplitFunction(
     existingFunction.scope,
     existingFunction.kind === FunctionKind.Free ? FunctionKind.Free : FunctionKind.Function,
     `${existingFunction.name}${IF_FUNCTIONALISER_INFIX}${counter + 1}`,
-    false,
+    false, // virtual
     FunctionVisibility.Private,
     existingFunction.stateMutability,
-    false,
+    false, // isConstructor
     createParameterList(inputParams, ast),
     retParams,
     [],

--- a/src/passes/loopFunctionaliser/returnToBreak.ts
+++ b/src/passes/loopFunctionaliser/returnToBreak.ts
@@ -102,11 +102,11 @@ export class ReturnToBreak extends ASTMapper {
     const decl = new VariableDeclaration(
       ast.reserveId(),
       '',
-      false,
-      false,
+      false, // constant
+      false, // indexed
       `${RETURN_FLAG_PREFIX}${this.returnFlags.size}`,
       ast.getContainingScope(containingWhile),
-      false,
+      false, // stateVariable
       DataLocation.Default,
       StateVariableVisibility.Default,
       Mutability.Mutable,

--- a/src/passes/loopFunctionaliser/utils.ts
+++ b/src/passes/loopFunctionaliser/utils.ts
@@ -82,10 +82,10 @@ export function extractWhileToFunction(
     scope.id,
     scope instanceof SourceUnit ? FunctionKind.Free : FunctionKind.Function,
     defName,
-    false,
+    false, // virtual
     FunctionVisibility.Private,
     FunctionStateMutability.NonPayable,
-    false,
+    false, // isConstructor
     createParameterList(inputParams, ast),
     retParams,
     [],
@@ -165,10 +165,10 @@ export function extractDoWhileToFunction(
     doWhileFuncDef.scope,
     doWhileFuncDef.kind,
     doBlockDefName,
-    false,
+    false, // virtual
     FunctionVisibility.Private,
     FunctionStateMutability.NonPayable,
-    false,
+    false, // isConstructor
     createParameterList(doBlockParams, ast),
     doBlockRetParams,
     [],

--- a/src/passes/newToDeploy.ts
+++ b/src/passes/newToDeploy.ts
@@ -214,11 +214,11 @@ export class NewToDeploy extends ASTMapper {
     const varDecl = new VariableDeclaration(
       ast.reserveId(),
       '',
-      true,
-      false,
+      true, // constant
+      false, // indexed
       varName,
       sourceUnit.id,
-      false,
+      false, // stateVariable
       DataLocation.Default,
       StateVariableVisibility.Internal,
       Mutability.Constant,

--- a/src/passes/staticArrayIndexer.ts
+++ b/src/passes/staticArrayIndexer.ts
@@ -132,11 +132,11 @@ export class StaticArrayIndexer extends ASTMapper {
     const varDecl = new VariableDeclaration(
       ast.reserveId(),
       '',
-      false,
-      false,
+      false, // constant
+      false, // indexed
       `${CALLDATA_TO_MEMORY_PREFIX}${identifier.name}`,
       parentFunction?.id,
-      false,
+      false, // stateVariable
       DataLocation.Memory,
       StateVariableVisibility.Internal,
       Mutability.Mutable,

--- a/src/passes/storageAllocator.ts
+++ b/src/passes/storageAllocator.ts
@@ -118,10 +118,10 @@ function insertIntoInitFunction(
     contract.id,
     FunctionKind.Function,
     `${INIT_FUNCTION_PREFIX}${contract.name}`,
-    false,
+    false, // virtual
     FunctionVisibility.Private,
     FunctionStateMutability.NonPayable,
-    false,
+    false, // isConstructor
     createParameterList([], ast),
     createParameterList([], ast),
     [],

--- a/src/passes/tupleAssignmentSplitter.ts
+++ b/src/passes/tupleAssignmentSplitter.ts
@@ -84,7 +84,7 @@ export class TupleAssignmentSplitter extends ASTMapper {
         ast.reserveId(),
         '',
         returnExpression.typeString,
-        false,
+        false, // isInlineArray
         vars.map((v) => createIdentifier(v, ast, undefined, node)),
       );
       ast.registerChild(node.vExpression, node);
@@ -126,11 +126,11 @@ export class TupleAssignmentSplitter extends ASTMapper {
         const decl = new VariableDeclaration(
           ast.reserveId(),
           node.src,
-          true,
-          false,
+          true, // constant
+          false, // indexed
           this.newTempVarName(),
           block.id,
-          false,
+          false, // stateVariable
           location ?? DataLocation.Default,
           StateVariableVisibility.Default,
           Mutability.Constant,

--- a/src/passes/tupleFixes/tupleFiller.ts
+++ b/src/passes/tupleFixes/tupleFiller.ts
@@ -60,11 +60,11 @@ export class TupleFiller extends ASTMapper {
         const declaration = new VariableDeclaration(
           ast.reserveId(),
           '',
-          false,
-          false,
+          false, // constant
+          false, // indexed
           `${TUPLE_FILLER_PREFIX}${this.counter++}`,
           scope,
-          false,
+          false, // stateVariable
           loc ?? DataLocation.Default,
           StateVariableVisibility.Default,
           Mutability.Mutable,

--- a/src/passes/variableDeclarationExpressionSplitter.ts
+++ b/src/passes/variableDeclarationExpressionSplitter.ts
@@ -109,11 +109,11 @@ export class VariableDeclarationExpressionSplitter extends ASTMapper {
           const newDeclaration = new VariableDeclaration(
             ast.reserveId(),
             node.src,
-            true,
-            false,
+            true, // constant
+            false, // indexed
             this.generateNewConstantName(),
             oldDeclaration.scope,
-            false,
+            false, // stateVariable
             oldDeclaration.storageLocation,
             StateVariableVisibility.Default,
             Mutability.Constant,

--- a/src/utils/defaultValueNodes.ts
+++ b/src/utils/defaultValueNodes.ts
@@ -150,7 +150,7 @@ function arrayDefault(
       ast.reserveId(),
       parentNode.src,
       `${getTupleTypeString(nodeType)} memory`,
-      true,
+      true, // isInlineArray
       expList,
       parentNode.raw,
     );

--- a/src/utils/functionGeneration.ts
+++ b/src/utils/functionGeneration.ts
@@ -94,11 +94,11 @@ export function createCairoFunctionStub(
         new VariableDeclaration(
           ast.reserveId(),
           '',
-          false,
-          false,
+          false, // constant
+          false, // indexed
           name,
           funcDefId,
-          false,
+          false, // stateVariable
           location ?? DataLocation.Default,
           StateVariableVisibility.Private,
           Mutability.Mutable,
@@ -114,10 +114,10 @@ export function createCairoFunctionStub(
     sourceUnit.id,
     FunctionKind.Function,
     name,
-    false,
+    false, // virtual
     FunctionVisibility.Private,
     options.mutability ?? FunctionStateMutability.NonPayable,
-    false,
+    false, // isConstructor
     createParameterList(createParameters(inputs), ast),
     createParameterList(createParameters(returns), ast),
     [],

--- a/src/utils/functionSignatureParser.ts
+++ b/src/utils/functionSignatureParser.ts
@@ -504,8 +504,8 @@ function peg$parse(input: string, options?: IParseOptions) {
       ['a', 'f'],
       ['A', 'F'],
     ],
-    false,
-    false,
+    false, // inverted
+    false, // ignoreCase
   );
   const peg$c50 = function (): any {
     return parseInt(text(), 10);

--- a/src/utils/getTypeString.ts
+++ b/src/utils/getTypeString.ts
@@ -99,7 +99,7 @@ export function getFunctionTypeString(
           throw new NotSupportedYetError(
             `Default location ref parameter to string not supported yet: ${printTypeNode(
               baseType,
-              true,
+              true, // detail
             )} in ${node.name}`,
           );
         }

--- a/src/utils/nameModifiers.ts
+++ b/src/utils/nameModifiers.ts
@@ -25,6 +25,8 @@ export const CONSTANT_STRING_TO_MEMORY_PREFIX = 'memory_string';
 // Used in ModifierHandler in FunctionModifierHandler
 export const MANGLED_PARAMETER = '__warp_parameter_';
 export const MANGLED_RETURN_PARAMETER = '__warp_ret_paramter_';
+export const MODIFIER_PREFIX = '__warp_modifier_';
+export const ORIGINAL_FUNCTION_PREFIX = '__warp_original_';
 
 // Used in ExternalArgModifier in MemoryRefInputModifier
 export const CALLDATA_TO_MEMORY_FUNCTION_PARAMETER_PREFIX = 'cd_to_wm_param_';

--- a/src/utils/nameModifiers.ts
+++ b/src/utils/nameModifiers.ts
@@ -24,7 +24,7 @@ export const CONSTANT_STRING_TO_MEMORY_PREFIX = 'memory_string';
 
 // Used in ModifierHandler in FunctionModifierHandler
 export const MANGLED_PARAMETER = '__warp_parameter_';
-export const MANGLED_RETURN_PARAMETER = '__warp_ret_paramter_';
+export const MANGLED_RETURN_PARAMETER = '__warp_ret_parameter_';
 export const MODIFIER_PREFIX = '__warp_modifier_';
 export const ORIGINAL_FUNCTION_PREFIX = '__warp_original_';
 

--- a/src/utils/nameModifiers.ts
+++ b/src/utils/nameModifiers.ts
@@ -23,8 +23,8 @@ export const CALLDATA_TO_MEMORY_PREFIX = 'cd_to_wm_';
 export const CONSTANT_STRING_TO_MEMORY_PREFIX = 'memory_string';
 
 // Used in ModifierHandler in FunctionModifierHandler
-export const MANGLED_PARAMETER = '__warp_parameter';
-export const MANGLED_RETURN_PARAMETER = '__warp_ret_paramter';
+export const MANGLED_PARAMETER = '__warp_parameter_';
+export const MANGLED_RETURN_PARAMETER = '__warp_ret_paramter_';
 
 // Used in ExternalArgModifier in MemoryRefInputModifier
 export const CALLDATA_TO_MEMORY_FUNCTION_PARAMETER_PREFIX = 'cd_to_wm_param_';

--- a/src/utils/nodeTemplates.ts
+++ b/src/utils/nodeTemplates.ts
@@ -244,10 +244,10 @@ export function createDefaultConstructor(node: ContractDefinition, ast: AST): Fu
     node.id,
     FunctionKind.Constructor,
     '',
-    false,
+    false, // virtual
     FunctionVisibility.Public,
     FunctionStateMutability.NonPayable,
-    true,
+    true, // isConstructor
     createParameterList([], ast),
     createParameterList([], ast),
     [],

--- a/src/utils/nodeTypeProcessing.ts
+++ b/src/utils/nodeTypeProcessing.ts
@@ -63,7 +63,7 @@ export function getParameterTypes(functionCall: FunctionCall, ast: AST): TypeNod
             functionCall.vExpression,
           )} was expected to be a TypeNameType(PointerType(UserDefinedType, _)), got ${printTypeNode(
             functionType,
-            true,
+            true, // detail
           )}`,
         ),
       );
@@ -91,7 +91,7 @@ export function specializeType(typeNode: TypeNode, loc: DataLocation): TypeNode 
       typeNode.location === loc,
       `Attempting to specialize ${typeNode.location} pointer type to ${loc}\nType:${printTypeNode(
         typeNode,
-        true,
+        true, // detail
       )}`,
     );
     return typeNode;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -336,7 +336,7 @@ export function toSingleExpression(expressions: Expression[], ast: AST): Express
     ast.reserveId(),
     '',
     `tuple(${expressions.map((e) => e.typeString).join(',')})`,
-    false,
+    false, // isInlineArray
     expressions,
   );
 }
@@ -356,11 +356,11 @@ export function splitDarray(
   const arrayLen = new VariableDeclaration(
     ast.reserveId(),
     '',
-    true,
-    false,
+    true, // constant
+    false, // indexed
     dArrayVarDecl.name + '_len',
     scope,
-    false,
+    false, // isInlineArray
     DataLocation.CallData,
     StateVariableVisibility.Internal,
     Mutability.Immutable,


### PR DESCRIPTION
This PR addresses some of the audits comments related to `ModifierHandler` pass: 42, 43, 46, 47, 49, 50. They include variables renaming, code refactoring and adding comments for readability

- [x] - SemTests Pass