### PR TITLE
Moving Global Counter for While Loops

### DIFF
--- a/src/passes/loopFunctionaliser/index.ts
+++ b/src/passes/loopFunctionaliser/index.ts
@@ -15,12 +15,14 @@ export class LoopFunctionaliser extends ASTMapper {
   }
 
   static map(ast: AST): AST {
+    const loopFnCounter = { count: 0 };
+
     ast.roots.forEach((root) => {
       const loopToContinueFunction: Map<number, FunctionDefinition> = new Map();
 
       new ForLoopToWhile().dispatchVisit(root, ast);
       new ReturnToBreak().dispatchVisit(root, ast);
-      new WhileLoopToFunction(loopToContinueFunction).dispatchVisit(root, ast);
+      new WhileLoopToFunction(loopToContinueFunction, loopFnCounter).dispatchVisit(root, ast);
       new BreakToReturn().dispatchVisit(root, ast);
       new ContinueToLoopCall(loopToContinueFunction).dispatchVisit(root, ast);
     });

--- a/src/passes/loopFunctionaliser/utils.ts
+++ b/src/passes/loopFunctionaliser/utils.ts
@@ -27,15 +27,12 @@ import {
 } from '../../utils/nodeTemplates';
 import { getContainingSourceUnit } from '../../utils/utils';
 
-// It's okay to use a global counter here as it only affects private functions
-// and never anything that can be referenced from another file
-let loopFnCounter = 0;
-
 export function extractWhileToFunction(
   node: WhileStatement,
   variables: VariableDeclaration[],
   loopToContinueFunction: Map<number, FunctionDefinition>,
   ast: AST,
+  loopFnCounter: number,
   prefix = WHILE_PREFIX,
 ): FunctionDefinition {
   const scope =
@@ -113,12 +110,14 @@ export function extractDoWhileToFunction(
   variables: VariableDeclaration[],
   loopToContinueFunction: Map<number, FunctionDefinition>,
   ast: AST,
+  loopFnCounter: number,
 ): FunctionDefinition {
   const doWhileFuncDef = extractWhileToFunction(
     node,
     variables,
     loopToContinueFunction,
     ast,
+    loopFnCounter,
     '__warp_do_while_',
   );
 

--- a/src/passes/loopFunctionaliser/whileLoopToFunction.ts
+++ b/src/passes/loopFunctionaliser/whileLoopToFunction.ts
@@ -5,7 +5,10 @@ import { collectUnboundVariables, createOuterCall } from '../../utils/functionGe
 import { createLoopCall, extractDoWhileToFunction, extractWhileToFunction } from './utils';
 
 export class WhileLoopToFunction extends ASTMapper {
-  constructor(private loopToContinueFunction: Map<number, FunctionDefinition>) {
+  constructor(
+    private loopToContinueFunction: Map<number, FunctionDefinition>,
+    private loopFnCounter: { count: number },
+  ) {
     super();
   }
 
@@ -24,6 +27,7 @@ export class WhileLoopToFunction extends ASTMapper {
       [...unboundVariables.keys()],
       this.loopToContinueFunction,
       ast,
+      this.loopFnCounter.count++,
     );
 
     const outerCall = createOuterCall(


### PR DESCRIPTION
This global counter was causing issues when transpiling multiple files. The counter is now zero-initialized for every AST, not every execution of the program

- [x] Sem Tests Pass
