### PR TITLE
Save solidity interfaces transpiled output

### DIFF
--- a/src/cairoWriter.ts
+++ b/src/cairoWriter.ts
@@ -347,8 +347,11 @@ class SourceUnitWriter extends CairoASTNodeWriter {
     generateInterfaceNameMappings(node);
 
     // Every sourceUnit should only define a single contract
-    const mainContract_ = node.vContracts.filter((cd) => cd.kind !== ContractKind.Interface);
-    assert(mainContract_.length <= 1, 'There should only be one active contract per sourceUnit');
+    const mainContract_ =
+      node.vContracts.length >= 2
+        ? node.vContracts.filter((cd) => cd.kind !== ContractKind.Interface)
+        : node.vContracts;
+    assert(mainContract_.length === 1, 'There should only be one active contract per sourceUnit');
     const [mainContract] = mainContract_;
 
     const [freeStructs, freeStructRemappings_] = mainContract

--- a/src/passes/dropUnusedSourceUnit.ts
+++ b/src/passes/dropUnusedSourceUnit.ts
@@ -1,6 +1,8 @@
+import path from 'path';
 import { ContractKind } from 'solc-typed-ast';
 import { AST } from '../ast/ast';
 import { ASTMapper } from '../ast/mapper';
+import { FREE_FILE_NAME } from '../export';
 
 export class DropUnusedSourceUnits extends ASTMapper {
   // Function to add passes that should have been run before this pass
@@ -17,7 +19,8 @@ export class DropUnusedSourceUnits extends ASTMapper {
         su.vContracts.some(
           (cd) =>
             (cd.kind === ContractKind.Contract && !cd.abstract) ||
-            cd.kind === ContractKind.Interface,
+            (cd.kind === ContractKind.Interface &&
+              path.basename(su.absolutePath) !== FREE_FILE_NAME),
         ),
     );
     return ast;

--- a/src/passes/dropUnusedSourceUnit.ts
+++ b/src/passes/dropUnusedSourceUnit.ts
@@ -14,7 +14,11 @@ export class DropUnusedSourceUnits extends ASTMapper {
     ast.roots = ast.roots.filter(
       (su) =>
         su.vContracts.length > 0 &&
-        su.vContracts.some((cd) => cd.kind === ContractKind.Contract && !cd.abstract),
+        su.vContracts.some(
+          (cd) =>
+            (cd.kind === ContractKind.Contract && !cd.abstract) ||
+            cd.kind === ContractKind.Interface,
+        ),
     );
     return ast;
   }


### PR DESCRIPTION
Previously solidity interfaces contracts where not written to files.
Now they do