### PR TITLE
Remove all compile repitions for multifile input

### DIFF
--- a/src/solCompile.ts
+++ b/src/solCompile.ts
@@ -17,9 +17,7 @@ import { error } from './utils/formatting';
 // size to the largest possible
 const MAX_BUFFER_SIZE = Number.MAX_SAFE_INTEGER;
 
-function compileSolFilesCommon(
-  files: string[],
-): { result: unknown; compilerVersion: string } {
+function compileSolFilesCommon(files: string[]): { result: unknown; compilerVersion: string } {
   const sources = files.map((file) => {
     return getSolFileVersion(file);
   });

--- a/src/solCompile.ts
+++ b/src/solCompile.ts
@@ -17,19 +17,37 @@ import { error } from './utils/formatting';
 // size to the largest possible
 const MAX_BUFFER_SIZE = Number.MAX_SAFE_INTEGER;
 
-export function compileSolFile(file: string, printWarnings: boolean): AST {
-  const requiredSolcVersion = getSolFileVersion(file);
-  const [, majorVersion] = matchCompilerVersion(requiredSolcVersion);
-  if (majorVersion != '7' && majorVersion != '8') {
-    throw new TranspileFailedError(`Unsupported version of solidity source ${requiredSolcVersion}`);
+function compileSolFilesCommon(
+  files: string[],
+): { result: unknown; compilerVersion: string } {
+  const sources = files.map((file) => {
+    return getSolFileVersion(file);
+  });
+
+  sources.forEach((version, i) => {
+    const [, majorVersion] = matchCompilerVersion(version);
+    if (majorVersion != '7' && majorVersion != '8') {
+      throw new TranspileFailedError(
+        `Unsupported version of solidity source ${version} in file ${files[i]}`,
+      );
+    }
+  });
+
+  if (!sources.every((version) => version === sources[0])) {
+    throw new TranspileFailedError(`All solidity files should be the same major version`);
   }
 
-  const solcOutput = cliCompile(formatInput(file), requiredSolcVersion);
+  const solcOutput = cliCompile(formatInput(files), sources[0]);
+  return solcOutput;
+}
+
+export function compileSolFiles(files: string[], printWarnings: boolean): AST {
+  const solcOutput = compileSolFilesCommon(files);
   printErrors(solcOutput.result, printWarnings, solcOutput.compilerVersion);
   const reader = new ASTReader();
   const sourceUnits = reader.read(solcOutput.result);
 
-  return new AST(sourceUnits, requiredSolcVersion);
+  return new AST(sourceUnits, solcOutput.compilerVersion);
 }
 
 const supportedVersions = ['0.8.14', '0.7.6'];
@@ -60,14 +78,16 @@ type SolcInput = {
   };
 };
 
-function formatInput(fileName: string): SolcInput {
+function formatInput(fileNames: string[]): SolcInput {
+  const sources: { [key: string]: { urls: string[] } } = {};
+  fileNames.forEach((fileName) => {
+    sources[fileName] = {
+      urls: [fileName],
+    };
+  });
   return {
     language: 'Solidity',
-    sources: {
-      [fileName]: {
-        urls: [fileName],
-      },
-    },
+    sources,
     settings: {
       outputSelection: {
         '*': {
@@ -164,14 +184,14 @@ function printErrors(cliOutput: unknown, printWarnings: boolean, compilerVersion
 }
 
 // used for the semantic test suite
-export function compileSolFileAndExtractContracts(file: string): unknown {
+export function compileSolFilesAndExtractContracts(file: string): unknown {
   const requiredSolcVersion = getSolFileVersion(file);
   const [, majorVersion] = matchCompilerVersion(requiredSolcVersion);
   if (majorVersion != '7' && majorVersion != '8') {
     throw new TranspileFailedError(`Unsupported version of solidity source ${requiredSolcVersion}`);
   }
 
-  const solcOutput = cliCompile(formatInput(file), requiredSolcVersion);
+  const solcOutput = cliCompile(formatInput([file]), requiredSolcVersion);
   assert(typeof solcOutput.result === 'object' && solcOutput.result !== null);
   return Object.entries(solcOutput.result).filter(([name]) => name === 'contracts')[0][1][file];
 }

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -1,6 +1,6 @@
 import { CompileFailedError } from 'solc-typed-ast';
 import { findAllFiles, findCairoSourceFilePaths, findSolSourceFilePaths } from './io';
-import { compileSolFile } from './solCompile';
+import { compileSolFiles } from './solCompile';
 import { compileCairo } from './starknetCli';
 import { transpile } from './transpiler';
 import {
@@ -296,8 +296,8 @@ function runSolFileTest(
 ): void {
   console.log(`Warping ${file}`);
   try {
-    transpile(compileSolFile(file, false), { strict: true, dev: true }).forEach(([file, cairo]) =>
-      outputFileSync(`${file.slice(0, -4)}.cairo`, cairo),
+    transpile(compileSolFiles([file], false), { strict: true, dev: true }).forEach(
+      ([file, cairo]) => outputFileSync(`${file.slice(0, -4)}.cairo`, cairo),
     );
     results.set(manglePath(removeExtension(file)), 'Success');
   } catch (e) {

--- a/src/utils/analyseSol.ts
+++ b/src/utils/analyseSol.ts
@@ -1,6 +1,6 @@
 import { PrintOptions } from '..';
 import { isValidSolFile } from '../io';
-import { compileSolFile } from '../solCompile';
+import { compileSolFiles } from '../solCompile';
 import { DefaultASTPrinter } from './astPrinter';
 
 export function analyseSol(file: string, options: PrintOptions) {
@@ -10,7 +10,7 @@ export function analyseSol(file: string, options: PrintOptions) {
 
   DefaultASTPrinter.applyOptions(options);
 
-  compileSolFile(file, true).roots.forEach((root) => {
+  compileSolFiles([file], true).roots.forEach((root) => {
     console.log(`---${root.absolutePath}---`);
     console.log(DefaultASTPrinter.print(root));
   });

--- a/tests/behaviour/expectations/semantic.ts
+++ b/tests/behaviour/expectations/semantic.ts
@@ -35,7 +35,7 @@ import whiteList from './semantic_whitelist';
 import whileListGenerated from './semantic_tests_generated';
 
 import { NotSupportedYetError } from '../../../src/utils/errors';
-import { compileSolFile, compileSolFileAndExtractContracts } from '../../../src/solCompile';
+import { compileSolFiles, compileSolFilesAndExtractContracts } from '../../../src/solCompile';
 import { printTypeNode } from '../../../src/utils/astPrinter';
 import { toUintOrFelt } from '../../../src/utils/utils';
 import { AsyncTest, Expect } from './types';
@@ -399,7 +399,7 @@ async function getContractAbiAndDefinition(
   lastContractName: string,
 ): Promise<[FunABI[], ContractDefinition, AST]> {
   // Get the abi of the contract for web3
-  const contracts: any = compileSolFileAndExtractContracts(file);
+  const contracts: any = compileSolFilesAndExtractContracts(file);
   const lastContract = contracts[lastContractName];
   if (lastContract === undefined) {
     throw new InvalidTestError(`Unable to find contract ${lastContractName} in file ${file}`);
@@ -408,7 +408,7 @@ async function getContractAbiAndDefinition(
 
   // Get the ast itself so we can resolve the types for our type conversion
   // later
-  const ast = compileSolFile(file, false);
+  const ast = compileSolFiles([file], false);
   const astRoot = ast.roots[ast.roots.length - 1];
   const [contractDef] = astRoot
     .getChildrenByType(ContractDefinition, true)


### PR DESCRIPTION
We remove all redundancies in compile by deferring to solc. Solc produces
a single linked ast for multiple file inputs so this resolves the full dependecy
chain.

There is a remarkable speed up to UniStark as a result of this pr.
