### PR TITLE
Update github runner for semantic tests

### DIFF
--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -33,7 +33,7 @@ jobs:
           find warplib/ -iname *.cairo -exec cairo-format -c {} +
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
     steps:
       - uses: actions/checkout@v2
 
@@ -79,7 +79,7 @@ jobs:
   benchmark:
     if: ${{ github.event_name == 'push' }}
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
This PR updates the Github Runner used for the Semantic Tests to a larger runner. This should hopefully fix the issue where the test failed.