### PR TITLE
Generated function pruner

### DIFF
--- a/src/cairoUtilFuncGen/base.ts
+++ b/src/cairoUtilFuncGen/base.ts
@@ -71,6 +71,13 @@ export abstract class CairoUtilFuncGenBase {
 export class StringIndexedFuncGen extends CairoUtilFuncGenBase {
   protected generatedFunctions: Map<string, CairoFunction> = new Map();
 
+  removeGeneratedFunction(fname: string) {
+    const functionsToRemove = [...this.generatedFunctions.keys()].filter(
+      (k) => this.generatedFunctions.get(k)?.name === fname,
+    );
+    functionsToRemove.forEach((fun) => this.generatedFunctions.delete(fun));
+  }
+
   getGeneratedCode(): string {
     return [...this.generatedFunctions.values()].map((func) => func.code).join('\n\n');
   }

--- a/src/cairoUtilFuncGen/base.ts
+++ b/src/cairoUtilFuncGen/base.ts
@@ -72,10 +72,9 @@ export class StringIndexedFuncGen extends CairoUtilFuncGenBase {
   protected generatedFunctions: Map<string, CairoFunction> = new Map();
 
   removeGeneratedFunction(fname: string) {
-    const functionsToRemove = [...this.generatedFunctions.keys()].filter(
-      (k) => this.generatedFunctions.get(k)?.name === fname,
-    );
-    functionsToRemove.forEach((fun) => this.generatedFunctions.delete(fun));
+    [...this.generatedFunctions.keys()]
+      .filter((k) => this.generatedFunctions.get(k)?.name === fname)
+      .map(this.generatedFunctions.delete, this.generatedFunctions);
   }
 
   getGeneratedCode(): string {

--- a/src/cairoUtilFuncGen/index.ts
+++ b/src/cairoUtilFuncGen/index.ts
@@ -1,6 +1,6 @@
 import { AST } from '../ast/ast';
 import { mergeImports } from '../utils/utils';
-import { CairoUtilFuncGenBase } from './base';
+import { CairoUtilFuncGenBase, StringIndexedFuncGen } from './base';
 import { InputCheckGen } from './inputArgCheck/inputCheck';
 import { MemoryArrayLiteralGen } from './memory/arrayLiteral';
 import { MemoryDynArrayLengthGen } from './memory/memoryDynArrayLength';
@@ -247,6 +247,11 @@ export class CairoUtilFuncGen {
         return 0;
       })
       .join('\n\n');
+  }
+  removeGeneratedFunction(name: string) {
+    this.getAllChildren()
+      .filter((c) => c instanceof StringIndexedFuncGen)
+      .forEach((c) => (c as StringIndexedFuncGen).removeGeneratedFunction(name));
   }
   private getAllChildren(): CairoUtilFuncGenBase[] {
     return getAllGenerators(this);

--- a/src/passes/functionPruner/functionRemover.ts
+++ b/src/passes/functionPruner/functionRemover.ts
@@ -7,44 +7,61 @@ import { isExternallyVisible } from '../../utils/utils';
 
 export class FunctionRemover extends ASTMapper {
   functionGraph: Map<number, FunctionDefinition[]>;
+  reachableFunctions: Set<string>;
+  reachableFunctionsFromRemovedFunctions: Set<string>;
 
   constructor(graph: Map<number, FunctionDefinition[]>) {
     super();
     this.functionGraph = graph;
+    this.reachableFunctions = new Set();
+    this.reachableFunctionsFromRemovedFunctions = new Set();
   }
 
   visitSourceUnit(node: SourceUnit, ast: AST): void {
-    this.removeUnreachableFunctions(node, ast);
     this.commonVisit(node, ast);
-  }
 
-  visitContractDefinition(node: ContractDefinition, _ast: AST) {
-    this.removeUnreachableFunctions(node, _ast);
-  }
+    this.collectReachableFunctions(node);
+    const utilFunGen = ast.getUtilFuncGen(node);
 
-  removeUnreachableFunctions(node: SourceUnit | ContractDefinition, ast: AST) {
-    const reachableFunctions: Set<number> = new Set();
-    // Collect visible functions and obtain ids of all reachable functions
-    node.vFunctions
-      .filter((func) => isExternallyVisible(func))
-      .forEach((func) => this.dfs(func, reachableFunctions));
     // Remove unreachable functions
     node.vFunctions
-      .filter((func) => !reachableFunctions.has(func.id))
+      .filter(
+        (func) =>
+          this.reachableFunctionsFromRemovedFunctions.has(func.name) &&
+          !this.reachableFunctions.has(func.name),
+      )
       .forEach((func) => {
         node.removeChild(func);
-        const utilFunGen = ast.getUtilFuncGen(node);
         utilFunGen.removeGeneratedFunction(func.name);
       });
   }
 
-  dfs(f: FunctionDefinition, visited: Set<number>): void {
-    visited.add(f.id);
+  visitContractDefinition(node: ContractDefinition, _ast: AST) {
+    this.collectReachableFunctions(node);
+
+    // Remove unreachable functions
+    node.vFunctions
+      .filter((func) => !this.reachableFunctions.has(func.name))
+      .forEach((func) => {
+        node.removeChild(func);
+        this.dfs(func, this.reachableFunctionsFromRemovedFunctions);
+      });
+  }
+
+  collectReachableFunctions(node: SourceUnit | ContractDefinition) {
+    // Collect visible functions and obtain ids of all reachable functions
+    node.vFunctions
+      .filter((func) => isExternallyVisible(func))
+      .forEach((func) => this.dfs(func, this.reachableFunctions));
+  }
+
+  dfs(f: FunctionDefinition, visited: Set<string>): void {
+    visited.add(f.name);
 
     const functions = this.functionGraph.get(f.id);
     assert(functions !== undefined, `Function ${printNode(f)} was not added to the functionGraph`);
     functions.forEach((f) => {
-      if (!visited.has(f.id)) this.dfs(f, visited);
+      if (!visited.has(f.name)) this.dfs(f, visited);
     });
   }
 }


### PR DESCRIPTION
Added functionality in `FunctionPruner` to remove generated functions #843 . The only generated functions being removed here are those which where accessible by the contract's removed functions, and are unreachable after removing those contract's functions. Here I made 2 main changes:
1. Created the variable `reachableFunctionsFromRemovedFunctions` which has the functions reachable from the removed contract's functions. In the beginning I thought on removing all unreachable generated functions, but this was not possible because there are calls to those functions generated after `FunctionPruner` pass, so on this pass there are unreachable generated functions which are later reachable.
2. Changed the identifier of the functions in the dfs, from `id` to `name`. This is because in the ast I found there are some repeated `FunctionDefinition` nodes, with different ids but same function name. This was causing some functions being removed because the ids didn't match. 