### PR TITLE
Remove 251 bit (now it's 256) keccak hashing: Events

### DIFF
--- a/src/cairoUtilFuncGen/event.ts
+++ b/src/cairoUtilFuncGen/event.ts
@@ -191,7 +191,6 @@ export class EventFunction extends StringIndexedFuncGen {
     return [
       `   let (mem_encode: felt) = ${abiFunc}(${argName});`,
       `   let (keccak_hash256: Uint256) = warp_keccak(mem_encode);`,
-      // `   let (keccak_hash256: Uint256) = felt_to_uint256(keccak_hash);`,
       `   let (${arrayName}_len: felt) = fixed_bytes256_to_felt_dynamic_array_spl(${arrayName}_len, ${arrayName}, 0, keccak_hash256);`,
     ].join('\n');
   }

--- a/src/cairoUtilFuncGen/event.ts
+++ b/src/cairoUtilFuncGen/event.ts
@@ -18,7 +18,7 @@ import {
   safeGetNodeType,
   TypeConversionContext,
   typeNameFromTypeNode,
-  warpEvenSignatureHash256FromString,
+  warpEventSignatureHash256FromString,
   EMIT_PREFIX,
 } from '../export';
 import { StringIndexedFuncGen } from './base';
@@ -111,7 +111,7 @@ export class EventFunction extends StringIndexedFuncGen {
 
     const cairoParams = params.map((p) => `${p.name} : ${p.type}`).join(', ');
 
-    const topic: { low: string; high: string } = warpEvenSignatureHash256FromString(
+    const topic: { low: string; high: string } = warpEventSignatureHash256FromString(
       this.ast.inference.signature(node, ABIEncoderVersion.V2),
     );
 

--- a/src/cairoUtilFuncGen/event.ts
+++ b/src/cairoUtilFuncGen/event.ts
@@ -18,7 +18,6 @@ import {
   safeGetNodeType,
   TypeConversionContext,
   typeNameFromTypeNode,
-  warpEventCanonicalSignaturehash,
   warpEventCanonicalSignaturehash256,
 } from '../export';
 import { StringIndexedFuncGen } from './base';

--- a/src/cairoUtilFuncGen/event.ts
+++ b/src/cairoUtilFuncGen/event.ts
@@ -23,7 +23,6 @@ import {
 import { StringIndexedFuncGen } from './base';
 import { ABIEncoderVersion } from 'solc-typed-ast/dist/types/abi';
 
-export const MASK_250 = BigInt('0x3ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff');
 export const BYTES_IN_FELT_PACKING = 31;
 const BIG_ENDIAN = 1; // 0 for little endian, used for packing of bytes (31 byte felts -> a 248 bit felt)
 
@@ -186,13 +185,13 @@ export class EventFunction extends StringIndexedFuncGen {
 
     this.requireImport('starkware.cairo.common.uint256', 'Uint256');
     this.requireImport(`warplib.maths.utils`, 'felt_to_uint256');
-    this.requireImport('warplib.keccak', 'warp_keccak_felt');
+    this.requireImport('warplib.keccak', 'warp_keccak');
     this.requireImport('warplib.dynamic_arrays_util', 'fixed_bytes256_to_felt_dynamic_array_spl');
 
     return [
       `   let (mem_encode: felt) = ${abiFunc}(${argName});`,
-      `   let (keccak_hash: felt) = warp_keccak_felt(mem_encode);`,
-      `   let (keccak_hash256: Uint256) = felt_to_uint256(keccak_hash);`,
+      `   let (keccak_hash256: Uint256) = warp_keccak(mem_encode);`,
+      // `   let (keccak_hash256: Uint256) = felt_to_uint256(keccak_hash);`,
       `   let (${arrayName}_len: felt) = fixed_bytes256_to_felt_dynamic_array_spl(${arrayName}_len, ${arrayName}, 0, keccak_hash256);`,
     ].join('\n');
   }

--- a/src/utils/event.ts
+++ b/src/utils/event.ts
@@ -58,18 +58,11 @@ export function warpEventCanonicalSignaturehash256(
   };
 
   const funcSignature = `${eventName}(${argTypes.map(getArgStringRepresentation).join(',')})`;
-  const funcSignatureHash = createKeccakHash('keccak256').update(funcSignature).digest('hex');
-
-  const [low, high] = toUintOrFelt(BigInt(`0x${funcSignatureHash}`), 256);
-
-  return {
-    low: `0x${low.toString(16)}`,
-    high: `0x${high.toString(16)}`,
-  };
+  return warpEventSignatureHash256FromString(funcSignature);
 }
 
 // NOTE: argTypes must not contain `uint` , it should be `uint256` instead
-export function warpEvenSignatureHash256FromString(functionSignature: string): {
+export function warpEventSignatureHash256FromString(functionSignature: string): {
   low: string;
   high: string;
 } {

--- a/src/utils/event.ts
+++ b/src/utils/event.ts
@@ -60,11 +60,11 @@ export function warpEventCanonicalSignaturehash256(
   const funcSignature = `${eventName}(${argTypes.map(getArgStringRepresentation).join(',')})`;
   const funcSignatureHash = createKeccakHash('keccak256').update(funcSignature).digest('hex');
 
-  const splitHash: bigint[] = toUintOrFelt(BigInt(`0x${funcSignatureHash}`), 256);
+  const [low, high] = toUintOrFelt(BigInt(`0x${funcSignatureHash}`), 256);
 
   return {
-    low: `0x${splitHash[0].toString(16)}`,
-    high: `0x${splitHash[1].toString(16)}`,
+    low: `0x${low.toString(16)}`,
+    high: `0x${high.toString(16)}`,
   };
 }
 

--- a/src/utils/event.ts
+++ b/src/utils/event.ts
@@ -61,3 +61,27 @@ export function warpEventCanonicalSignaturehash(eventName: string, argTypes: arg
     BigInt(`0x${createKeccakHash('keccak256').update(funcSignatureHash).digest('hex')}`) & MASK_250
   ).toString(16)}`;
 }
+
+// NOTE: argTypes must not contain `uint` , it should be `uint256` instead
+export function warpEventCanonicalSignaturehash256(
+  eventName: string,
+  argTypes: argType[],
+): { low: string; high: string } {
+  const getArgStringRepresentation = (arg: argType): string => {
+    if (typeof arg === 'string') return arg;
+    return `(${arg.map(getArgStringRepresentation).join(',')})`;
+  };
+
+  const funcSignature = `${eventName}(${argTypes.map(getArgStringRepresentation).join(',')})`;
+  const funcSignatureHash = createKeccakHash('keccak256').update(funcSignature).digest('hex');
+
+  const hash = BigInt(`0x${createKeccakHash('keccak256').update(funcSignatureHash).digest('hex')}`);
+
+  const hash_low_128 = hash & 0xffffffffffffffffffffffffffffffffn;
+  const hash_high_128 = (hash >> 128n) & 0xffffffffffffffffffffffffffffffffn;
+
+  return {
+    low: `0x${hash_low_128.toString(16)}`,
+    high: `0x${hash_high_128.toString(16)}`,
+  };
+}

--- a/src/utils/event.ts
+++ b/src/utils/event.ts
@@ -74,10 +74,10 @@ export function warpEvenSignatureHash256FromString(functionSignature: string): {
   high: string;
 } {
   const funcSignatureHash = createKeccakHash('keccak256').update(functionSignature).digest('hex');
-  const splitHash: bigint[] = toUintOrFelt(BigInt(`0x${funcSignatureHash}`), 256);
+  const [low, high] = toUintOrFelt(BigInt(`0x${funcSignatureHash}`), 256);
 
   return {
-    low: `0x${splitHash[0].toString(16)}`,
-    high: `0x${splitHash[1].toString(16)}`,
+    low: `0x${low.toString(16)}`,
+    high: `0x${high.toString(16)}`,
   };
 }

--- a/src/utils/event.ts
+++ b/src/utils/event.ts
@@ -1,5 +1,6 @@
 import createKeccakHash from 'keccak';
 import { MASK_250 } from '../cairoUtilFuncGen/event';
+import { toUintOrFelt } from './export';
 
 export type EventItem = { data: string[]; keys: string[]; order: number };
 
@@ -77,11 +78,10 @@ export function warpEventCanonicalSignaturehash256(
 
   const hash = BigInt(`0x${createKeccakHash('keccak256').update(funcSignatureHash).digest('hex')}`);
 
-  const hash_low_128 = hash & 0xffffffffffffffffffffffffffffffffn;
-  const hash_high_128 = (hash >> 128n) & 0xffffffffffffffffffffffffffffffffn;
+  const splitHash: bigint[] = toUintOrFelt(hash, 256);
 
   return {
-    low: `0x${hash_low_128.toString(16)}`,
-    high: `0x${hash_high_128.toString(16)}`,
+    low: `0x${splitHash[0].toString(16)}`,
+    high: `0x${splitHash[1].toString(16)}`,
   };
 }

--- a/src/utils/event.ts
+++ b/src/utils/event.ts
@@ -58,9 +58,7 @@ export function warpEventCanonicalSignaturehash(eventName: string, argTypes: arg
   const funcSignature = `${eventName}(${argTypes.map(getArgStringRepresentation).join(',')})`;
   const funcSignatureHash = createKeccakHash('keccak256').update(funcSignature).digest('hex');
 
-  return `0x${(
-    BigInt(`0x${createKeccakHash('keccak256').update(funcSignatureHash).digest('hex')}`) & MASK_250
-  ).toString(16)}`;
+  return `0x${(BigInt(`0x${funcSignatureHash}`) & MASK_250).toString(16)}`;
 }
 
 // NOTE: argTypes must not contain `uint` , it should be `uint256` instead
@@ -76,9 +74,7 @@ export function warpEventCanonicalSignaturehash256(
   const funcSignature = `${eventName}(${argTypes.map(getArgStringRepresentation).join(',')})`;
   const funcSignatureHash = createKeccakHash('keccak256').update(funcSignature).digest('hex');
 
-  const hash = BigInt(`0x${createKeccakHash('keccak256').update(funcSignatureHash).digest('hex')}`);
-
-  const splitHash: bigint[] = toUintOrFelt(hash, 256);
+  const splitHash: bigint[] = toUintOrFelt(BigInt(`0x${funcSignatureHash}`), 256);
 
   return {
     low: `0x${splitHash[0].toString(16)}`,

--- a/tests/behaviour/contracts/events/indexed.sol
+++ b/tests/behaviour/contracts/events/indexed.sol
@@ -7,6 +7,7 @@ contract WARP{
     //Event Definitions
     event uintEvent(uint indexed);
     event arrayEvent(uint[] indexed);
+    event arrayStringEvent(string[] indexed);
     event nestedArrayEvent(uint[][] indexed);
     event structEvent(C indexed);
 
@@ -20,6 +21,14 @@ contract WARP{
         a[1] = 3;
         a[2] = 5;
         emit arrayEvent(a);
+    }
+
+    function arrayString() public {
+        string[] memory a = new string[](3);
+        a[0] = "a";
+        a[1] = "b";
+        a[2] = "c";
+        emit arrayStringEvent(a);
     }
 
     function nestedArray() public {

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -12,7 +12,11 @@ import {
   MAX_INT8,
 } from './utils';
 import createKeccakHash from 'keccak';
-import { MASK_250, warpEventCanonicalSignaturehash } from '../../../src/export';
+import {
+  MASK_250,
+  warpEventCanonicalSignaturehash,
+  warpEventCanonicalSignaturehash256,
+} from '../../../src/export';
 
 export const expectations = flatten(
   new Dir('tests', [
@@ -2224,7 +2228,15 @@ export const expectations = flatten(
                 [
                   {
                     data: ['69'],
-                    keys: [warpEventCanonicalSignaturehash('uintEvent', ['uint256'])],
+                    keys: [
+                      `0x${(
+                        BigInt(warpEventCanonicalSignaturehash256('uintEvent', ['uint256']).low) +
+                        (BigInt(
+                          warpEventCanonicalSignaturehash256('uintEvent', ['uint256']).high,
+                        ) <<
+                          128n)
+                      ).toString(16)}`,
+                    ],
                     order: 0,
                   },
                 ],
@@ -2240,7 +2252,17 @@ export const expectations = flatten(
                 [
                   {
                     data: ['32', '3', '2', '3', '5'],
-                    keys: [warpEventCanonicalSignaturehash('arrayEvent', ['uint256[]'])],
+                    keys: [
+                      `0x${(
+                        BigInt(
+                          warpEventCanonicalSignaturehash256('arrayEvent', ['uint256[]']).low,
+                        ) +
+                        (BigInt(
+                          warpEventCanonicalSignaturehash256('arrayEvent', ['uint256[]']).high,
+                        ) <<
+                          128n)
+                      ).toString(16)}`,
+                    ],
                     order: 0,
                   },
                 ],
@@ -2256,7 +2278,19 @@ export const expectations = flatten(
                 [
                   {
                     data: ['32', '2', '64', '192', '3', '2', '3', '5', '2', '7', '11'],
-                    keys: [warpEventCanonicalSignaturehash('nestedArrayEvent', ['uint256[][]'])],
+                    keys: [
+                      `0x${(
+                        BigInt(
+                          warpEventCanonicalSignaturehash256('nestedArrayEvent', ['uint256[][]'])
+                            .low,
+                        ) +
+                        (BigInt(
+                          warpEventCanonicalSignaturehash256('nestedArrayEvent', ['uint256[][]'])
+                            .high,
+                        ) <<
+                          128n)
+                      ).toString(16)}`,
+                    ],
                     order: 0,
                   },
                 ],
@@ -2273,7 +2307,19 @@ export const expectations = flatten(
                   {
                     data: ['32', '128', '7', '11', '13', '3', '2', '3', '5'],
                     keys: [
-                      warpEventCanonicalSignaturehash('structEvent', [['uint8[]', 'uint256[3]']]),
+                      `0x${(
+                        BigInt(
+                          warpEventCanonicalSignaturehash256('structEvent', [
+                            ['uint8[]', 'uint256[3]'],
+                          ]).low,
+                        ) +
+                        (BigInt(
+                          warpEventCanonicalSignaturehash256('structEvent', [
+                            ['uint8[]', 'uint256[3]'],
+                          ]).high,
+                        ) <<
+                          128n)
+                      ).toString(16)}`,
                     ],
                     order: 0,
                   },
@@ -2292,7 +2338,16 @@ export const expectations = flatten(
                 [
                   {
                     data: [],
-                    keys: [warpEventCanonicalSignaturehash('uintEvent', ['uint256']), '69'],
+                    keys: [
+                      `0x${(
+                        BigInt(warpEventCanonicalSignaturehash256('uintEvent', ['uint256']).low) +
+                        (BigInt(
+                          warpEventCanonicalSignaturehash256('uintEvent', ['uint256']).high,
+                        ) <<
+                          128n)
+                      ).toString(16)}`,
+                      '69',
+                    ],
                     order: 0,
                   },
                 ],
@@ -2309,7 +2364,15 @@ export const expectations = flatten(
                   {
                     data: [],
                     keys: [
-                      warpEventCanonicalSignaturehash('arrayEvent', ['uint256[]']),
+                      `0x${(
+                        BigInt(
+                          warpEventCanonicalSignaturehash256('arrayEvent', ['uint256[]']).low,
+                        ) +
+                        (BigInt(
+                          warpEventCanonicalSignaturehash256('arrayEvent', ['uint256[]']).high,
+                        ) <<
+                          128n)
+                      ).toString(16)}`,
                       // 2,
                       // 3,
                       // 5,
@@ -2346,7 +2409,17 @@ export const expectations = flatten(
                   {
                     data: [],
                     keys: [
-                      warpEventCanonicalSignaturehash('nestedArrayEvent', ['uint256[][]']),
+                      `0x${(
+                        BigInt(
+                          warpEventCanonicalSignaturehash256('nestedArrayEvent', ['uint256[][]'])
+                            .low,
+                        ) +
+                        (BigInt(
+                          warpEventCanonicalSignaturehash256('nestedArrayEvent', ['uint256[][]'])
+                            .high,
+                        ) <<
+                          128n)
+                      ).toString(16)}`,
                       // 2,
                       // 3,
                       // 5,
@@ -2387,7 +2460,19 @@ export const expectations = flatten(
                   {
                     data: [],
                     keys: [
-                      warpEventCanonicalSignaturehash('structEvent', [['uint8[]', 'uint256[3]']]),
+                      `0x${(
+                        BigInt(
+                          warpEventCanonicalSignaturehash256('structEvent', [
+                            ['uint8[]', 'uint256[3]'],
+                          ]).low,
+                        ) +
+                        (BigInt(
+                          warpEventCanonicalSignaturehash256('structEvent', [
+                            ['uint8[]', 'uint256[3]'],
+                          ]).high,
+                        ) <<
+                          128n)
+                      ).toString(16)}`,
                       // '2',
                       // '3',
                       // '5',
@@ -2438,7 +2523,19 @@ export const expectations = flatten(
                       '2',
                       `${(BigInt(0x42) << BigInt(248)) | (BigInt(0x43) << BigInt(240))}`,
                     ],
-                    keys: [warpEventCanonicalSignaturehash('allStringEvent', ['string', 'string'])],
+                    keys: [
+                      `0x${(
+                        BigInt(
+                          warpEventCanonicalSignaturehash256('allStringEvent', ['string', 'string'])
+                            .low,
+                        ) +
+                        (BigInt(
+                          warpEventCanonicalSignaturehash256('allStringEvent', ['string', 'string'])
+                            .high,
+                        ) <<
+                          128n)
+                      ).toString(16)}`,
+                    ],
                     order: 0,
                   },
                 ],
@@ -2459,7 +2556,21 @@ export const expectations = flatten(
                       `${(BigInt(0x42) << BigInt(248)) | (BigInt(0x43) << BigInt(240))}`,
                     ],
                     keys: [
-                      warpEventCanonicalSignaturehash('allStringMiscEvent', ['string', 'string']),
+                      `0x${(
+                        BigInt(
+                          warpEventCanonicalSignaturehash256('allStringMiscEvent', [
+                            'string',
+                            'string',
+                          ]).low,
+                        ) +
+                        (BigInt(
+                          warpEventCanonicalSignaturehash256('allStringMiscEvent', [
+                            'string',
+                            'string',
+                          ]).high,
+                        ) <<
+                          128n)
+                      ).toString(16)}`,
                       `${
                         BigInt(
                           `0x${createKeccakHash('keccak256')
@@ -2487,7 +2598,21 @@ export const expectations = flatten(
                   {
                     data: ['1'],
                     keys: [
-                      warpEventCanonicalSignaturehash('allUintMiscEvent', ['uint256', 'uint256']),
+                      `0x${(
+                        BigInt(
+                          warpEventCanonicalSignaturehash256('allUintMiscEvent', [
+                            'uint256',
+                            'uint256',
+                          ]).low,
+                        ) +
+                        (BigInt(
+                          warpEventCanonicalSignaturehash256('allUintMiscEvent', [
+                            'uint256',
+                            'uint256',
+                          ]).high,
+                        ) <<
+                          128n)
+                      ).toString(16)}`,
                       '2',
                     ],
                     order: 0,
@@ -2506,7 +2631,21 @@ export const expectations = flatten(
                   {
                     data: [],
                     keys: [
-                      warpEventCanonicalSignaturehash('allIndexedEvent', ['uint256', 'uint256']),
+                      `0x${(
+                        BigInt(
+                          warpEventCanonicalSignaturehash256('allIndexedEvent', [
+                            'uint256',
+                            'uint256',
+                          ]).low,
+                        ) +
+                        (BigInt(
+                          warpEventCanonicalSignaturehash256('allIndexedEvent', [
+                            'uint256',
+                            'uint256',
+                          ]).high,
+                        ) <<
+                          128n)
+                      ).toString(16)}`,
                       '1',
                       '2',
                     ],
@@ -2532,13 +2671,39 @@ export const expectations = flatten(
                       '1',
                       `${BigInt(0x62) << BigInt(248)}`,
                     ],
-                    keys: [warpEventCanonicalSignaturehash('allStringEvent', ['string', 'string'])],
+                    keys: [
+                      `0x${(
+                        BigInt(
+                          warpEventCanonicalSignaturehash256('allStringEvent', ['string', 'string'])
+                            .low,
+                        ) +
+                        (BigInt(
+                          warpEventCanonicalSignaturehash256('allStringEvent', ['string', 'string'])
+                            .high,
+                        ) <<
+                          128n)
+                      ).toString(16)}`,
+                    ],
                     order: 0,
                   },
                   {
                     data: ['32', '1', `${BigInt(0x62) << BigInt(248)}`],
                     keys: [
-                      warpEventCanonicalSignaturehash('allStringMiscEvent', ['string', 'string']),
+                      `0x${(
+                        BigInt(
+                          warpEventCanonicalSignaturehash256('allStringMiscEvent', [
+                            'string',
+                            'string',
+                          ]).low,
+                        ) +
+                        (BigInt(
+                          warpEventCanonicalSignaturehash256('allStringMiscEvent', [
+                            'string',
+                            'string',
+                          ]).high,
+                        ) <<
+                          128n)
+                      ).toString(16)}`,
                       `${
                         BigInt(
                           `0x${createKeccakHash('keccak256')
@@ -2552,7 +2717,21 @@ export const expectations = flatten(
                   {
                     data: ['1'],
                     keys: [
-                      warpEventCanonicalSignaturehash('allUintMiscEvent', ['uint256', 'uint256']),
+                      `0x${(
+                        BigInt(
+                          warpEventCanonicalSignaturehash256('allUintMiscEvent', [
+                            'uint256',
+                            'uint256',
+                          ]).low,
+                        ) +
+                        (BigInt(
+                          warpEventCanonicalSignaturehash256('allUintMiscEvent', [
+                            'uint256',
+                            'uint256',
+                          ]).high,
+                        ) <<
+                          128n)
+                      ).toString(16)}`,
                       '2',
                     ],
                     order: 2,
@@ -2560,7 +2739,21 @@ export const expectations = flatten(
                   {
                     data: [],
                     keys: [
-                      warpEventCanonicalSignaturehash('allIndexedEvent', ['uint256', 'uint256']),
+                      `0x${(
+                        BigInt(
+                          warpEventCanonicalSignaturehash256('allIndexedEvent', [
+                            'uint256',
+                            'uint256',
+                          ]).low,
+                        ) +
+                        (BigInt(
+                          warpEventCanonicalSignaturehash256('allIndexedEvent', [
+                            'uint256',
+                            'uint256',
+                          ]).high,
+                        ) <<
+                          128n)
+                      ).toString(16)}`,
                       '1',
                       '2',
                     ],

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -13,7 +13,7 @@ import {
   cairoUint256toBigIntHex,
 } from './utils';
 import createKeccakHash from 'keccak';
-import { MASK_250, warpEventCanonicalSignaturehash256 } from '../../../src/export';
+import { warpEventCanonicalSignaturehash256 } from '../../../src/export';
 
 export const expectations = flatten(
   new Dir('tests', [
@@ -2337,22 +2337,20 @@ export const expectations = flatten(
                       // 2,
                       // 3,
                       // 5,
-                      `${
-                        BigInt(
-                          `0x${createKeccakHash('keccak256')
-                            .update(
-                              (
-                                (BigInt(2) << BigInt(32 * 8 * 2)) |
-                                (BigInt(3) << BigInt(32 * 8 * 1)) |
-                                BigInt(5)
-                              )
-                                .toString(16)
-                                .padStart(32 * 3 * 2, '0'),
-                              'hex',
+                      `${BigInt(
+                        `0x${createKeccakHash('keccak256')
+                          .update(
+                            (
+                              (BigInt(2) << BigInt(32 * 8 * 2)) |
+                              (BigInt(3) << BigInt(32 * 8 * 1)) |
+                              BigInt(5)
                             )
-                            .digest('hex')}`,
-                        ) & MASK_250
-                      }`,
+                              .toString(16)
+                              .padStart(32 * 3 * 2, '0'),
+                            'hex',
+                          )
+                          .digest('hex')}`,
+                      )}`,
                     ],
                     order: 0,
                   },
@@ -2373,22 +2371,20 @@ export const expectations = flatten(
                       cairoUint256toBigIntHex(
                         warpEventCanonicalSignaturehash256('arrayStringEvent', ['string[]']),
                       ),
-                      `${
-                        BigInt(
-                          `0x${createKeccakHash('keccak256')
-                            .update(
-                              (
-                                (BigInt(0x61) << BigInt(32 * 8 * 3 - 8)) |
-                                (BigInt(0x62) << BigInt(32 * 8 * 2 - 8)) |
-                                (BigInt(0x63) << BigInt(32 * 8 * 1 - 8))
-                              )
-                                .toString(16)
-                                .padEnd(32 * (8 / 4) * 3, '0'),
-                              'hex',
+                      `${BigInt(
+                        `0x${createKeccakHash('keccak256')
+                          .update(
+                            (
+                              (BigInt(0x61) << BigInt(32 * 8 * 3 - 8)) |
+                              (BigInt(0x62) << BigInt(32 * 8 * 2 - 8)) |
+                              (BigInt(0x63) << BigInt(32 * 8 * 1 - 8))
                             )
-                            .digest('hex')}`,
-                        ) & MASK_250
-                      }`,
+                              .toString(16)
+                              .padEnd(32 * (8 / 4) * 3, '0'),
+                            'hex',
+                          )
+                          .digest('hex')}`,
+                      )}`,
                     ],
                     order: 0,
                   },
@@ -2414,24 +2410,22 @@ export const expectations = flatten(
                       // 5,
                       // 7,
                       // 11,
-                      `${
-                        BigInt(
-                          `0x${createKeccakHash('keccak256')
-                            .update(
-                              (
-                                (BigInt(2) << BigInt(32 * 8 * 4)) |
-                                (BigInt(3) << BigInt(32 * 8 * 3)) |
-                                (BigInt(5) << BigInt(32 * 8 * 2)) |
-                                (BigInt(7) << BigInt(32 * 8 * 1)) |
-                                BigInt(11)
-                              )
-                                .toString(16)
-                                .padStart(32 * 5 * 2, '0'),
-                              'hex',
+                      `${BigInt(
+                        `0x${createKeccakHash('keccak256')
+                          .update(
+                            (
+                              (BigInt(2) << BigInt(32 * 8 * 4)) |
+                              (BigInt(3) << BigInt(32 * 8 * 3)) |
+                              (BigInt(5) << BigInt(32 * 8 * 2)) |
+                              (BigInt(7) << BigInt(32 * 8 * 1)) |
+                              BigInt(11)
                             )
-                            .digest('hex')}`,
-                        ) & MASK_250
-                      }`,
+                              .toString(16)
+                              .padStart(32 * 5 * 2, '0'),
+                            'hex',
+                          )
+                          .digest('hex')}`,
+                      )}`,
                     ],
                     order: 0,
                   },
@@ -2460,25 +2454,23 @@ export const expectations = flatten(
                       // '7',
                       // '11',
                       // '13',
-                      `${
-                        BigInt(
-                          `0x${createKeccakHash('keccak256')
-                            .update(
-                              (
-                                (BigInt(2) << BigInt(32 * 8 * 5)) |
-                                (BigInt(3) << BigInt(32 * 8 * 4)) |
-                                (BigInt(5) << BigInt(32 * 8 * 3)) |
-                                (BigInt(7) << BigInt(32 * 8 * 2)) |
-                                (BigInt(11) << BigInt(32 * 8 * 1)) |
-                                BigInt(13)
-                              )
-                                .toString(16)
-                                .padStart(32 * 6 * 2, '0'),
-                              'hex',
+                      `${BigInt(
+                        `0x${createKeccakHash('keccak256')
+                          .update(
+                            (
+                              (BigInt(2) << BigInt(32 * 8 * 5)) |
+                              (BigInt(3) << BigInt(32 * 8 * 4)) |
+                              (BigInt(5) << BigInt(32 * 8 * 3)) |
+                              (BigInt(7) << BigInt(32 * 8 * 2)) |
+                              (BigInt(11) << BigInt(32 * 8 * 1)) |
+                              BigInt(13)
                             )
-                            .digest('hex')}`,
-                        ) & MASK_250
-                      }`,
+                              .toString(16)
+                              .padStart(32 * 6 * 2, '0'),
+                            'hex',
+                          )
+                          .digest('hex')}`,
+                      )}`,
                     ],
                     order: 0,
                   },
@@ -2535,16 +2527,11 @@ export const expectations = flatten(
                           'string',
                         ]),
                       ),
-                      `${
-                        BigInt(
-                          `0x${createKeccakHash('keccak256')
-                            .update(
-                              ((BigInt(0x41) << BigInt(8)) | BigInt(0x42)).toString(16),
-                              'hex',
-                            )
-                            .digest('hex')}`,
-                        ) & MASK_250
-                      }`,
+                      `${BigInt(
+                        `0x${createKeccakHash('keccak256')
+                          .update(((BigInt(0x41) << BigInt(8)) | BigInt(0x42)).toString(16), 'hex')
+                          .digest('hex')}`,
+                      )}`,
                     ],
                     order: 0,
                   },
@@ -2633,13 +2620,11 @@ export const expectations = flatten(
                           'string',
                         ]),
                       ),
-                      `${
-                        BigInt(
-                          `0x${createKeccakHash('keccak256')
-                            .update(BigInt(0x61).toString(16), 'hex')
-                            .digest('hex')}`,
-                        ) & MASK_250
-                      }`,
+                      `${BigInt(
+                        `0x${createKeccakHash('keccak256')
+                          .update(BigInt(0x61).toString(16), 'hex')
+                          .digest('hex')}`,
+                      )}`,
                     ],
                     order: 1,
                   },

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -13,11 +13,7 @@ import {
   cairoUint256toBigIntHex,
 } from './utils';
 import createKeccakHash from 'keccak';
-import {
-  MASK_250,
-  warpEventCanonicalSignaturehash,
-  warpEventCanonicalSignaturehash256,
-} from '../../../src/export';
+import { MASK_250, warpEventCanonicalSignaturehash256 } from '../../../src/export';
 
 export const expectations = flatten(
   new Dir('tests', [

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -10,6 +10,7 @@ import {
   toCairoInt8,
   MIN_INT8,
   MAX_INT8,
+  cairoUint256toBigIntHex,
 } from './utils';
 import createKeccakHash from 'keccak';
 import {
@@ -2229,13 +2230,9 @@ export const expectations = flatten(
                   {
                     data: ['69'],
                     keys: [
-                      `0x${(
-                        BigInt(warpEventCanonicalSignaturehash256('uintEvent', ['uint256']).low) +
-                        (BigInt(
-                          warpEventCanonicalSignaturehash256('uintEvent', ['uint256']).high,
-                        ) <<
-                          128n)
-                      ).toString(16)}`,
+                      cairoUint256toBigIntHex(
+                        warpEventCanonicalSignaturehash256('uintEvent', ['uint256']),
+                      ),
                     ],
                     order: 0,
                   },
@@ -2253,15 +2250,9 @@ export const expectations = flatten(
                   {
                     data: ['32', '3', '2', '3', '5'],
                     keys: [
-                      `0x${(
-                        BigInt(
-                          warpEventCanonicalSignaturehash256('arrayEvent', ['uint256[]']).low,
-                        ) +
-                        (BigInt(
-                          warpEventCanonicalSignaturehash256('arrayEvent', ['uint256[]']).high,
-                        ) <<
-                          128n)
-                      ).toString(16)}`,
+                      cairoUint256toBigIntHex(
+                        warpEventCanonicalSignaturehash256('arrayEvent', ['uint256[]']),
+                      ),
                     ],
                     order: 0,
                   },
@@ -2279,17 +2270,9 @@ export const expectations = flatten(
                   {
                     data: ['32', '2', '64', '192', '3', '2', '3', '5', '2', '7', '11'],
                     keys: [
-                      `0x${(
-                        BigInt(
-                          warpEventCanonicalSignaturehash256('nestedArrayEvent', ['uint256[][]'])
-                            .low,
-                        ) +
-                        (BigInt(
-                          warpEventCanonicalSignaturehash256('nestedArrayEvent', ['uint256[][]'])
-                            .high,
-                        ) <<
-                          128n)
-                      ).toString(16)}`,
+                      cairoUint256toBigIntHex(
+                        warpEventCanonicalSignaturehash256('nestedArrayEvent', ['uint256[][]']),
+                      ),
                     ],
                     order: 0,
                   },
@@ -2307,19 +2290,11 @@ export const expectations = flatten(
                   {
                     data: ['32', '128', '7', '11', '13', '3', '2', '3', '5'],
                     keys: [
-                      `0x${(
-                        BigInt(
-                          warpEventCanonicalSignaturehash256('structEvent', [
-                            ['uint8[]', 'uint256[3]'],
-                          ]).low,
-                        ) +
-                        (BigInt(
-                          warpEventCanonicalSignaturehash256('structEvent', [
-                            ['uint8[]', 'uint256[3]'],
-                          ]).high,
-                        ) <<
-                          128n)
-                      ).toString(16)}`,
+                      cairoUint256toBigIntHex(
+                        warpEventCanonicalSignaturehash256('structEvent', [
+                          ['uint8[]', 'uint256[3]'],
+                        ]),
+                      ),
                     ],
                     order: 0,
                   },
@@ -2339,13 +2314,9 @@ export const expectations = flatten(
                   {
                     data: [],
                     keys: [
-                      `0x${(
-                        BigInt(warpEventCanonicalSignaturehash256('uintEvent', ['uint256']).low) +
-                        (BigInt(
-                          warpEventCanonicalSignaturehash256('uintEvent', ['uint256']).high,
-                        ) <<
-                          128n)
-                      ).toString(16)}`,
+                      cairoUint256toBigIntHex(
+                        warpEventCanonicalSignaturehash256('uintEvent', ['uint256']),
+                      ),
                       '69',
                     ],
                     order: 0,
@@ -2364,15 +2335,9 @@ export const expectations = flatten(
                   {
                     data: [],
                     keys: [
-                      `0x${(
-                        BigInt(
-                          warpEventCanonicalSignaturehash256('arrayEvent', ['uint256[]']).low,
-                        ) +
-                        (BigInt(
-                          warpEventCanonicalSignaturehash256('arrayEvent', ['uint256[]']).high,
-                        ) <<
-                          128n)
-                      ).toString(16)}`,
+                      cairoUint256toBigIntHex(
+                        warpEventCanonicalSignaturehash256('arrayEvent', ['uint256[]']),
+                      ),
                       // 2,
                       // 3,
                       // 5,
@@ -2409,17 +2374,9 @@ export const expectations = flatten(
                   {
                     data: [],
                     keys: [
-                      `0x${(
-                        BigInt(
-                          warpEventCanonicalSignaturehash256('nestedArrayEvent', ['uint256[][]'])
-                            .low,
-                        ) +
-                        (BigInt(
-                          warpEventCanonicalSignaturehash256('nestedArrayEvent', ['uint256[][]'])
-                            .high,
-                        ) <<
-                          128n)
-                      ).toString(16)}`,
+                      cairoUint256toBigIntHex(
+                        warpEventCanonicalSignaturehash256('nestedArrayEvent', ['uint256[][]']),
+                      ),
                       // 2,
                       // 3,
                       // 5,
@@ -2460,19 +2417,11 @@ export const expectations = flatten(
                   {
                     data: [],
                     keys: [
-                      `0x${(
-                        BigInt(
-                          warpEventCanonicalSignaturehash256('structEvent', [
-                            ['uint8[]', 'uint256[3]'],
-                          ]).low,
-                        ) +
-                        (BigInt(
-                          warpEventCanonicalSignaturehash256('structEvent', [
-                            ['uint8[]', 'uint256[3]'],
-                          ]).high,
-                        ) <<
-                          128n)
-                      ).toString(16)}`,
+                      cairoUint256toBigIntHex(
+                        warpEventCanonicalSignaturehash256('structEvent', [
+                          ['uint8[]', 'uint256[3]'],
+                        ]),
+                      ),
                       // '2',
                       // '3',
                       // '5',
@@ -2524,17 +2473,9 @@ export const expectations = flatten(
                       `${(BigInt(0x42) << BigInt(248)) | (BigInt(0x43) << BigInt(240))}`,
                     ],
                     keys: [
-                      `0x${(
-                        BigInt(
-                          warpEventCanonicalSignaturehash256('allStringEvent', ['string', 'string'])
-                            .low,
-                        ) +
-                        (BigInt(
-                          warpEventCanonicalSignaturehash256('allStringEvent', ['string', 'string'])
-                            .high,
-                        ) <<
-                          128n)
-                      ).toString(16)}`,
+                      cairoUint256toBigIntHex(
+                        warpEventCanonicalSignaturehash256('allStringEvent', ['string', 'string']),
+                      ),
                     ],
                     order: 0,
                   },
@@ -2556,21 +2497,12 @@ export const expectations = flatten(
                       `${(BigInt(0x42) << BigInt(248)) | (BigInt(0x43) << BigInt(240))}`,
                     ],
                     keys: [
-                      `0x${(
-                        BigInt(
-                          warpEventCanonicalSignaturehash256('allStringMiscEvent', [
-                            'string',
-                            'string',
-                          ]).low,
-                        ) +
-                        (BigInt(
-                          warpEventCanonicalSignaturehash256('allStringMiscEvent', [
-                            'string',
-                            'string',
-                          ]).high,
-                        ) <<
-                          128n)
-                      ).toString(16)}`,
+                      cairoUint256toBigIntHex(
+                        warpEventCanonicalSignaturehash256('allStringMiscEvent', [
+                          'string',
+                          'string',
+                        ]),
+                      ),
                       `${
                         BigInt(
                           `0x${createKeccakHash('keccak256')
@@ -2598,21 +2530,12 @@ export const expectations = flatten(
                   {
                     data: ['1'],
                     keys: [
-                      `0x${(
-                        BigInt(
-                          warpEventCanonicalSignaturehash256('allUintMiscEvent', [
-                            'uint256',
-                            'uint256',
-                          ]).low,
-                        ) +
-                        (BigInt(
-                          warpEventCanonicalSignaturehash256('allUintMiscEvent', [
-                            'uint256',
-                            'uint256',
-                          ]).high,
-                        ) <<
-                          128n)
-                      ).toString(16)}`,
+                      cairoUint256toBigIntHex(
+                        warpEventCanonicalSignaturehash256('allUintMiscEvent', [
+                          'uint256',
+                          'uint256',
+                        ]),
+                      ),
                       '2',
                     ],
                     order: 0,
@@ -2631,21 +2554,12 @@ export const expectations = flatten(
                   {
                     data: [],
                     keys: [
-                      `0x${(
-                        BigInt(
-                          warpEventCanonicalSignaturehash256('allIndexedEvent', [
-                            'uint256',
-                            'uint256',
-                          ]).low,
-                        ) +
-                        (BigInt(
-                          warpEventCanonicalSignaturehash256('allIndexedEvent', [
-                            'uint256',
-                            'uint256',
-                          ]).high,
-                        ) <<
-                          128n)
-                      ).toString(16)}`,
+                      cairoUint256toBigIntHex(
+                        warpEventCanonicalSignaturehash256('allIndexedEvent', [
+                          'uint256',
+                          'uint256',
+                        ]),
+                      ),
                       '1',
                       '2',
                     ],
@@ -2672,38 +2586,21 @@ export const expectations = flatten(
                       `${BigInt(0x62) << BigInt(248)}`,
                     ],
                     keys: [
-                      `0x${(
-                        BigInt(
-                          warpEventCanonicalSignaturehash256('allStringEvent', ['string', 'string'])
-                            .low,
-                        ) +
-                        (BigInt(
-                          warpEventCanonicalSignaturehash256('allStringEvent', ['string', 'string'])
-                            .high,
-                        ) <<
-                          128n)
-                      ).toString(16)}`,
+                      cairoUint256toBigIntHex(
+                        warpEventCanonicalSignaturehash256('allStringEvent', ['string', 'string']),
+                      ),
                     ],
                     order: 0,
                   },
                   {
                     data: ['32', '1', `${BigInt(0x62) << BigInt(248)}`],
                     keys: [
-                      `0x${(
-                        BigInt(
-                          warpEventCanonicalSignaturehash256('allStringMiscEvent', [
-                            'string',
-                            'string',
-                          ]).low,
-                        ) +
-                        (BigInt(
-                          warpEventCanonicalSignaturehash256('allStringMiscEvent', [
-                            'string',
-                            'string',
-                          ]).high,
-                        ) <<
-                          128n)
-                      ).toString(16)}`,
+                      cairoUint256toBigIntHex(
+                        warpEventCanonicalSignaturehash256('allStringMiscEvent', [
+                          'string',
+                          'string',
+                        ]),
+                      ),
                       `${
                         BigInt(
                           `0x${createKeccakHash('keccak256')
@@ -2717,21 +2614,12 @@ export const expectations = flatten(
                   {
                     data: ['1'],
                     keys: [
-                      `0x${(
-                        BigInt(
-                          warpEventCanonicalSignaturehash256('allUintMiscEvent', [
-                            'uint256',
-                            'uint256',
-                          ]).low,
-                        ) +
-                        (BigInt(
-                          warpEventCanonicalSignaturehash256('allUintMiscEvent', [
-                            'uint256',
-                            'uint256',
-                          ]).high,
-                        ) <<
-                          128n)
-                      ).toString(16)}`,
+                      cairoUint256toBigIntHex(
+                        warpEventCanonicalSignaturehash256('allUintMiscEvent', [
+                          'uint256',
+                          'uint256',
+                        ]),
+                      ),
                       '2',
                     ],
                     order: 2,
@@ -2739,21 +2627,12 @@ export const expectations = flatten(
                   {
                     data: [],
                     keys: [
-                      `0x${(
-                        BigInt(
-                          warpEventCanonicalSignaturehash256('allIndexedEvent', [
-                            'uint256',
-                            'uint256',
-                          ]).low,
-                        ) +
-                        (BigInt(
-                          warpEventCanonicalSignaturehash256('allIndexedEvent', [
-                            'uint256',
-                            'uint256',
-                          ]).high,
-                        ) <<
-                          128n)
-                      ).toString(16)}`,
+                      cairoUint256toBigIntHex(
+                        warpEventCanonicalSignaturehash256('allIndexedEvent', [
+                          'uint256',
+                          'uint256',
+                        ]),
+                      ),
                       '1',
                       '2',
                     ],

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -10,7 +10,7 @@ import {
   toCairoInt8,
   MIN_INT8,
   MAX_INT8,
-  cairoUint256toBigIntHex,
+  cairoUint256toHex,
 } from './utils';
 import createKeccakHash from 'keccak';
 import { warpEventCanonicalSignaturehash256 } from '../../../src/export';
@@ -2226,7 +2226,7 @@ export const expectations = flatten(
                   {
                     data: ['69'],
                     keys: [
-                      cairoUint256toBigIntHex(
+                      cairoUint256toHex(
                         warpEventCanonicalSignaturehash256('uintEvent', ['uint256']),
                       ),
                     ],
@@ -2246,7 +2246,7 @@ export const expectations = flatten(
                   {
                     data: ['32', '3', '2', '3', '5'],
                     keys: [
-                      cairoUint256toBigIntHex(
+                      cairoUint256toHex(
                         warpEventCanonicalSignaturehash256('arrayEvent', ['uint256[]']),
                       ),
                     ],
@@ -2266,7 +2266,7 @@ export const expectations = flatten(
                   {
                     data: ['32', '2', '64', '192', '3', '2', '3', '5', '2', '7', '11'],
                     keys: [
-                      cairoUint256toBigIntHex(
+                      cairoUint256toHex(
                         warpEventCanonicalSignaturehash256('nestedArrayEvent', ['uint256[][]']),
                       ),
                     ],
@@ -2286,7 +2286,7 @@ export const expectations = flatten(
                   {
                     data: ['32', '128', '7', '11', '13', '3', '2', '3', '5'],
                     keys: [
-                      cairoUint256toBigIntHex(
+                      cairoUint256toHex(
                         warpEventCanonicalSignaturehash256('structEvent', [
                           ['uint8[]', 'uint256[3]'],
                         ]),
@@ -2310,7 +2310,7 @@ export const expectations = flatten(
                   {
                     data: [],
                     keys: [
-                      cairoUint256toBigIntHex(
+                      cairoUint256toHex(
                         warpEventCanonicalSignaturehash256('uintEvent', ['uint256']),
                       ),
                       '69',
@@ -2331,7 +2331,7 @@ export const expectations = flatten(
                   {
                     data: [],
                     keys: [
-                      cairoUint256toBigIntHex(
+                      cairoUint256toHex(
                         warpEventCanonicalSignaturehash256('arrayEvent', ['uint256[]']),
                       ),
                       // 2,
@@ -2368,7 +2368,7 @@ export const expectations = flatten(
                   {
                     data: [],
                     keys: [
-                      cairoUint256toBigIntHex(
+                      cairoUint256toHex(
                         warpEventCanonicalSignaturehash256('arrayStringEvent', ['string[]']),
                       ),
                       `${BigInt(
@@ -2402,7 +2402,7 @@ export const expectations = flatten(
                   {
                     data: [],
                     keys: [
-                      cairoUint256toBigIntHex(
+                      cairoUint256toHex(
                         warpEventCanonicalSignaturehash256('nestedArrayEvent', ['uint256[][]']),
                       ),
                       // 2,
@@ -2443,7 +2443,7 @@ export const expectations = flatten(
                   {
                     data: [],
                     keys: [
-                      cairoUint256toBigIntHex(
+                      cairoUint256toHex(
                         warpEventCanonicalSignaturehash256('structEvent', [
                           ['uint8[]', 'uint256[3]'],
                         ]),
@@ -2497,7 +2497,7 @@ export const expectations = flatten(
                       `${(BigInt(0x42) << BigInt(248)) | (BigInt(0x43) << BigInt(240))}`,
                     ],
                     keys: [
-                      cairoUint256toBigIntHex(
+                      cairoUint256toHex(
                         warpEventCanonicalSignaturehash256('allStringEvent', ['string', 'string']),
                       ),
                     ],
@@ -2521,7 +2521,7 @@ export const expectations = flatten(
                       `${(BigInt(0x42) << BigInt(248)) | (BigInt(0x43) << BigInt(240))}`,
                     ],
                     keys: [
-                      cairoUint256toBigIntHex(
+                      cairoUint256toHex(
                         warpEventCanonicalSignaturehash256('allStringMiscEvent', [
                           'string',
                           'string',
@@ -2549,7 +2549,7 @@ export const expectations = flatten(
                   {
                     data: ['1'],
                     keys: [
-                      cairoUint256toBigIntHex(
+                      cairoUint256toHex(
                         warpEventCanonicalSignaturehash256('allUintMiscEvent', [
                           'uint256',
                           'uint256',
@@ -2573,7 +2573,7 @@ export const expectations = flatten(
                   {
                     data: [],
                     keys: [
-                      cairoUint256toBigIntHex(
+                      cairoUint256toHex(
                         warpEventCanonicalSignaturehash256('allIndexedEvent', [
                           'uint256',
                           'uint256',
@@ -2605,7 +2605,7 @@ export const expectations = flatten(
                       `${BigInt(0x62) << BigInt(248)}`,
                     ],
                     keys: [
-                      cairoUint256toBigIntHex(
+                      cairoUint256toHex(
                         warpEventCanonicalSignaturehash256('allStringEvent', ['string', 'string']),
                       ),
                     ],
@@ -2614,7 +2614,7 @@ export const expectations = flatten(
                   {
                     data: ['32', '1', `${BigInt(0x62) << BigInt(248)}`],
                     keys: [
-                      cairoUint256toBigIntHex(
+                      cairoUint256toHex(
                         warpEventCanonicalSignaturehash256('allStringMiscEvent', [
                           'string',
                           'string',
@@ -2631,7 +2631,7 @@ export const expectations = flatten(
                   {
                     data: ['1'],
                     keys: [
-                      cairoUint256toBigIntHex(
+                      cairoUint256toHex(
                         warpEventCanonicalSignaturehash256('allUintMiscEvent', [
                           'uint256',
                           'uint256',
@@ -2644,7 +2644,7 @@ export const expectations = flatten(
                   {
                     data: [],
                     keys: [
-                      cairoUint256toBigIntHex(
+                      cairoUint256toHex(
                         warpEventCanonicalSignaturehash256('allIndexedEvent', [
                           'uint256',
                           'uint256',

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -2363,6 +2363,42 @@ export const expectations = flatten(
                 ],
               ],
             ]),
+            new Expect('arrayString', [
+              [
+                'arrayString',
+                [],
+                [],
+                '0',
+                undefined,
+                [
+                  {
+                    data: [],
+                    keys: [
+                      cairoUint256toBigIntHex(
+                        warpEventCanonicalSignaturehash256('arrayStringEvent', ['string[]']),
+                      ),
+                      `${
+                        BigInt(
+                          `0x${createKeccakHash('keccak256')
+                            .update(
+                              (
+                                (BigInt(0x61) << BigInt(32 * 8 * 3 - 8)) |
+                                (BigInt(0x62) << BigInt(32 * 8 * 2 - 8)) |
+                                (BigInt(0x63) << BigInt(32 * 8 * 1 - 8))
+                              )
+                                .toString(16)
+                                .padEnd(32 * (8 / 4) * 3, '0'),
+                              'hex',
+                            )
+                            .digest('hex')}`,
+                        ) & MASK_250
+                      }`,
+                    ],
+                    order: 0,
+                  },
+                ],
+              ],
+            ]),
             new Expect('nestedArray', [
               [
                 'nestedArray',

--- a/tests/behaviour/expectations/utils.ts
+++ b/tests/behaviour/expectations/utils.ts
@@ -88,3 +88,7 @@ export function toCairoInt256(val: number | bigint): [string, string] {
 }
 
 export const toCairoInt8 = (val: number | bigint) => BigInt.asUintN(8, BigInt(val)).toString();
+
+export function cairoUint256toBigIntHex(val: { low: string; high: string }): string {
+  return `0x${(BigInt(val.low) + (BigInt(val.high) << 128n)).toString(16)}`;
+}

--- a/tests/behaviour/expectations/utils.ts
+++ b/tests/behaviour/expectations/utils.ts
@@ -89,6 +89,6 @@ export function toCairoInt256(val: number | bigint): [string, string] {
 
 export const toCairoInt8 = (val: number | bigint) => BigInt.asUintN(8, BigInt(val)).toString();
 
-export function cairoUint256toBigIntHex(val: { low: string; high: string }): string {
+export function cairoUint256toHex(val: { low: string; high: string }): string {
   return `0x${(BigInt(val.low) + (BigInt(val.high) << 128n)).toString(16)}`;
 }

--- a/warplib/keccak.cairo
+++ b/warplib/keccak.cairo
@@ -27,22 +27,6 @@ func warp_keccak{
     return (res,);
 }
 
-func warp_keccak_felt{
-    range_check_ptr, bitwise_ptr: BitwiseBuiltin*, warp_memory: DictAccess*, keccak_ptr: felt*
-}(loc: felt) -> (output: felt) {
-    alloc_locals;
-    let (input_len, input) = wm_to_felt_array(loc);
-    let (pow2_122: felt) = pow2(122);
-    let mask122: felt = pow2_122 - 1;
-    let (packed_bytes_len, packed_bytes) = pack_bytes_felt(BYTES_IN_FELT, 0, input_len, input);
-    let (res256: Uint256) = keccak_bigend{keccak_ptr=keccak_ptr}(packed_bytes, input_len);
-    let low: felt = res256.low;
-    let (high: felt) = bitwise_and(mask122, res256.high);
-    let res250: Uint256 = Uint256(low, high);
-    let (res: felt) = narrow_safe(res250);
-    return (res,);
-}
-
 func pack_bytes_felt{range_check_ptr}(
     packing_bytes: felt, big_endian: felt, input_len: felt, input: felt*
 ) -> (output_len: felt, output: felt*) {


### PR DESCRIPTION
Previously, we were only taking 251 bits of  events' topic.