### PR TITLE
Add utility to encode strings for tests

### DIFF
--- a/src/semanticTestRunner.ts
+++ b/src/semanticTestRunner.ts
@@ -61,7 +61,7 @@ whitelistData.split('\n').forEach((line) => {
 
     if (testPathLets.length > 1) {
       testsSupportStatus.set(
-        testPathLets[0].replace("'", '').replace(',', '').trim(), // remove possible trailing punctation marks
+        testPathLets[0].replace("'", '').replace(',', '').trim(), // remove possible trailing punctuation marks
         testPathLets.slice(1).join('//').trim(), // comment part of the test
       );
     } else {
@@ -71,7 +71,7 @@ whitelistData.split('\n').forEach((line) => {
 });
 
 if (process.argv.includes('--compare')) {
-  // Comparisions of tests between white_list and current version
+  // Comparisons of tests between white_list and current version
 
   const testFiles = execSync(
     // Get all solidity files under tests/behaviour/solidity/test/libsolidity/semanticTests (recursively)

--- a/tests/behaviour/expectations/behaviour.ts
+++ b/tests/behaviour/expectations/behaviour.ts
@@ -11,6 +11,7 @@ import {
   MIN_INT8,
   MAX_INT8,
   cairoUint256toHex,
+  encodeString,
 } from './utils';
 import createKeccakHash from 'keccak';
 import { warpEventCanonicalSignaturehash256 } from '../../../src/export';
@@ -656,7 +657,7 @@ export const expectations = flatten(
             Expect.Simple('f', ['4', '0', '1'], ['5', '0']),
           ]),
           File.Simple('conditionals', [
-            Expect.Simple('returnStr', ['1'], ['4', '87', '65', '82', '80']),
+            Expect.Simple('returnStr', ['1'], [...encodeString('WARP')]),
             Expect.Simple('updateVar', ['1'], ['20', '0', '46', '0']),
             Expect.Simple('updateVar', ['0'], ['15', '0', '50', '0']),
           ]),
@@ -2482,7 +2483,7 @@ export const expectations = flatten(
             new Expect('allString', [
               [
                 'allString',
-                ['2', '65', '66', '2', '66', '67'],
+                [...encodeString('AB'), ...encodeString('BC')],
                 [],
                 '0',
                 undefined,
@@ -2509,7 +2510,7 @@ export const expectations = flatten(
             new Expect('allStringMisc', [
               [
                 'allStringMisc',
-                ['2', '65', '66', '2', '66', '67'],
+                [...encodeString('AB'), ...encodeString('BC')],
                 [],
                 '0',
                 undefined,
@@ -4526,20 +4527,20 @@ export const expectations = flatten(
         new Dir('stringLiteral', [
           File.Simple('stringLiteralMemory', [
             Expect.Simple('plainLiteral', [], []),
-            Expect.Simple('returnLiteral', [], ['4', '87', '65', '82', '80']),
-            Expect.Simple('varDecl', [], ['4', '87', '65', '82', '80']),
+            Expect.Simple('returnLiteral', [], [...encodeString('WARP')]),
+            Expect.Simple('varDecl', [], [...encodeString('WARP')]),
             Expect.Simple(
               'literalAssignmentToMemoryFromParams',
-              ['2', '86', '65'],
-              ['4', '87', '65', '82', '80'],
+              [...encodeString('VA')],
+              [...encodeString('WARP')],
             ),
-            Expect.Simple('tupleRet', [], ['2', '87', '65', '2', '82', '80']),
-            Expect.Simple('funcCallWithArg', [], ['4', '87', '65', '82', '80']),
-            Expect.Simple('nestedFuncCallWithArg', [], ['4', '87', '65', '82', '80']),
+            Expect.Simple('tupleRet', [], [...encodeString('WA'), ...encodeString('RP')]),
+            Expect.Simple('funcCallWithArg', [], [...encodeString('WARP')]),
+            Expect.Simple('nestedFuncCallWithArg', [], [...encodeString('WARP')]),
           ]),
           File.Simple('stringLiteralStorage', [
-            Expect.Simple('literalAssignment', [], ['4', '87', '65', '82', '80']),
-            Expect.Simple('memoryToStorageAssignment', [], ['4', '87', '65', '82', '80']),
+            Expect.Simple('literalAssignment', [], [...encodeString('WARP')]),
+            Expect.Simple('memoryToStorageAssignment', [], [...encodeString('WARP')]),
           ]),
         ]),
         new Dir('this_keyword', [
@@ -4572,7 +4573,7 @@ export const expectations = flatten(
             Expect.Simple('dMax', [], ['3']),
           ]),
           File.Simple('informationContract', [
-            Expect.Simple('getName', [], ['4', '87', '65', '82', '80']),
+            Expect.Simple('getName', [], [...encodeString('WARP')]),
             Expect.Simple('getId', [], ['3619205059']),
           ]),
         ]),
@@ -4687,31 +4688,10 @@ export const expectations = flatten(
       new File(
         'ERC20',
         'ERC20',
+        [...encodeString('NETHERCOIN'), ...encodeString('NETH')],
         [
-          '10',
-          '78',
-          '69',
-          '84',
-          '72',
-          '69',
-          '82',
-          '67',
-          '79',
-          '73',
-          '78',
-          '4',
-          '78',
-          '69',
-          '84',
-          '72',
-        ],
-        [
-          Expect.Simple(
-            'name',
-            [],
-            ['10', '78', '69', '84', '72', '69', '82', '67', '79', '73', '78'],
-          ),
-          Expect.Simple('symbol', [], ['4', '78', '69', '84', '72']),
+          Expect.Simple('name', [], [...encodeString('NETHERCOIN')]),
+          Expect.Simple('symbol', [], [...encodeString('NETH')]),
           Expect.Simple('decimals', [], ['18']),
           Expect.Simple('totalSupply', [], ['0', '0']),
           Expect.Simple('balanceOf', ['1234'], ['0', '0']),

--- a/tests/behaviour/expectations/semantic.ts
+++ b/tests/behaviour/expectations/semantic.ts
@@ -46,6 +46,7 @@ import assert from 'assert';
 import { AST } from '../../../src/ast/ast';
 import { createDefaultConstructor } from '../../../src/utils/nodeTemplates';
 import { safeGetNodeType } from '../../../src/utils/nodeTypeProcessing';
+import { encodeString } from './utils';
 
 // this format will cause problems with overloading
 export interface Parameter {
@@ -283,11 +284,7 @@ export function encodeValue(tp: TypeNode, value: SolValue, inference: InferType)
     if (typeof value !== 'string') {
       throw new Error(`Can't encode ${value} as stringType`);
     }
-    const valueEncoded: number[] = Buffer.from(value).toJSON().data;
-
-    const byteString: string[] = [];
-    valueEncoded.forEach((val) => byteString.push(val.toString()));
-    return [byteString.length.toString()].concat(byteString);
+    return encodeString(value);
   } else if (tp instanceof AddressType) {
     return encodeAsUintOrFelt(tp, value, 160);
   } else if (tp instanceof BuiltinType) {

--- a/tests/behaviour/expectations/semantic_whitelist.ts
+++ b/tests/behaviour/expectations/semantic_whitelist.ts
@@ -508,15 +508,15 @@ const tests: string[] = [
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/events/events_with_same_name_inherited_emit.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/events/event_really_lots_of_data.sol', //msg.data
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/events/event_lots_of_data.sol', // msg.value
-    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/events/event_signature_in_library.sol', // WILL NOT SUPPORT indexed
-    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/events/event_indexed_mixed.sol', // WILL NOT SUPPORT indexed
-    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/events/event_emit_from_other_contract.sol', // WILL NOT SUPPORT indexed
-    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/events/event_indexed_string.sol', // WILL NOT SUPPORT indexed
-    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/events/event_anonymous_with_topics.sol', // WILL NOT SUPPORT indexed
-    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/events/event_anonymous_with_signature_collision2.sol', // WILL NOT SUPPORT indexed
-    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/events/event_constructor.sol', // WILL NOT SUPPORT indexed
-    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/events/event_emit.sol', // WILL NOT SUPPORT indexed
-    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/events/event_anonymous_with_signature_collision.sol', // WILL NOT SUPPORT indexed
+    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/events/event_signature_in_library.sol',
+    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/events/event_indexed_mixed.sol',
+    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/events/event_emit_from_other_contract.sol', //WILL NOT SUPPORT msg.value
+    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/events/event_indexed_string.sol',
+    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/events/event_anonymous_with_topics.sol', //WILL NOT SUPPORT msg.value
+    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/events/event_anonymous_with_signature_collision2.sol', //WILL NOT SUPPORT msg.value
+    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/events/event_constructor.sol', //Bug related to indexed parameters
+    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/events/event_emit.sol', //WILL NOT SUPPORT msg.value
+    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/events/event_anonymous_with_signature_collision.sol', //WILL NOT SUPPORT msg.value
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/events/event_indexed_function.sol', // WILL NOT SUPPORT function objects
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/events/event_indexed_function2.sol', // WILL NOT SUPPORT function objects
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/events/event.sol', // WILL NOT SUPPORT yul
@@ -1349,7 +1349,7 @@ const tests: string[] = [
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/userDefinedValueType/conversion.sol', // moved to behaviour tests for reliable passing of out of bounds data
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/userDefinedValueType/abicodec.sol', // WILL NOT SUPPORT member of adresses are not supported
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/userDefinedValueType/calldata.sol', // WILL NOT SUPPORT address members
-    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/userDefinedValueType/erc20.sol', // WILL NOT SUPPORT indexed parameters
+    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/userDefinedValueType/erc20.sol', // fails at deployment
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/userDefinedValueType/multisource.sol', // WILL NOT SUPPORT module
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/userDefinedValueType/multisource_module.sol', // WILL NOT SUPPORT module
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/userDefinedValueType/ownable.sol', // WILL NOT SUPPORT user defined errors
@@ -1411,7 +1411,7 @@ const tests: string[] = [
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/various/tuples.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/various/typed_multi_variable_declaration.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/various/negative_stack_height.sol', // starknet-compile takes too long to transpile the output, testnet dies
-    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/various/erc20.sol', // WILL NOT SUPPORT indexed
+    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/various/erc20.sol', // fails at deployment
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/various/skip_dynamic_types_for_static_arrays_with_dynamic_elements.sol', // nested dynarrays
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/various/store_bytes.sol', // msg.data
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/various/value_complex.sol', // address.balance

--- a/tests/behaviour/expectations/semantic_whitelist.ts
+++ b/tests/behaviour/expectations/semantic_whitelist.ts
@@ -431,12 +431,12 @@ const tests: string[] = [
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/constructor/base_constructor_arguments.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/constructor/constructor_arguments_external.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/constructor/functions_called_by_constructor_through_dispatch.sol', // WILL NOT SUPPORT function objects
-    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/constructor/constructor_function_complex.sol', // WILL NOT SUPPORT function objectss
+    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/constructor/constructor_function_complex.sol', // WILL NOT SUPPORT function objects
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/constructor/no_callvalue_check.sol', // WILL NOT SUPPORT due to the use of `value` function option
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/constructor/evm_exceptions_in_constructor_call_fail.sol', // address.call
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/constructor/constructor_arguments_internal.sol',
-    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/constructor/bytes_in_constructors_packer.sol', // Bug here related to constructos and inheritance
-    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/constructor/arrays_in_constructors.sol', // Bug related to contract inheritance
+    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/constructor/bytes_in_constructors_packer.sol',
+    // 'tests/behaviour/solidity/test/libsolidity/semanticTests/constructor/arrays_in_constructors.sol',
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/constructor/callvalue_check.sol', // WILL NOT SUPPORT yul
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/constructor/constructor_function_argument.sol', // WILL NOT SUPPORT function objects
     // 'tests/behaviour/solidity/test/libsolidity/semanticTests/constructor/store_function_in_constructor_packed.sol', // WILL NOT SUPPORT function objects

--- a/tests/behaviour/expectations/utils.ts
+++ b/tests/behaviour/expectations/utils.ts
@@ -92,3 +92,9 @@ export const toCairoInt8 = (val: number | bigint) => BigInt.asUintN(8, BigInt(va
 export function cairoUint256toHex(val: { low: string; high: string }): string {
   return `0x${(BigInt(val.low) + (BigInt(val.high) << 128n)).toString(16)}`;
 }
+
+export function encodeString(value: string): string[] {
+  const valueEncoded: number[] = Buffer.from(value).toJSON().data;
+  const byteString: string[] = valueEncoded.map((val) => val.toString());
+  return [byteString.length.toString()].concat(byteString);
+}

--- a/tests/behaviour/expectations/utils.ts
+++ b/tests/behaviour/expectations/utils.ts
@@ -94,7 +94,6 @@ export function cairoUint256toHex(val: { low: string; high: string }): string {
 }
 
 export function encodeString(value: string): string[] {
-  const valueEncoded: number[] = Buffer.from(value).toJSON().data;
-  const byteString: string[] = valueEncoded.map((val) => val.toString());
-  return [byteString.length.toString()].concat(byteString);
+  const valueEncoded: Buffer = Buffer.from(value);
+  return [valueEncoded.length, ...valueEncoded].map((val) => val.toString());
 }


### PR DESCRIPTION
There was already a part of the code for the semantic tests that did the encoding of strings, so I just extracted the logic into a method and updated the behaviour tests.

I did this to check some semantic tests that were failing and realize there were other tests that were commented on the `semantic_whitelist` that were not failing anymore. So I updated that as well