### PR TITLE
Fix storage static arrays bug

### DIFF
--- a/src/cairoUtilFuncGen/serialisation.ts
+++ b/src/cairoUtilFuncGen/serialisation.ts
@@ -43,7 +43,13 @@ function producePackExpression(type: CairoType): (string | Read)[] {
     return ['(', ...type.members.flatMap((member) => [...producePackExpression(member), ',']), ')'];
   }
   if (type instanceof CairoStaticArray) {
-    return ['(', ...Array(type.size).fill([...producePackExpression(type.type), ',']).flat(), ')'];
+    return [
+      '(',
+      ...Array(type.size)
+        .fill([...producePackExpression(type.type), ','])
+        .flat(),
+      ')',
+    ];
   }
   if (type instanceof CairoStruct) {
     return [

--- a/src/cairoUtilFuncGen/serialisation.ts
+++ b/src/cairoUtilFuncGen/serialisation.ts
@@ -43,7 +43,7 @@ function producePackExpression(type: CairoType): (string | Read)[] {
     return ['(', ...type.members.flatMap((member) => [...producePackExpression(member), ',']), ')'];
   }
   if (type instanceof CairoStaticArray) {
-    return ['(', ...Array(type.size).fill(producePackExpression(type.type)).flat(), ')'];
+    return ['(', ...Array(type.size).fill([...producePackExpression(type.type), ',']).flat(), ')'];
   }
   if (type instanceof CairoStruct) {
     return [

--- a/src/cairoUtilFuncGen/serialisation.ts
+++ b/src/cairoUtilFuncGen/serialisation.ts
@@ -2,7 +2,6 @@ import {
   CairoFelt,
   CairoStaticArray,
   CairoStruct,
-  CairoTuple,
   CairoType,
   WarpLocation,
 } from '../utils/cairoTypeSystem';
@@ -39,9 +38,6 @@ enum Read {
 function producePackExpression(type: CairoType): (string | Read)[] {
   if (type instanceof WarpLocation) return [Read.Id];
   if (type instanceof CairoFelt) return [Read.Felt];
-  if (type instanceof CairoTuple) {
-    return ['(', ...type.members.flatMap((member) => [...producePackExpression(member), ',']), ')'];
-  }
   if (type instanceof CairoStaticArray) {
     return [
       '(',

--- a/src/cairoUtilFuncGen/serialisation.ts
+++ b/src/cairoUtilFuncGen/serialisation.ts
@@ -1,5 +1,6 @@
 import {
   CairoFelt,
+  CairoStaticArray,
   CairoStruct,
   CairoTuple,
   CairoType,
@@ -40,6 +41,9 @@ function producePackExpression(type: CairoType): (string | Read)[] {
   if (type instanceof CairoFelt) return [Read.Felt];
   if (type instanceof CairoTuple) {
     return ['(', ...type.members.flatMap((member) => [...producePackExpression(member), ',']), ')'];
+  }
+  if (type instanceof CairoStaticArray) {
+    return ['(', ...Array(type.size).fill(producePackExpression(type.type)).flat(), ')'];
   }
   if (type instanceof CairoStruct) {
     return [

--- a/src/utils/cairoTypeSystem.ts
+++ b/src/utils/cairoTypeSystem.ts
@@ -256,10 +256,10 @@ export class CairoStaticArray extends CairoType {
     return `[Tuple]${`(${this.type.fullStringRepresentation})`.repeat(this.size)}`;
   }
   toString(): string {
-    return `(${this.type.toString()}` + `${`,` + this.type.toString()}`.repeat(this.size - 1) + `)`;
+    return `(${this.type.toString()}` + `${`, ` + this.type.toString()}`.repeat(this.size - 1) + `)`;
   }
   get typeName(): string {
-    return `${this.type.typeName}` + `${`,` + this.type.typeName}`.repeat(this.size - 1);
+    return `${this.type.typeName}` + `${`x` + this.type.typeName}`.repeat(this.size - 1);
   }
   get width(): number {
     return this.type.width * this.size;

--- a/src/utils/cairoTypeSystem.ts
+++ b/src/utils/cairoTypeSystem.ts
@@ -71,7 +71,7 @@ export abstract class CairoType {
           tp.size,
           `Arrays of very large size (${tp.size.toString()}) are not supported`,
         );
-        return new CairoTuple(Array(narrowedLength).fill(elementType));
+        return new CairoStaticArray(elementType, narrowedLength);
       }
     } else if (tp instanceof BoolType) {
       return new CairoFelt();
@@ -245,6 +245,31 @@ export class CairoTuple extends CairoType {
     return this.members.flatMap((memberType, index) =>
       memberType.serialiseMembers(`${name}[${index}]`),
     );
+  }
+}
+
+export class CairoStaticArray extends CairoType {
+  constructor(public type: CairoType, public size: number) {
+    super();
+  }
+  get fullStringRepresentation(): string {
+    return `[Tuple]${`(${this.type.fullStringRepresentation})`.repeat(this.size)}`;
+  }
+  toString(): string {
+    return `(${this.type.toString()}` + `${`,` + this.type.toString()}`.repeat(this.size - 1);
+  }
+  get typeName(): string {
+    return `(${this.type.typeName}` + `${`,` + this.type.typeName}`.repeat(this.size - 1);
+  }
+  get width(): number {
+    return this.type.width * this.size;
+  }
+  serialiseMembers(name: string): string[] {
+    let serializedMembers: string[] = [];
+    for (let index = 0; index < this.size; ++index) {
+      serializedMembers.concat(this.type.serialiseMembers(`${name}[${index}]`));
+    }
+    return serializedMembers;
   }
 }
 

--- a/src/utils/cairoTypeSystem.ts
+++ b/src/utils/cairoTypeSystem.ts
@@ -256,7 +256,9 @@ export class CairoStaticArray extends CairoType {
     return `[Tuple]${`(${this.type.fullStringRepresentation})`.repeat(this.size)}`;
   }
   toString(): string {
-    return `(${this.type.toString()}` + `${`, ` + this.type.toString()}`.repeat(this.size - 1) + `)`;
+    return (
+      `(${this.type.toString()}` + `${`, ` + this.type.toString()}`.repeat(this.size - 1) + `)`
+    );
   }
   get typeName(): string {
     return `${this.type.typeName}` + `${`x` + this.type.typeName}`.repeat(this.size - 1);

--- a/src/utils/cairoTypeSystem.ts
+++ b/src/utils/cairoTypeSystem.ts
@@ -269,7 +269,7 @@ export class CairoStaticArray extends CairoType {
   serialiseMembers(name: string): string[] {
     const serializedMembers: string[] = [];
     for (let index = 0; index < this.size; ++index) {
-      serializedMembers.concat(this.type.serialiseMembers(`${name}[${index}]`));
+      serializedMembers.push(...this.type.serialiseMembers(`${name}[${index}]`));
     }
     return serializedMembers;
   }

--- a/src/utils/cairoTypeSystem.ts
+++ b/src/utils/cairoTypeSystem.ts
@@ -24,7 +24,7 @@ import { AST } from '../ast/ast';
 import { printTypeNode } from './astPrinter';
 import { NotSupportedYetError, TranspileFailedError } from './errors';
 import { safeGetNodeType } from './nodeTypeProcessing';
-import { mangleStructName, narrowBigIntSafe } from './utils';
+import { mangleStructName, mapRange, narrowBigIntSafe } from './utils';
 
 export enum TypeConversionContext {
   MemoryAllocation,
@@ -267,11 +267,7 @@ export class CairoStaticArray extends CairoType {
     return this.type.width * this.size;
   }
   serialiseMembers(name: string): string[] {
-    const serializedMembers: string[] = [];
-    for (let index = 0; index < this.size; ++index) {
-      serializedMembers.push(...this.type.serialiseMembers(`${name}[${index}]`));
-    }
-    return serializedMembers;
+    return mapRange(this.size, (n) => this.type.serialiseMembers(`${name}[${n}]`)).flat();
   }
 }
 

--- a/src/utils/cairoTypeSystem.ts
+++ b/src/utils/cairoTypeSystem.ts
@@ -256,16 +256,16 @@ export class CairoStaticArray extends CairoType {
     return `[Tuple]${`(${this.type.fullStringRepresentation})`.repeat(this.size)}`;
   }
   toString(): string {
-    return `(${this.type.toString()}` + `${`,` + this.type.toString()}`.repeat(this.size - 1);
+    return `(${this.type.toString()}` + `${`,` + this.type.toString()}`.repeat(this.size - 1) + `)`;
   }
   get typeName(): string {
-    return `(${this.type.typeName}` + `${`,` + this.type.typeName}`.repeat(this.size - 1);
+    return `${this.type.typeName}` + `${`,` + this.type.typeName}`.repeat(this.size - 1);
   }
   get width(): number {
     return this.type.width * this.size;
   }
   serialiseMembers(name: string): string[] {
-    let serializedMembers: string[] = [];
+    const serializedMembers: string[] = [];
     for (let index = 0; index < this.size; ++index) {
       serializedMembers.concat(this.type.serialiseMembers(`${name}[${index}]`));
     }

--- a/src/utils/cairoTypeSystem.ts
+++ b/src/utils/cairoTypeSystem.ts
@@ -225,35 +225,12 @@ export class CairoDynArray extends CairoStruct {
   }
 }
 
-export class CairoTuple extends CairoType {
-  constructor(public members: CairoType[]) {
-    super();
-  }
-  get fullStringRepresentation(): string {
-    return `[Tuple]${this.members.map((type) => `(${type.fullStringRepresentation})`)}`;
-  }
-  toString(): string {
-    return `(${this.members.map((m) => m.toString()).join(', ')})`;
-  }
-  get typeName(): string {
-    return `${this.members.map((m) => m.typeName).join('x')}`;
-  }
-  get width(): number {
-    return this.members.reduce((acc, t) => acc + t.width, 0);
-  }
-  serialiseMembers(name: string): string[] {
-    return this.members.flatMap((memberType, index) =>
-      memberType.serialiseMembers(`${name}[${index}]`),
-    );
-  }
-}
-
 export class CairoStaticArray extends CairoType {
   constructor(public type: CairoType, public size: number) {
     super();
   }
   get fullStringRepresentation(): string {
-    return `[Tuple]${`(${this.type.fullStringRepresentation})`.repeat(this.size)}`;
+    return `[StaticArray][${this.size}][${this.type.fullStringRepresentation}]`;
   }
   toString(): string {
     return (

--- a/tests/behaviour/contracts/largeSizeArray/large_size_array.sol
+++ b/tests/behaviour/contracts/largeSizeArray/large_size_array.sol
@@ -1,9 +1,9 @@
 pragma solidity ^0.8.0;
 
 contract WARP {
-    uint256[100000000] public data;
+    uint256[10000000000000000000] public data;
 
-    function getLength() public returns (uint256) {
+    function getLength() public view returns (uint256) {
         return data.length;
     }
 

--- a/tests/behaviour/contracts/largeSizeArray/large_size_array.sol
+++ b/tests/behaviour/contracts/largeSizeArray/large_size_array.sol
@@ -1,13 +1,13 @@
 pragma solidity ^0.8.0;
 
 contract WARP {
-    uint8[100000000] public data;
+    uint256[100000000] public data;
 
     function getLength() public returns (uint256) {
         return data.length;
     }
 
-    function setValue(uint8 index, uint8 value) public returns (uint8) {
+    function setValue(uint256 index, uint256 value) public returns (uint256) {
         data[index] = value;
         return data[index];
     }

--- a/tests/behaviour/contracts/largeSizeArray/large_size_array.sol
+++ b/tests/behaviour/contracts/largeSizeArray/large_size_array.sol
@@ -1,13 +1,13 @@
 pragma solidity ^0.8.0;
 
 contract WARP {
-    uint256[100000000] public data;
+    uint8[100000000] public data;
 
     function getLength() public returns (uint256) {
         return data.length;
     }
 
-    function setValue(uint256 index, uint256 value) public returns (uint256) {
+    function setValue(uint8 index, uint8 value) public returns (uint8) {
         data[index] = value;
         return data[index];
     }

--- a/tests/behaviour/contracts/largeSizeArray/large_size_array.sol
+++ b/tests/behaviour/contracts/largeSizeArray/large_size_array.sol
@@ -1,0 +1,14 @@
+pragma solidity ^0.8.0;
+
+contract WARP {
+    uint256[100000000] public data;
+
+    function getLength() public returns (uint256) {
+        return data.length;
+    }
+
+    function setValue(uint256 index, uint256 value) public returns (uint256) {
+        data[index] = value;
+        return data[index];
+    }
+}

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -3438,7 +3438,7 @@ export const expectations = flatten(
         new Dir('largeSizeArray', [
           File.Simple('large_size_array', [
             Expect.Simple('getLength', [], ['100000000', '0']),
-            Expect.Simple('setValue', ['300', '456'], ['456']),
+            Expect.Simple('setValue', ['10000000', '0', '456', '0'], ['456', '0']),
           ]),
         ]),
         new Dir('libraries', [

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -3435,6 +3435,12 @@ export const expectations = flatten(
             new File('derived', 'Derived', [], [Expect.Simple('f', [], ['36', '0', '24', '0'])]),
           ]),
         ]),
+        new Dir('largeSizeArray', [
+          File.Simple('large_size_array', [
+            Expect.Simple('getLength', [], ['100000000']),
+            Expect.Simple('setValue', ['10000000', '456'], ['456']),
+          ]),
+        ]),
         new Dir('libraries', [
           File.Simple('constantInitialization', [Expect.Simple('f', [], ['20001'])]),
           File.Simple('using_for', [

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -3437,8 +3437,8 @@ export const expectations = flatten(
         ]),
         new Dir('largeSizeArray', [
           File.Simple('large_size_array', [
-            Expect.Simple('getLength', [], ['100000000']),
-            Expect.Simple('setValue', ['10000000', '456'], ['456']),
+            Expect.Simple('getLength', [], ['100000000', '0']),
+            Expect.Simple('setValue', ['300', '456'], ['456']),
           ]),
         ]),
         new Dir('libraries', [

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -3437,8 +3437,12 @@ export const expectations = flatten(
         ]),
         new Dir('largeSizeArray', [
           File.Simple('large_size_array', [
-            Expect.Simple('getLength', [], ['100000000', '0']),
-            Expect.Simple('setValue', ['10000000', '0', '456', '0'], ['456', '0']),
+            Expect.Simple('getLength', [], [...toCairoUint256(10000000000000000000)]),
+            Expect.Simple(
+              'setValue',
+              [...toCairoUint256(10000000), ...toCairoUint256(456)],
+              [...toCairoUint256(456)],
+            ),
           ]),
         ]),
         new Dir('libraries', [


### PR DESCRIPTION
This PR is to fix the bug of Initialization of large-size static arrays, described on #863. 

@rodrigo-pino suggested me 3 possible approaches to this issue:
1. Update the `CairoTuple` type so that it groups the tuple items by types.
2. Create a new type related to `CairoTuple` for arrays that receives the type and the size.
3. Same as 2, but without the new type being related to `CairoTuple`.

For the approach (1) I found that for tuples having `n` elements and more than 1 type (`t >1 && t<=n`), you need to save the positions of the tuple corresponding to each single type. I didn't see any clean way to do this without having the list of types that overflow the Node heap.
While implementing approach (2) I found the new type didn't have to reuse any of the implementations from `CairoTuple`, so I choose approach (3) and created a new type `CairoStaticArray`.