### PR TITLE
Update function visibility check & handle CairoAssert type

### DIFF
--- a/src/passes/publicFunctionSplitter/internalFunctionCallCollector.ts
+++ b/src/passes/publicFunctionSplitter/internalFunctionCallCollector.ts
@@ -42,9 +42,3 @@ export class InternalFunctionCallCollector extends ASTMapper {
     this.commonVisit(node, ast);
   }
 }
-
-export function isInternalFuncCall(node: FunctionCall, ast: AST): boolean {
-  const type = safeGetNodeType(node.vExpression, ast.inference);
-  assert(type instanceof FunctionType);
-  return type.visibility === 'internal';
-}

--- a/src/passes/publicFunctionSplitter/internalFunctionCallCollector.ts
+++ b/src/passes/publicFunctionSplitter/internalFunctionCallCollector.ts
@@ -1,9 +1,7 @@
-import assert = require('assert');
 import {
   ContractDefinition,
   FunctionCall,
   FunctionDefinition,
-  FunctionType,
   MemberAccess,
   UserDefinedType,
 } from 'solc-typed-ast';

--- a/src/passes/publicFunctionSplitter/internalFunctionCallCollector.ts
+++ b/src/passes/publicFunctionSplitter/internalFunctionCallCollector.ts
@@ -2,7 +2,6 @@ import assert = require('assert');
 import {
   ContractDefinition,
   FunctionCall,
-  FunctionCallKind,
   FunctionDefinition,
   FunctionType,
   MemberAccess,
@@ -27,11 +26,7 @@ export class InternalFunctionCallCollector extends ASTMapper {
 
   visitFunctionCall(node: FunctionCall, ast: AST): void {
     const funcDef = node.vReferencedDeclaration;
-    if (
-      funcDef instanceof FunctionDefinition &&
-      node.kind === FunctionCallKind.FunctionCall &&
-      isInternalFuncCall(node, ast)
-    ) {
+    if (funcDef instanceof FunctionDefinition) {
       if (node.vExpression instanceof MemberAccess) {
         const typeNode = safeGetNodeType(node.vExpression.vExpression, ast.inference);
         if (

--- a/src/passes/publicFunctionSplitter/publicFunctionCallModifier.ts
+++ b/src/passes/publicFunctionSplitter/publicFunctionCallModifier.ts
@@ -4,10 +4,10 @@ import {
   FunctionDefinition,
   Identifier,
   MemberAccess,
+  isFunctionCallExternal,
 } from 'solc-typed-ast';
 import { AST } from '../../ast/ast';
 import { ASTMapper } from '../../ast/mapper';
-import { isInternalFuncCall } from './internalFunctionCallCollector';
 
 export class PublicFunctionCallModifier extends ASTMapper {
   constructor(public internalToExternalFunctionMap: Map<FunctionDefinition, FunctionDefinition>) {
@@ -31,7 +31,7 @@ export class PublicFunctionCallModifier extends ASTMapper {
       // The function call will need to be modified irrespective of whether it is internal or external.
       if (replacementFunction !== undefined) {
         // If it is an external call the function gets re-pointed to the new external call.
-        if (!isInternalFuncCall(node, ast)) {
+        if (isFunctionCallExternal(node)) {
           node.vExpression.referencedDeclaration = replacementFunction.id;
           // If it is an internal call then the functionCall.vExpressions name needs to be changed to
           // match it's modified function definition's name

--- a/src/utils/nodeTypeProcessing.ts
+++ b/src/utils/nodeTypeProcessing.ts
@@ -38,6 +38,7 @@ import { TranspileFailedError } from './errors';
 import { error } from './formatting';
 import { getContainingSourceUnit } from './utils';
 import { getNodeType, getNodeTypeInCtx } from './typeStrings/typeString_parser';
+import { CairoAssert } from '../export'; // eslint-disable-line
 
 /*
 Normal function calls and struct constructors require different methods for
@@ -297,6 +298,9 @@ export function safeGetNodeType(
   getContainingSourceUnit(node);
   // if (node instanceof Literal) {
   //   return getNodeType(node, inference);
+  // }
+  // if (node instanceof CairoAssert){
+  //   return new TupleType([]);
   // }
   // if (node instanceof VariableDeclaration) {
   //   return inference.variableDeclarationToTypeNode(node);

--- a/src/utils/nodeTypeProcessing.ts
+++ b/src/utils/nodeTypeProcessing.ts
@@ -38,7 +38,7 @@ import { TranspileFailedError } from './errors';
 import { error } from './formatting';
 import { getContainingSourceUnit } from './utils';
 import { getNodeType, getNodeTypeInCtx } from './typeStrings/typeString_parser';
-import { CairoAssert } from '../export'; // eslint-disable-line
+import { CairoAssert } from '../ast/cairoNodes'; // eslint-disable-line
 
 /*
 Normal function calls and struct constructors require different methods for


### PR DESCRIPTION
* Add typenode generation for CairoAssert
* Fix `inheritance/functions/functionOverriding`
* Remove `isInternalFuncCall`