### PR TITLE
Modifiers in inherited functions

### DIFF
--- a/src/passes/inheritanceInliner/functionInheritance.ts
+++ b/src/passes/inheritanceInliner/functionInheritance.ts
@@ -157,8 +157,6 @@ function createDelegatingFunction(
   const oldBody = funcToCopy.vBody;
   funcToCopy.vBody = undefined;
   const newFunc = cloneASTNode(funcToCopy, ast);
-  newFunc.isConstructor = false;
-  newFunc.vModifiers = [];
   funcToCopy.vBody = oldBody;
 
   const newBody = createBlock(
@@ -180,6 +178,9 @@ function createDelegatingFunction(
 
   newFunc.scope = scope;
   newFunc.vOverrideSpecifier = undefined;
+  newFunc.isConstructor = false;
+  // Modifiers are invoked in the private function already
+  newFunc.vModifiers = [];
   newFunc.vBody = newBody;
   newFunc.acceptChildren();
   ast.setContextRecursive(newFunc);

--- a/src/passes/inheritanceInliner/functionInheritance.ts
+++ b/src/passes/inheritanceInliner/functionInheritance.ts
@@ -157,6 +157,8 @@ function createDelegatingFunction(
   const oldBody = funcToCopy.vBody;
   funcToCopy.vBody = undefined;
   const newFunc = cloneASTNode(funcToCopy, ast);
+  newFunc.isConstructor = false;
+  newFunc.vModifiers = [];
   funcToCopy.vBody = oldBody;
 
   const newBody = createBlock(

--- a/tests/behaviour/contracts/inheritance/modifiers/inheritedModifiedFunction.sol
+++ b/tests/behaviour/contracts/inheritance/modifiers/inheritedModifiedFunction.sol
@@ -1,0 +1,16 @@
+pragma solidity ^0.8.6;
+
+contract A {
+  uint256 x = 0;
+
+  modifier step(uint256 value) {
+    x += value;
+    _;
+  }
+
+  function f(uint256 amount) external step(amount) returns (uint256) {
+    return x;
+  }
+}
+
+contract B is A {}

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -2805,6 +2805,12 @@ export const expectations = flatten(
               ],
             ),
             new File(
+              'inheritedModifiedFunction',
+              'B',
+              [],
+              [Expect.Simple('f', ['20', '0'], ['20', '0'])],
+            ),
+            new File(
               'modifierInheritance',
               'D',
               [],


### PR DESCRIPTION
Problem:
All the inherited functions get added as private functions in the current contract. Those that were externally visible need to remain externally visible here as well, so a wrapper function is created with the correct visibility and it calls the corresponding private function. This wrapper has the modifiers of the original function, since it is a clone, and the private function that is being called is also a clone, so it has the same modifiers. So all modifiers are called twice.

Solution:
Remove all modifiers from the wrapper function

- [x] Sem Tests Pass