### PR TITLE
Minor improvements to `TypeInformationCalculator`

### DIFF
--- a/src/passes/annotateImplicits.ts
+++ b/src/passes/annotateImplicits.ts
@@ -19,7 +19,9 @@ import { getDocString, isCairoStub } from './cairoStubProcessor';
 export class AnnotateImplicits extends ASTMapper {
   // Function to add passes that should have been run before this pass
   addInitialPassPrerequisites(): void {
-    const passKeys: Set<string> = new Set<string>([]);
+    const passKeys: Set<string> = new Set<string>([
+      'Tic', // Type builtins are not handled at this stage
+    ]);
     passKeys.forEach((key) => this.addPassPrerequisite(key));
   }
 

--- a/src/passes/typeInformationCalculator.ts
+++ b/src/passes/typeInformationCalculator.ts
@@ -18,7 +18,7 @@ import { ABIEncoderVersion } from 'solc-typed-ast/dist/types/abi';
 import { AST } from '../ast/ast';
 import { ASTMapper } from '../ast/mapper';
 import { printTypeNode } from '../utils/astPrinter';
-import { TranspileFailedError, WillNotSupportError } from '../utils/errors';
+import { WillNotSupportError } from '../utils/errors';
 import { createNumberLiteral, createStringLiteral } from '../utils/nodeTemplates';
 import { safeGetNodeType } from '../utils/nodeTypeProcessing';
 

--- a/src/passes/typeInformationCalculator.ts
+++ b/src/passes/typeInformationCalculator.ts
@@ -6,6 +6,7 @@ import {
   EnumDefinition,
   EnumValue,
   Expression,
+  ExternalReferenceType,
   FunctionCall,
   Identifier,
   IntType,
@@ -17,7 +18,7 @@ import { ABIEncoderVersion } from 'solc-typed-ast/dist/types/abi';
 import { AST } from '../ast/ast';
 import { ASTMapper } from '../ast/mapper';
 import { printTypeNode } from '../utils/astPrinter';
-import { WillNotSupportError } from '../utils/errors';
+import { TranspileFailedError, WillNotSupportError } from '../utils/errors';
 import { createNumberLiteral, createStringLiteral } from '../utils/nodeTemplates';
 import { safeGetNodeType } from '../utils/nodeTypeProcessing';
 
@@ -62,25 +63,30 @@ export class TypeInformationCalculator extends ASTMapper {
   }
 
   visitMemberAccess(node: MemberAccess, ast: AST): void {
+    this.visitExpression(node, ast);
+    const typeFuncCall = node.vExpression;
     if (
-      !node.vExpression.typeString.startsWith('type(') ||
-      !(node.vExpression instanceof FunctionCall)
+      !(
+        typeFuncCall instanceof FunctionCall &&
+        typeFuncCall.vFunctionCallType === ExternalReferenceType.Builtin &&
+        typeFuncCall.vFunctionName === 'type'
+      )
     ) {
-      return this.visitExpression(node.vExpression, ast);
+      return;
     }
+    assert(
+      typeFuncCall.vArguments.length === 1,
+      `Calls to type() must have one argument, got ${typeFuncCall.vArguments.length}.`,
+    );
+    const argNode = typeFuncCall.vArguments[0];
 
-    const argNode = node.vExpression.vArguments[0];
-
-    const replaceNode: ASTNode | null = this.getReplacement(
+    const replaceNode: ASTNode = this.getReplacement(
       argNode,
       node.memberName,
       node.typeString,
       ast,
     );
-
-    if (replaceNode !== null) {
-      ast.replaceNode(node, replaceNode);
-    }
+    ast.replaceNode(node, replaceNode);
   }
 
   private getReplacement(
@@ -88,7 +94,7 @@ export class TypeInformationCalculator extends ASTMapper {
     memberName: string,
     typestring: string,
     ast: AST,
-  ): ASTNode | null {
+  ): ASTNode {
     let nodeType = safeGetNodeType(node, ast.compilerVersion);
     assert(
       nodeType instanceof TypeNameType,
@@ -117,9 +123,6 @@ export class TypeInformationCalculator extends ASTMapper {
       if (userDef instanceof ContractDefinition) {
         if (memberName === 'name') return createStringLiteral(userDef.name, ast);
 
-        if (['runtimeCode', 'executionCode'].includes(memberName))
-          throw new WillNotSupportError(`Access to ${memberName} is not supported`);
-
         if (userDef.kind === ContractKind.Interface && memberName === 'interfaceId') {
           const interfaceId = userDef.interfaceId(ABIEncoderVersion.V2);
           assert(
@@ -129,8 +132,14 @@ export class TypeInformationCalculator extends ASTMapper {
           const value = BigInt('0x' + interfaceId);
           return createNumberLiteral(value, ast);
         }
+
+        throw new WillNotSupportError(
+          `Member access "type(${nodeType.name}).${memberName}" is not supported`,
+        );
       }
     }
-    return null;
+    throw new WillNotSupportError(
+      `Member access "type(${printTypeNode(nodeType)}).${memberName} is not supported"`,
+    );
   }
 }


### PR DESCRIPTION
- Fix a bug with type info of contracts where it didn't throw an error
- Always throw an error when there is `type()` case which is not being handled