### PR TITLE
Fix Event mangling

### DIFF
--- a/src/cairoWriter.ts
+++ b/src/cairoWriter.ts
@@ -73,7 +73,6 @@ import {
   VariableDeclarationStatement,
   WhileStatement,
 } from 'solc-typed-ast';
-import { ABIEncoderVersion } from 'solc-typed-ast/dist/types/abi';
 import { AST } from './ast/ast';
 import {
   CairoAssert,

--- a/src/cairoWriter.ts
+++ b/src/cairoWriter.ts
@@ -712,7 +712,6 @@ class CairoFunctionDefinitionWriter extends CairoASTNodeWriter {
 class BlockWriter extends CairoASTNodeWriter {
   writeInner(node: Block, writer: ASTWriter): SrcDesc {
     const documentation = getDocumentation(node.documentation, writer);
-    // node.vStatements.map((statement) => console.log(writer.write(statement), statement.constructor.name));
     return [
       [
         documentation,
@@ -780,7 +779,6 @@ class ExpressionStatementWriter extends CairoASTNodeWriter {
   newVarCounter = 0;
   writeInner(node: ExpressionStatement, writer: ASTWriter): SrcDesc {
     const documentation = getDocumentation(node.documentation, writer);
-    // console.log(writer.write(node.vExpression), node.constructor.name, node.vExpression.constructor.name);
     if (
       node.vExpression instanceof FunctionCall &&
       node.vExpression.kind !== FunctionCallKind.StructConstructorCall
@@ -1029,14 +1027,7 @@ class EventDefinitionWriter extends CairoASTNodeWriter {
   writeInner(node: EventDefinition, writer: ASTWriter): SrcDesc {
     const documentation = getDocumentation(node.documentation, writer);
     const args: string = writer.write(node.vParameters);
-    return [
-      [
-        documentation,
-        `@event`,
-        `func ${node.name}_${node.canonicalSignatureHash(ABIEncoderVersion.V2)}(${args}){`,
-        `}`,
-      ].join('\n'),
-    ];
+    return [[documentation, `@event`, `func ${node.name}(${args}){`, `}`].join('\n')];
   }
 }
 
@@ -1047,14 +1038,7 @@ class EmitStatementWriter extends CairoASTNodeWriter {
 
     const documentation = getDocumentation(node.documentation, writer);
     const args: string = node.vEventCall.vArguments.map((v) => writer.write(v)).join(', ');
-    return [
-      [
-        documentation,
-        `${node.vEventCall.vFunctionName}_${eventDef.canonicalSignatureHash(
-          ABIEncoderVersion.V2,
-        )}.emit(${args});`,
-      ].join('\n'),
-    ];
+    return [[documentation, `${eventDef.name}.emit(${args});`].join('\n')];
   }
 }
 

--- a/src/passes/identifierManglerPass/declarationNameMangler.ts
+++ b/src/passes/identifierManglerPass/declarationNameMangler.ts
@@ -6,6 +6,7 @@ import {
   SourceUnit,
   ContractDefinition,
   ASTNode,
+  EventDefinition,
 } from 'solc-typed-ast';
 import { ABIEncoderVersion } from 'solc-typed-ast/dist/types/abi';
 import { AST } from '../../ast/ast';
@@ -130,11 +131,15 @@ export class DeclarationNameMangler extends ASTMapper {
         node.name = this.createNewInternalFunctionName(node.name);
     }
   }
+  mangleEventDefinition(node: EventDefinition): void {
+    node.name = `${node.name}_${node.canonicalSignatureHash(ABIEncoderVersion.V2)}`;
+  }
   mangleContractDefinition(node: ContractDefinition): void {
     checkSourceTerms(node.name, node);
     node.vStructs.forEach((s) => this.mangleStructDefinition(s));
     node.vFunctions.forEach((n) => this.mangleFunctionDefinition(n));
     node.vStateVariables.forEach((v) => this.mangleVariableDeclaration(v));
+    node.vEvents.forEach((e) => this.mangleEventDefinition(e));
   }
   visitSourceUnit(node: SourceUnit, ast: AST): void {
     node.vStructs.forEach((s) => this.mangleStructDefinition(s));

--- a/src/passes/identifierManglerPass/expressionNameMangler.ts
+++ b/src/passes/identifierManglerPass/expressionNameMangler.ts
@@ -9,6 +9,7 @@ import {
   UserDefinedValueTypeDefinition,
   ExternalReferenceType,
   ImportDirective,
+  EventDefinition,
 } from 'solc-typed-ast';
 
 import { AST } from '../../ast/ast';
@@ -30,6 +31,7 @@ export class ExpressionNameMangler extends ASTMapper {
     if (
       node.vIdentifierType === ExternalReferenceType.UserDefined &&
       (node.vReferencedDeclaration instanceof VariableDeclaration ||
+        node.vReferencedDeclaration instanceof EventDefinition ||
         (node.vReferencedDeclaration instanceof FunctionDefinition &&
           !(node.parent instanceof ImportDirective)))
     ) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@algorithm.ts/gcd@^2.0.14":
+  version "2.0.14"
+  resolved "https://registry.yarnpkg.com/@algorithm.ts/gcd/-/gcd-2.0.14.tgz#8658c58cb4abd60f06cc29eb17b96e3c2d25fc62"
+  integrity sha512-nxiHsW1huiSZo067aXjKxGoQFGwH7jTltDo12xCeJn4w9bEOfgmmWJorh/CNs8c6F+qergd937wm0jnczynR1Q==
+
 "@cspotcode/source-map-consumer@0.8.0":
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz#33bf4b7b39c178821606f669bbc447a6a629786b"


### PR DESCRIPTION
The canonicalSignatureHash for events was being calculated in the cairoWriter, this is problematic since the bytesConverter changes all references to the `bytesN` type to its corresponding `uintM` type; so the canonicalSignatureHash would differ from the expected one if the event had a `bytesN` parameter