### PR TITLE
Update `getPackedEncoding` to return 32 bytes when dealing with addresses

### DIFF
--- a/src/cairoUtilFuncGen/abi/abiEncode.ts
+++ b/src/cairoUtilFuncGen/abi/abiEncode.ts
@@ -1,5 +1,6 @@
 import assert from 'assert';
 import {
+  AddressType,
   ArrayType,
   generalizeType,
   SourceUnit,
@@ -170,7 +171,9 @@ export class AbiEncode extends AbiBase {
     // Is value type
     const size = getPackedByteSize(type, this.ast.compilerVersion);
     const instructions: string[] = [];
-    if (size < 32) {
+    // packed size of addresses is 32 bytes, but they are treated as felts,
+    // so they should be converted to Uint256 accordingly
+    if (size < 32 || type instanceof AddressType) {
       this.requireImport(`warplib.maths.utils`, 'felt_to_uint256');
       instructions.push(`let (${varToEncode}256) = felt_to_uint256(${varToEncode});`);
       varToEncode = `${varToEncode}256`;

--- a/src/utils/nodeTypeProcessing.ts
+++ b/src/utils/nodeTypeProcessing.ts
@@ -295,7 +295,6 @@ export function safeGetNodeTypeInCtx(
  *  @returns returns the types byte representation using packed abi encoding
  */
 export function getPackedByteSize(type: TypeNode, version: string): number | bigint {
-  let x = 3;
   if (type instanceof IntType) {
     return type.nBits / 8;
   }

--- a/src/utils/nodeTypeProcessing.ts
+++ b/src/utils/nodeTypeProcessing.ts
@@ -285,9 +285,10 @@ export function safeGetNodeTypeInCtx(
 /**
  * Given a type returns its packed solidity bytes size
  * e.g. uint8 -> byte size is 1
- *      address -> byte size is 20
  *      uint16[3] -> byte size is 6
  *      and so on
+ *  address are 32 bytes instead of 20 bytes due to size difference
+ *  between addresses in StarkNet and Ethereum
  *  For every type whose byte size can be known on compile time
  *  @param type Solidity type
  *  @param version required for calculating structs byte size
@@ -301,7 +302,7 @@ export function getPackedByteSize(type: TypeNode, version: string): number | big
     return type.size;
   }
   if (type instanceof AddressType) {
-    return 20;
+    return 32;
   }
   if (
     type instanceof BoolType ||

--- a/src/utils/nodeTypeProcessing.ts
+++ b/src/utils/nodeTypeProcessing.ts
@@ -295,6 +295,7 @@ export function safeGetNodeTypeInCtx(
  *  @returns returns the types byte representation using packed abi encoding
  */
 export function getPackedByteSize(type: TypeNode, version: string): number | bigint {
+  let x = 3;
   if (type instanceof IntType) {
     return type.nBits / 8;
   }

--- a/tests/behaviour/contracts/abiEncode/abiEncodePacked.sol
+++ b/tests/behaviour/contracts/abiEncode/abiEncodePacked.sol
@@ -21,6 +21,10 @@ contract WARP  {
     }
 
     // Reference Types
+    function addressArray(address[3] memory a1, address[] memory a2) public pure returns (bytes memory) {
+        return abi.encodePacked(a1, a2);
+    }
+
     function bArray (bytes memory a, bytes memory b) public pure returns (bytes memory) {
         return abi.encodePacked(a, b);
     }

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -75,6 +75,11 @@ export const expectations = flatten(
             Expect.Simple('booleans', ['1', '1'], ['2', '1', '1']),
             Expect.Simple('enums', ['3', '2'], ['2', '3', '2']),
             Expect.Simple(
+              'addressArray',
+              ['2', '3', `${2n ** 180n}`, '2', '5', '7'],
+              getByte32Array(2, 3, 2n ** 180n, 5, 7),
+            ),
+            Expect.Simple(
               'bArray',
               ['3', '2', '3', '5', '4', '7', '11', '13', '17'],
               ['7', '2', '3', '5', '7', '11', '13', '17'],

--- a/tests/behaviour/expectations/index.ts
+++ b/tests/behaviour/expectations/index.ts
@@ -45,4 +45,4 @@ function filterTests(
   return tests.filter((test) => test.name.includes(filter));
 }
 
-export const expectations = filterTests(behaviour, semantic);
+export const expectations = filterTests(behaviour, semantic, 'abiEncodePacked');

--- a/tests/behaviour/expectations/index.ts
+++ b/tests/behaviour/expectations/index.ts
@@ -45,4 +45,4 @@ function filterTests(
   return tests.filter((test) => test.name.includes(filter));
 }
 
-export const expectations = filterTests(behaviour, semantic, 'abiEncodePacked');
+export const expectations = filterTests(behaviour, semantic);


### PR DESCRIPTION
- [x] Sem Tests Pass