### PR TITLE
Remove fs-extra since its not browser friendly

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "chalk": "^4.1.2",
     "commander": "^9.1.0",
     "ethers": "^5.6.2",
-    "fs-extra": "^10.0.1",
     "keccak": "^3.0.2",
     "peggy": "^1.2.0",
     "prompts": "^2.4.2",

--- a/src/autoRunSemanticTests.ts
+++ b/src/autoRunSemanticTests.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'child_process';
 import assert from 'assert';
-import { existsSync, readFileSync, writeFileSync } from 'fs-extra';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
 
 if (!existsSync('./tests/behaviour/solidity')) {
   execSync('bash ./tests/behaviour/setup.sh');

--- a/src/io.ts
+++ b/src/io.ts
@@ -1,8 +1,9 @@
 import * as path from 'path';
-import * as fs from 'fs-extra';
+import * as fs from 'fs';
 import { OutputOptions, TranspilationOptions } from './cli';
 import { TranspileFailedError, logError } from './utils/errors';
 import { AST } from './ast/ast';
+import { outputFileSync } from './utils/fs';
 
 export function isValidSolFile(path: string, printError = true): boolean {
   if (!fs.existsSync(path)) {
@@ -77,11 +78,11 @@ export function outputResult(
     const contractName = path.basename(outputPath).slice(0, -'.cairo'.length);
     const solFilePath = path.dirname(outputPath);
 
-    fs.outputFileSync(
+    outputFileSync(
       abiOutPath,
       JSON.stringify(ast.solidityABI.contracts[solFilePath][contractName]['abi'], null, 2),
     );
-    fs.outputFileSync(fullCodeOutPath, code);
+    outputFileSync(fullCodeOutPath, code);
 
     // Cairo-format is disabled, as it has a bug
     // if (options.formatCairo || options.dev) {

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -11,7 +11,7 @@ import {
 } from './utils/errors';
 import { groupBy, printCompileErrors } from './utils/utils';
 import * as fs from 'fs';
-import { outputFileSync } from 'fs-extra';
+import { outputFileSync } from './utils/fs';
 import { error } from './utils/formatting';
 
 const WARP_TEST = 'warp_test';

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -6,6 +6,6 @@ export function outputFileSync(file: string, data: string) {
   if (fs.existsSync(dir)) {
     return fs.writeFileSync(file, data);
   }
-  fs.mkdirSync(dir);
+  fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(file, data);
 }

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -1,0 +1,11 @@
+import * as path from 'path';
+import * as fs from 'fs';
+
+export function outputFileSync(file: string, data: string) {
+  const dir = path.dirname(file);
+  if (fs.existsSync(dir)) {
+    return fs.writeFileSync(file, data);
+  }
+  fs.mkdirSync(dir);
+  fs.writeFileSync(file, data);
+}

--- a/tests/behaviour/expectations/index.ts
+++ b/tests/behaviour/expectations/index.ts
@@ -2,7 +2,7 @@ import { expectations as semantic } from './semantic';
 import { expectations as behaviour } from './behaviour';
 import { exceptions } from './semantic_exceptions';
 import { AsyncTest, Expect, File } from './types';
-import { readFileSync } from 'fs-extra';
+import { readFileSync } from 'fs';
 
 function getSyncTestFromPath(path: string): File {
   const text = readFileSync(path + '.sol', 'utf-8');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2390,15 +2390,6 @@ fresh@0.5.2:
   resolved "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz"
   integrity sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==
 
-fs-extra@^10.0.1:
-  version "10.0.1"
-  resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz"
-  integrity sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==
-  dependencies:
-    graceful-fs "^4.2.0"
-    jsonfile "^6.0.1"
-    universalify "^2.0.0"
-
 fs-extra@^10.1.0:
   version "10.1.0"
   resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz"


### PR DESCRIPTION
fs-extra emits a warning when fs module is missing, it calls on `process.emitWarning` to do it which crashes in browsers