### PR TITLE
Modifier cloning bug

### DIFF
--- a/tests/behaviour/contracts/modifiers/modifierRecursive.sol
+++ b/tests/behaviour/contracts/modifiers/modifierRecursive.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract WARP {
+  uint256 public called;
+  modifier mod1() {
+    called++;
+    _;
+  }
+
+  function fact(uint256 x) public mod1 returns (uint256 r) {
+    if (x == 0) return 1;
+    return x * fact(x - 1);
+  }
+}

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -3350,6 +3350,12 @@ export const expectations = flatten(
             Expect.Simple('f', ['90000', '0'], ['10000', '0']),
             Expect.Simple('f', ['110000', '0'], ['0', '0']),
           ]),
+          File.Simple('modifierRecursive', [
+            new Expect('modifier', [
+              ['fact', ['5', '0'], ['120', '0'], '0'],
+              ['called', [], ['6', '0'], '0'],
+            ]),
+          ]),
           File.Simple('modifierWithReturn', [
             Expect.Simple('returnFiveThroughModifiers', [], ['5']),
           ]),


### PR DESCRIPTION
When extracting the original function in the `ModifierHandler`, the function that is modified gets cloned, so if there is a function call inside this function to this same function (a recursive call), the referenced declaration gets rebind to the cloned function, but in this case that's not what it's needed. It should remain referencing the function that was being modified. 

In order to solve the problem, the body of the function is saved in a temporary variable, and the node's body is set to undefined. After the function is cloned, the body is attached to the cloned function.

- [x] Sem Tests Running
- [x] Sem Tests Pass