### PR TITLE
Avoid retranspilation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -87,7 +87,7 @@ program
         const otherFiles = new Set<string>(
           otherAST.roots.map((sourceUnit) => sourceUnit.absolutePath),
         );
-        return files.every(otherFiles.has);
+        return files.every((f) => otherFiles.has(f));
       });
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,16 +78,18 @@ program
     const contractToHashMap = new Map<string, string>();
 
     const solcASTs = files.map((file) => compileSolFile(file, options.warnings));
+    // Every AST which is a subset of another AST gets removed
     const roots = solcASTs.filter((ast) => {
       const files = ast.roots.map((sourceUnit) => sourceUnit.absolutePath);
-      return solcASTs.some((otherAST) => {
+      //returns true if no other ast contains this
+      return !solcASTs.some((otherAST) => {
+        if (otherAST === ast) return false;
         const otherFiles = new Set<string>(
           otherAST.roots.map((sourceUnit) => sourceUnit.absolutePath),
         );
         return files.every(otherFiles.has);
       });
     });
-    solcASTs.sort((ast) => -ast.roots.length);
 
     roots.forEach((ast) => {
       // if (files.length > 1) {


### PR DESCRIPTION
Optimization to avoid retranspilation of files when excuting 
```bash
warp transpile <file_list>
```
Previous behaviour:
```bash
warp transpile x.sol y.sol
```
if x.sol imports y.sol, then during `x` transpilation, `y` would get transpiled as it's a dependency
Then `y` would get transpiled (again!)

Current behaviour:
`y` is transpiled only once, during the process of the transpilation of `x`