### PR TITLE
Change the capitalization of Starknet

### DIFF
--- a/docs/docs/features/contract_factories.mdx
+++ b/docs/docs/features/contract_factories.mdx
@@ -2,15 +2,15 @@
 title: Contract Factories
 ---
 
-Contract factories are now supported by Warp. Contract factories work slightly differently on StarkNet as they do on Ethereum.
-To deploy a contract on StarkNet we need to know the class hash of the contract being deployed, this class hash is then passed
+Contract factories are now supported by Warp. Contract factories work slightly differently on Starknet as they do on Ethereum.
+To deploy a contract on Starknet we need to know the class hash of the contract being deployed, this class hash is then passed
 as an argument to the deploy system call. Warp is designed so that the above is hidden from the user and handled internally.
 The class hash is calculated offline and inserted into the transpiled Contract factory as a constant.
 
 Note that the contract being deployed by the contract factory will still need to be declared online by the user.
 
 :warning: **Warning**: Warp also supports the use of the salt option i.e `new Contract{salt: salt}()` but because of core differences
-between Ethereum and StarkNet the salt value will be truncated from 32 to the 31 most significant bytes.
+between Ethereum and Starknet the salt value will be truncated from 32 to the 31 most significant bytes.
 
 The following Solidity contract named example.sol will be used to illustrate the feature:
 

--- a/docs/docs/get_around_unsupported_features.md
+++ b/docs/docs/get_around_unsupported_features.md
@@ -12,7 +12,7 @@ There is no algorithm to get around unsupported features, in most scenarios it i
 - tx.gasprice, tx.origin: No equivalent in Cairo so far.
 - Member access of block(block.gaslimit, block.chainid): No equivalent in Cairo. Most of the time won't be needed.
 - User defined Errors: No equivalent in Cairo for now.
-- Receive function: StarkNet doesn't have a native currency for the protocol so should be rewritten using other approach.
+- Receive function: Starknet doesn't have a native currency for the protocol so should be rewritten using other approach.
 - Function call options e.g x.f{gas: 10000}(arg1): Most of the options passed are not compatible with Cairo so in most cases can be just removed.
 
 ## Unsupported features that developer can get around.

--- a/docs/docs/getting_started/cli.mdx
+++ b/docs/docs/getting_started/cli.mdx
@@ -16,7 +16,7 @@ Available Commands:
     compile [options] <file>            Compile cairo files with warplib in the cairo-path
     gen_interface [options] <file>      Use native Cairo contracts in your Soldity by creating a Solidity interface and a Cairo translation contract for the target Cairo contract
     deploy [options] <file>             Deploy a warped cairo contract
-    deploy_account [options]            Deploy an account to StarkNet
+    deploy_account [options]            Deploy an account to Starknet
     invoke [options] <file>             Invoke a function on a warped contract using the Solidity abi
     call [options] <file>               Call a function on a warped contract using the Solidity abi
     install [options]                   Install the python dependencies required for Warp
@@ -78,11 +78,11 @@ compile `[options]` `<file...>`:
 
 declare `[options]` `<cairo_contract>`:
 
-    --network <network>                        StarkNet network URL
+    --network <network>                        Starknet network URL
     --account <account>                        The name of the account. If not given, the default for the wallet will be used.
     --account_dir <account_dir>                The directory of the account
-    --gateway_url <gateway_url>                StarkNet gateway URL
-    --feeder_gateway_url <feeder_gateway_url>  StarkNet feeder gateway URL
+    --gateway_url <gateway_url>                Starknet gateway URL
+    --feeder_gateway_url <feeder_gateway_url>  Starknet feeder gateway URL
     --wallet <wallet>                          The name of the wallet, including the python module and wallet class
     --max_fee <max_fee>                        Maximum fee to pay for the transaction
     -h, --help                                 display help for command
@@ -92,9 +92,9 @@ deploy `[options]` `<file...>`:
     -d, --debug_info                           Compile include debug information (default: false)
     --inputs <inputs...>                       Arguments to be passed to constructor of the program as a comma separated list of strings, ints and lists
     --use_cairo_abi                            Use the cairo abi instead of solidity for the inputs (default: false)
-    --network <network>                        StarkNet network URL
-    --gateway_url <gateway_url>                StarkNet gateway URL
-    --feeder_gateway_url <feeder_gateway_url>  StarkNet feeder gateway URL
+    --network <network>                        Starknet network URL
+    --gateway_url <gateway_url>                Starknet gateway URL
+    --feeder_gateway_url <feeder_gateway_url>  Starknet feeder gateway URL
     --no_wallet                                Do not use a wallet for deployment (default: false)
     --wallet <wallet>                          Wallet provider to use
     --account <account>                        Account to use for deployment
@@ -106,9 +106,9 @@ deploy_account `[options]`:
 
     --account <account>                        The name of the account. If not given, the default for the wallet will be used
     --account_dir <account_dir>                The directory of the account.
-    --network <network>                        StarkNet network URL
-    --gateway_url <gateway_url>                StarkNet gateway URL
-    --feeder_gateway_url <feeder_gateway_url>  StarkNet feeder gateway URL
+    --network <network>                        Starknet network URL
+    --gateway_url <gateway_url>                Starknet gateway URL
+    --feeder_gateway_url <feeder_gateway_url>  Starknet feeder gateway URL
     --wallet <wallet>                          The name of the wallet, including the python module and wallet class
     --max_fee <max_fee>                        Maximum fee to pay for the transaction.
     -h, --help                                 display help for command
@@ -121,9 +121,9 @@ invoke `[options]` `<file...>`:
     --use_cairo_abi                            Use the cairo abi instead of solidity for the inputs (default: false)
     --account <account>                        The name of the account. If not given, the default for the wallet will be used
     --account_dir <account_dir>                The directory of the account
-    --network <network>                        StarkNet network URL
-    --gateway_url <gateway_url>                StarkNet gateway URL
-    --feeder_gateway_url <feeder_gateway_url>  StarkNet feeder gateway URL
+    --network <network>                        Starknet network URL
+    --gateway_url <gateway_url>                Starknet gateway URL
+    --feeder_gateway_url <feeder_gateway_url>  Starknet feeder gateway URL
     --wallet <wallet>                          The name of the wallet, including the python module and wallet class
     --max_fee <max_fee>                        Maximum fee to pay for the transaction
     -h, --help                                 display help for command
@@ -136,9 +136,9 @@ call `[options]` `<file...>`:
     --use_cairo_abi                            Use the cairo abi instead of solidity for the inputs (default: false)
     --account <account>                        The name of the account. If not given, the default for the wallet will be used
     --account_dir <account_dir>                The directory of the account
-    --network <network>                        StarkNet network URL
-    --gateway_url <gateway_url>                StarkNet gateway URL
-    --feeder_gateway_url <feeder_gateway_url>  StarkNet feeder gateway URL
+    --network <network>                        Starknet network URL
+    --gateway_url <gateway_url>                Starknet gateway URL
+    --feeder_gateway_url <feeder_gateway_url>  Starknet feeder gateway URL
     --wallet <wallet>                          The name of the wallet, including the python module and wallet class
     --max_fee <max_fee>                        Maximum fee to pay for the transaction
     -h, --help                                 display help for command

--- a/docs/docs/getting_started/inputs-and-outputs.mdx
+++ b/docs/docs/getting_started/inputs-and-outputs.mdx
@@ -24,7 +24,7 @@ To use the Cairo ABI to pass inputs, add the `--use_cairo_abi` flag to the `depl
 
 Note that there are some nuances that come with using the Cairo ABI:
 
-- StarkNet does not support Solidity-style strings, so Warp represents strings as dynamic arrays of bytes.
+- Starknet does not support Solidity-style strings, so Warp represents strings as dynamic arrays of bytes.
   In Cairo ABI, each dynamic array is represented in two parts, the length of the string, and the values of the array
   `<arr_len>,<arr[0],arr[1]...arr[n-1]>`.
   e.g `ExampleString` -> `13,0x45,0x78,0x61,0x6d,0x70,0x6c,0x65,0x53,0x74,0x72,0x69,0x6e,0x67`

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 
 We are excited to announce the second version of Warp, now designed to transpile your Solidity code directly into Cairo.
 
-Warp 1 set out to show that compiling Solidity code into Cairo was possible, and paved the way for developers to access the benefits of StarkNet without needing to master Cairo. Using everything we learned from Warp 1, we have written a new version adding vast improvements to contract efficiency and user experience. In this blog, we will talk through the improvements made to Warp, transpile OpenZeppelin’s ERC20 contract, and describe future plans for the project.
+Warp 1 set out to show that compiling Solidity code into Cairo was possible, and paved the way for developers to access the benefits of Starknet without needing to master Cairo. Using everything we learned from Warp 1, we have written a new version adding vast improvements to contract efficiency and user experience. In this blog, we will talk through the improvements made to Warp, transpile OpenZeppelin’s ERC20 contract, and describe future plans for the project.
 
 ### Warp 2 vs Warp 1
 

--- a/docs/docs/solidity_equivalents/abi_encode.mdx
+++ b/docs/docs/solidity_equivalents/abi_encode.mdx
@@ -10,7 +10,7 @@ Due to cairo addresses being able to occupy the whole felt space and solidity's 
 
 - When ABI Encoding:
   although each data type occupies 32 bytes slot, and a `felt` fits perfectly inside,
-  an address encoded on a warped contract on StarkNet and later decoded on a L1 will
+  an address encoded on a warped contract on Starknet and later decoded on a L1 will
   cause a `revert` if the address is bigger than 20 bytes. If you wish to decode a cairo address on L1 you must
   substitute the address type for `uint256` (or other similar size type) e.g `abi.decode(data, (address))` -> `abi.decode(data, (uint256))`
 

--- a/docs/docs/solidity_equivalents/addresses.mdx
+++ b/docs/docs/solidity_equivalents/addresses.mdx
@@ -2,11 +2,11 @@
 title: Addresses
 ---
 
-An Ethereum address has a width of 160 bits, while a StarkNet address has a width of 251 bits. To support this change in address size, we had to modified the solc compiler. As a result, Warp's flavour of Solidity uses 256 bits for addresses instead of 160.
+An Ethereum address has a width of 160 bits, while a Starknet address has a width of 251 bits. To support this change in address size, we had to modified the solc compiler. As a result, Warp's flavour of Solidity uses 256 bits for addresses instead of 160.
 
 This modification means there are some things to consider when using the address type in Warp.
 
 First, the bounds of an address are not checked at compile time, which can introduce strange behaviour.
 The expression `address(uint256(MAX_UINT256))` will not cause any compile time or runtime errors even though the maximum value for addresses is `2**251 - 1`.
 
-Second, the `ecrecover` precompile now returns uint160 and not an address type. The`ecrecover` function does not work with StarkNet's curve, using it to try return a StarkNet address will cause errors. The function will only work when recovering an Ethereum address and returns a `uint160` type and not an `address` type.
+Second, the `ecrecover` precompile now returns uint160 and not an address type. The`ecrecover` function does not work with Starknet's curve, using it to try return a Starknet address will cause errors. The function will only work when recovering an Ethereum address and returns a `uint160` type and not an `address` type.

--- a/docs/docs/solidity_equivalents/inputs.mdx
+++ b/docs/docs/solidity_equivalents/inputs.mdx
@@ -2,7 +2,7 @@
 title: Transcoding Inputs for Starknet Contracts
 ---
 
-StarkNet contracts, also known as zk-STARK contracts, are a type of smart contract that utilizes zero-knowledge proof technology to provide privacy and security to its users and these contracts are written in [cairo](https://www.cairo-lang.org/docs/) language. Unlike traditional smart contracts written in Solidity, the inputs to a StarkNet contract are structurally different, making it necessary to understand how to interact with them effectively.
+Starknet contracts, also known as zk-STARK contracts, are a type of smart contract that utilizes zero-knowledge proof technology to provide privacy and security to its users and these contracts are written in [cairo](https://www.cairo-lang.org/docs/) language. Unlike traditional smart contracts written in Solidity, the inputs to a Starknet contract are structurally different, making it necessary to understand how to interact with them effectively.
 
 [Warp](https://github.com/NethermindEth/warp) is a transpiler tool developed by Nethermind, which is capable of converting Solidity smart contracts into Starknet contracts. However, the input parameters `(calldata)` for the Solidity smart contracts may differ slightly from those required for Starknet contracts written in Cairo. This is due to the differences in the programming languages used and the specific requirements of the respective platforms.
 

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -8,7 +8,7 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'Warp 🚀',
-  tagline: 'Bringing Solidity to StarkNet at warp speed',
+  tagline: 'Bringing Solidity to Starknet at warp speed',
   url: 'https://nethermindeth.github.io/',
   baseUrl: '/warp/',
   onBrokenLinks: 'throw',

--- a/docs/i18n/vi/code.json
+++ b/docs/i18n/vi/code.json
@@ -4,7 +4,7 @@
     "description": "The name of the project"
   },
   "homepage.projectDescription": {
-    "message": "Bringing Solidity to StarkNet at warp speed",
+    "message": "Bringing Solidity to Starknet at warp speed",
     "description": "Description of Warp at homepage"
   },
   "homepage.documentation.linkLabel": {

--- a/docs/i18n/vi/docusaurus-plugin-content-docs/current/features/contract_factories.mdx
+++ b/docs/i18n/vi/docusaurus-plugin-content-docs/current/features/contract_factories.mdx
@@ -2,15 +2,15 @@
 title: Contract Factories
 ---
 
-Contract factories are now supported by Warp. Contract factories work slightly differently on StarkNet as they do on Ethereum.
-To deploy a contract on StarkNet we need to know the class hash of the contract being deployed, this class hash is then passed
+Contract factories are now supported by Warp. Contract factories work slightly differently on Starknet as they do on Ethereum.
+To deploy a contract on Starknet we need to know the class hash of the contract being deployed, this class hash is then passed
 as an argument to the deploy system call. Warp is designed so that the above is hidden from the user and handled internally.
 The class hash is calculated offline and inserted into the transpiled Contract factory as a constant.
 
 Note that the contract being deployed by the contract factory will still need to be declared online by the user.
 
 :warning: **Warning**: Warp also supports the use of the salt option i.e `new Contract{salt: salt}()` but because of core differences
-between Ethereum and StarkNet the salt value will be truncated from 32 to the 31 most significant bytes.
+between Ethereum and Starknet the salt value will be truncated from 32 to the 31 most significant bytes.
 
 The following Solidity contract named example.sol will be used to illustrate the feature:
 

--- a/docs/i18n/vi/docusaurus-plugin-content-docs/current/getting_started/cli.mdx
+++ b/docs/i18n/vi/docusaurus-plugin-content-docs/current/getting_started/cli.mdx
@@ -16,7 +16,7 @@ Available Commands:
     compile [options] <file>            Compile cairo files with warplib in the cairo-path
     gen_interface [options] <file>      Use native Cairo contracts in your Soldity by creating a Solidity interface and a Cairo translation contract for the target Cairo contract
     deploy [options] <file>             Deploy a warped cairo contract
-    deploy_account [options]            Deploy an account to StarkNet
+    deploy_account [options]            Deploy an account to Starknet
     invoke [options] <file>             Invoke a function on a warped contract using the Solidity abi
     call [options] <file>               Call a function on a warped contract using the Solidity abi
     install [options]                   Install the python dependencies required for Warp
@@ -78,11 +78,11 @@ compile `[options]` `<file...>`:
 
 declare `[options]` `<cairo_contract>`:
 
-    --network <network>                        StarkNet network URL
+    --network <network>                        Starknet network URL
     --account <account>                        The name of the account. If not given, the default for the wallet will be used.
     --account_dir <account_dir>                The directory of the account
-    --gateway_url <gateway_url>                StarkNet gateway URL
-    --feeder_gateway_url <feeder_gateway_url>  StarkNet feeder gateway URL
+    --gateway_url <gateway_url>                Starknet gateway URL
+    --feeder_gateway_url <feeder_gateway_url>  Starknet feeder gateway URL
     --wallet <wallet>                          The name of the wallet, including the python module and wallet class
     --max_fee <max_fee>                        Maximum fee to pay for the transaction
     -h, --help                                 display help for command
@@ -92,9 +92,9 @@ deploy `[options]` `<file...>`:
     -d, --debug_info                           Compile include debug information (default: false)
     --inputs <inputs...>                       Arguments to be passed to constructor of the program as a comma seperated list of strings, ints and lists
     --use_cairo_abi                            Use the cairo abi instead of solidity for the inputs (default: false)
-    --network <network>                        StarkNet network URL
-    --gateway_url <gateway_url>                StarkNet gateway URL
-    --feeder_gateway_url <feeder_gateway_url>  StarkNet feeder gateway URL
+    --network <network>                        Starknet network URL
+    --gateway_url <gateway_url>                Starknet gateway URL
+    --feeder_gateway_url <feeder_gateway_url>  Starknet feeder gateway URL
     --no_wallet                                Do not use a wallet for deployment (default: false)
     --wallet <wallet>                          Wallet provider to use
     --account <account>                        Account to use for deployment
@@ -106,9 +106,9 @@ deploy_account `[options]`:
 
     --account <account>                        The name of the account. If not given, the default for the wallet will be used
     --account_dir <account_dir>                The directory of the account.
-    --network <network>                        StarkNet network URL
-    --gateway_url <gateway_url>                StarkNet gateway URL
-    --feeder_gateway_url <feeder_gateway_url>  StarkNet feeder gateway URL
+    --network <network>                        Starknet network URL
+    --gateway_url <gateway_url>                Starknet gateway URL
+    --feeder_gateway_url <feeder_gateway_url>  Starknet feeder gateway URL
     --wallet <wallet>                          The name of the wallet, including the python module and wallet class
     --max_fee <max_fee>                        Maximum fee to pay for the transaction.
     -h, --help                                 display help for command
@@ -121,9 +121,9 @@ invoke `[options]` `<file...>`:
     --use_cairo_abi                            Use the cairo abi instead of solidity for the inputs (default: false)
     --account <account>                        The name of the account. If not given, the default for the wallet will be used
     --account_dir <account_dir>                The directory of the account
-    --network <network>                        StarkNet network URL
-    --gateway_url <gateway_url>                StarkNet gateway URL
-    --feeder_gateway_url <feeder_gateway_url>  StarkNet feeder gateway URL
+    --network <network>                        Starknet network URL
+    --gateway_url <gateway_url>                Starknet gateway URL
+    --feeder_gateway_url <feeder_gateway_url>  Starknet feeder gateway URL
     --wallet <wallet>                          The name of the wallet, including the python module and wallet class
     --max_fee <max_fee>                        Maximum fee to pay for the transaction
     -h, --help                                 display help for command
@@ -136,9 +136,9 @@ call `[options]` `<file...>`:
     --use_cairo_abi                            Use the cairo abi instead of solidity for the inputs (default: false)
     --account <account>                        The name of the account. If not given, the default for the wallet will be used
     --account_dir <account_dir>                The directory of the account
-    --network <network>                        StarkNet network URL
-    --gateway_url <gateway_url>                StarkNet gateway URL
-    --feeder_gateway_url <feeder_gateway_url>  StarkNet feeder gateway URL
+    --network <network>                        Starknet network URL
+    --gateway_url <gateway_url>                Starknet gateway URL
+    --feeder_gateway_url <feeder_gateway_url>  Starknet feeder gateway URL
     --wallet <wallet>                          The name of the wallet, including the python module and wallet class
     --max_fee <max_fee>                        Maximum fee to pay for the transaction
     -h, --help                                 display help for command

--- a/docs/i18n/vi/docusaurus-plugin-content-docs/current/getting_started/inputs-and-outputs.mdx
+++ b/docs/i18n/vi/docusaurus-plugin-content-docs/current/getting_started/inputs-and-outputs.mdx
@@ -24,7 +24,7 @@ To use the Cairo ABI to pass inputs, add the `--use_cairo_abi` flag to the `depl
 
 Note that there are some nuances that come with using the Cairo ABI:
 
-- StarkNet does not support Solidity-style strings, so Warp represents strings as dynamic arrays of bytes.
+- Starknet does not support Solidity-style strings, so Warp represents strings as dynamic arrays of bytes.
   In Cairo ABI, each dynamic array is represented in two parts, the length of the array, and the values of the array
   `<arr_len>,<arr[0],arr[1]...arr[n-1]>`.
   e.g `ExampleString` -> `13,0x45,0x78,0x61,0x6d,0x70,0x6c,0x65,0x53,0x74,0x72,0x69,0x6e,0x67`

--- a/docs/i18n/vi/docusaurus-plugin-content-docs/current/intro.md
+++ b/docs/i18n/vi/docusaurus-plugin-content-docs/current/intro.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 
 We are excited to announce the second version of Warp, now designed to transpile your Solidity code directly into Cairo.
 
-Warp 1 set out to show that compiling Solidity code into Cairo was possible, and paved the way for developers to access the benefits of StarkNet without needing to master Cairo. Using everything we learned from Warp 1, we have written a new version adding vast improvements to contract efficiency and user experience. In this blog, we will talk through the improvements made to Warp, transpile OpenZeppelin’s ERC20 contract, and describe future plans for the project.
+Warp 1 set out to show that compiling Solidity code into Cairo was possible, and paved the way for developers to access the benefits of Starknet without needing to master Cairo. Using everything we learned from Warp 1, we have written a new version adding vast improvements to contract efficiency and user experience. In this blog, we will talk through the improvements made to Warp, transpile OpenZeppelin’s ERC20 contract, and describe future plans for the project.
 
 ### Warp 2 vs Warp 1
 

--- a/docs/i18n/vi/docusaurus-plugin-content-docs/current/solidity_equivalents/abi_encode.mdx
+++ b/docs/i18n/vi/docusaurus-plugin-content-docs/current/solidity_equivalents/abi_encode.mdx
@@ -10,7 +10,7 @@ Due to cairo addresses being able to occupy the whole felt space and solidity's 
 
 - When ABI Encoding:
   although each data type occupies 32 bytes slot, and a `felt` fits perfectly inside,
-  an address encoded on a warped contract on StarkNet and later decoded on a L1 will
+  an address encoded on a warped contract on Starknet and later decoded on a L1 will
   cause a `revert` if the address is bigger than 20 bytes. If you wish to decode a cairo address on L1 you must
   substitute the address type for `uint256` (or other similar size type) e.g `abi.decode(data, (address))` -> `abi.decode(data, (uint256))`
 

--- a/docs/i18n/vi/docusaurus-plugin-content-docs/current/solidity_equivalents/addresses.mdx
+++ b/docs/i18n/vi/docusaurus-plugin-content-docs/current/solidity_equivalents/addresses.mdx
@@ -2,11 +2,11 @@
 title: Addresses
 ---
 
-An Ethereum address has a width of 160 bits, while a StarkNet address has a width of 251 bits. To support this change in address size, we had modified the solc compiler. As a result, Warp-transpiled contracts uses 256 bits for addresses instead of 160.
+An Ethereum address has a width of 160 bits, while a Starknet address has a width of 251 bits. To support this change in address size, we had modified the solc compiler. As a result, Warp-transpiled contracts uses 256 bits for addresses instead of 160.
 
 This modification means there are some things to consider when using the address type in Warp.
 
 First, the bounds of an address are not checked at compile time, which can introduce strange behaviour.
 The expression `address(uint256(MAX_UINT256))` will not cause any compile time or runtime errors even though the maximum value for addresses is `2**251 - 1`.
 
-Second, the `ecrecover` precompile now returns uint160 and not an address type. The`ecrecover` function does not work with StarkNet's curve, using it to try return a StarkNet address will cause errors. The function will only work when recovering an Ethereum address and returns a `uint160` type and not an `address` type.
+Second, the `ecrecover` precompile now returns uint160 and not an address type. The`ecrecover` function does not work with Starknet's curve, using it to try return a Starknet address will cause errors. The function will only work when recovering an Ethereum address and returns a `uint160` type and not an `address` type.

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -18,7 +18,7 @@ function HomepageHeader() {
         </h1>
         <p className="hero__subtitle">
           <Translate id="homepage.projectDescription" description="Description of Warp at homepage">
-            Bringing Solidity to StarkNet at warp speed
+            Bringing Solidity to Starknet at warp speed
           </Translate>
         </p>
         <div className={styles.buttons}>

--- a/readme.md
+++ b/readme.md
@@ -2,8 +2,8 @@
 
 # Warp
 
-Warp brings Solidity to StarkNet, making it possible to transpile Ethereum
-smart contracts to StarkNet Cairo Contracts.
+Warp brings Solidity to Starknet, making it possible to transpile Ethereum
+smart contracts to Starknet Cairo Contracts.
 
 ## Quickstart
 
@@ -176,18 +176,18 @@ bin/warp transpile example_contracts/ERC20.sol
 
 If you have used installation method 1 you can use the `warp` command in any folder. If you have used installation method 2, you will have to specify the path to the warp directory followed by `bin/warp` e.g `path_to_warp_repo/bin/warp ...`
 
-### StarkNet setup
+### Starknet setup
 
 Select your network and wallet types. It's recommended to set these as
 environment variables but they can also be passed as explicit arguments to the
-Warp CLI and the StarkNet CLI.
+Warp CLI and the Starknet CLI.
 
 ```
 export STARKNET_WALLET=starkware.starknet.wallets.open_zeppelin.OpenZeppelinAccount
 export STARKNET_NETWORK=alpha-goerli
 ```
 
-Make sure you have a StarkNet account set up, if you have not done so yet
+Make sure you have a Starknet account set up, if you have not done so yet
 please:
 
 ```
@@ -203,18 +203,18 @@ To transpile a Solidity contract:
 warp transpile <path to Solidity contract>
 ```
 
-To declare a StarkNet contract:
+To declare a Starknet contract:
 
 ```bash
-warp declare <path to StarkNet contract>
+warp declare <path to Starknet contract>
 ```
 
 _Please note to deploy a contract you will first have to declare it._
 
-To deploy a StarkNet contract:
+To deploy a Starknet contract:
 
 ```bash
-warp deploy <path to StarkNet contract>
+warp deploy <path to Starknet contract>
 ```
 
 The deploy command will generate the compiled json file as well as the abi json
@@ -233,7 +233,7 @@ Libraries are bundled into the point of use, therefore if you try transpile a st
 
 <hr>
 Several features of Solidity are not supported/do not have analogs in Starknet yet.
-We will try our best to add these features as StarkNet supports them, but some may not be
+We will try our best to add these features as Starknet supports them, but some may not be
 possible due to fundamental differences in the platforms.
 
 Please see the list below:
@@ -275,7 +275,7 @@ Please see the list below:
 | member access of address object e.g address.balance |    :question:     |
 |              nested tuple assignments               |    :question:     |
 
-Note: We have changed the return of `ecrecover` to be `uint160` because we use the `address` type for StarkNet addresses.
+Note: We have changed the return of `ecrecover` to be `uint160` because we use the `address` type for Starknet addresses.
 
 ## Docker :whale:
 
@@ -346,7 +346,7 @@ Then to see that your contribution doesn't break the behaviour tests follow thes
 tests/behaviour/setup.sh
 ```
 
-2. In a separate terminal, start a StarkNet testnet server (in an environment with cairo-lang installed):
+2. In a separate terminal, start a Starknet testnet server (in an environment with cairo-lang installed):
 
 ```bash
 yarn testnet

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -218,10 +218,10 @@ program
   .command('status <tx_hash>')
   .description('Get the status of a transaction')
   .option('--network <network>', 'Starknet network URL', process.env.STARKNET_NETWORK)
-  .option('--gateway_url <gateway_url>', 'StarkNet gateway URL', process.env.STARKNET_GATEWAY_URL)
+  .option('--gateway_url <gateway_url>', 'Starknet gateway URL', process.env.STARKNET_GATEWAY_URL)
   .option(
     '--feeder_gateway_url <feeder_gateway_url>',
-    'StarkNet feeder gateway URL',
+    'Starknet feeder gateway URL',
     process.env.STARKNET_FEEDER_GATEWAY_URL,
   )
   .action((tx_hash: string, options: IOptionalNetwork) => {
@@ -295,11 +295,11 @@ program
     undefined,
   )
   .option('--use_cairo_abi', 'Use the cairo abi instead of solidity for the inputs', false)
-  .option('--network <network>', 'StarkNet network URL', process.env.STARKNET_NETWORK)
-  .option('--gateway_url <gateway_url>', 'StarkNet gateway URL', process.env.STARKNET_GATEWAY_URL)
+  .option('--network <network>', 'Starknet network URL', process.env.STARKNET_NETWORK)
+  .option('--gateway_url <gateway_url>', 'Starknet gateway URL', process.env.STARKNET_GATEWAY_URL)
   .option(
     '--feeder_gateway_url <feeder_gateway_url>',
-    'StarkNet feeder gateway URL',
+    'Starknet feeder gateway URL',
     process.env.STARKNET_FEEDER_GATEWAY_URL,
   )
   .option('--no_wallet', 'Do not use a wallet for deployment', false)
@@ -329,7 +329,7 @@ export type IDeployAccountProps = IOptionalAccount &
 
 program
   .command('deploy_account')
-  .description('Deploy an account to StarkNet')
+  .description('Deploy an account to Starknet')
   .option(
     '--account <account>',
     'The name of the account. If not given, the default for the wallet will be used',
@@ -339,11 +339,11 @@ program
     'The directory of the account.',
     process.env.STARKNET_ACCOUNT_DIR,
   )
-  .option('--network <network>', 'StarkNet network URL', process.env.STARKNET_NETWORK)
-  .option('--gateway_url <gateway_url>', 'StarkNet gateway URL', process.env.STARKNET_GATEWAY_URL)
+  .option('--network <network>', 'Starknet network URL', process.env.STARKNET_NETWORK)
+  .option('--gateway_url <gateway_url>', 'Starknet gateway URL', process.env.STARKNET_GATEWAY_URL)
   .option(
     '--feeder_gateway_url <feeder_gateway_url>',
-    'StarkNet feeder gateway URL',
+    'Starknet feeder gateway URL',
     process.env.STARKNET_FEEDER_GATEWAY_URL,
   )
   .option(
@@ -387,11 +387,11 @@ program
     'The directory of the account',
     process.env.STARKNET_ACCOUNT_DIR,
   )
-  .option('--network <network>', 'StarkNet network URL', process.env.STARKNET_NETWORK)
-  .option('--gateway_url <gateway_url>', 'StarkNet gateway URL', process.env.STARKNET_GATEWAY_URL)
+  .option('--network <network>', 'Starknet network URL', process.env.STARKNET_NETWORK)
+  .option('--gateway_url <gateway_url>', 'Starknet gateway URL', process.env.STARKNET_GATEWAY_URL)
   .option(
     '--feeder_gateway_url <feeder_gateway_url>',
-    'StarkNet feeder gateway URL',
+    'Starknet feeder gateway URL',
     process.env.STARKNET_FEEDER_GATEWAY_URL,
   )
   .option(
@@ -424,11 +424,11 @@ program
     'The directory of the account',
     process.env.STARKNET_ACCOUNT_DIR,
   )
-  .option('--network <network>', 'StarkNet network URL', process.env.STARKNET_NETWORK)
-  .option('--gateway_url <gateway_url>', 'StarkNet gateway URL', process.env.STARKNET_GATEWAY_URL)
+  .option('--network <network>', 'Starknet network URL', process.env.STARKNET_NETWORK)
+  .option('--gateway_url <gateway_url>', 'Starknet gateway URL', process.env.STARKNET_GATEWAY_URL)
   .option(
     '--feeder_gateway_url <feeder_gateway_url>',
-    'StarkNet feeder gateway URL',
+    'Starknet feeder gateway URL',
     process.env.STARKNET_FEEDER_GATEWAY_URL,
   )
   .option(
@@ -472,7 +472,7 @@ export interface IDeclareOptions {
 program
   .command('declare <cairo_contract>')
   .description('Declare a Cairo contract')
-  .option('--network <network>', 'StarkNet network URL', process.env.STARKNET_NETWORK)
+  .option('--network <network>', 'Starknet network URL', process.env.STARKNET_NETWORK)
   .option(
     '--account <account>',
     'The name of the account. If not given, the default for the wallet will be used.',
@@ -482,10 +482,10 @@ program
     'The directory of the account',
     process.env.STARKNET_ACCOUNT_DIR,
   )
-  .option('--gateway_url <gateway_url>', 'StarkNet gateway URL', process.env.STARKNET_GATEWAY_URL)
+  .option('--gateway_url <gateway_url>', 'Starknet gateway URL', process.env.STARKNET_GATEWAY_URL)
   .option(
     '--feeder_gateway_url <feeder_gateway_url>',
-    'StarkNet feeder gateway URL',
+    'Starknet feeder gateway URL',
     process.env.STARKNET_FEEDER_GATEWAY_URL,
   )
   .option(
@@ -514,11 +514,11 @@ program
     'The directory of the account',
     process.env.STARKNET_ACCOUNT_DIR,
   )
-  .option('--network <network>', 'StarkNet network URL', process.env.STARKNET_NETWORK)
-  .option('--gateway_url <gateway_url>', 'StarkNet gateway URL', process.env.STARKNET_GATEWAY_URL)
+  .option('--network <network>', 'Starknet network URL', process.env.STARKNET_NETWORK)
+  .option('--gateway_url <gateway_url>', 'Starknet gateway URL', process.env.STARKNET_GATEWAY_URL)
   .option(
     '--feeder_gateway_url <feeder_gateway_url>',
-    'StarkNet feeder gateway URL',
+    'Starknet feeder gateway URL',
     process.env.STARKNET_FEEDER_GATEWAY_URL,
   )
   .option(

--- a/src/passes/warnSupportedFeatures.ts
+++ b/src/passes/warnSupportedFeatures.ts
@@ -79,7 +79,7 @@ export class WarnSupportedFeatures extends ASTMapper {
       console.log(
         `${warning(
           'Warning',
-        )}: Due to StarkNet restrictions, salt used for contract creation is narrowed from 'uint256' to 'felt' taking the first 248 most significant bits`,
+        )}: Due to Starknet restrictions, salt used for contract creation is narrowed from 'uint256' to 'felt' taking the first 248 most significant bits`,
       );
       [...deploySalts.entries()].forEach(([path, nodes]) => warn(path, nodes));
     }

--- a/src/starknetCli.ts
+++ b/src/starknetCli.ts
@@ -318,7 +318,7 @@ function declareContract(filePath: string, options: IDeclareOptions) {
       },
     );
   } catch {
-    logError('StarkNet declare failed');
+    logError('Starknet declare failed');
   }
 }
 
@@ -352,7 +352,7 @@ export function runStarknetNewAccount(options: StarkNetNewAccountOptions) {
       },
     );
   } catch {
-    logError('StarkNet new account creation failed');
+    logError('Starknet new account creation failed');
   }
 }
 

--- a/src/utils/nodeTypeProcessing.ts
+++ b/src/utils/nodeTypeProcessing.ts
@@ -344,7 +344,7 @@ export function safeCanonicalHash(f: FunctionDefinition, ast: AST) {
  *      uint16[3] -> byte size is 6
  *      and so on
  *  address are 32 bytes instead of 20 bytes due to size difference
- *  between addresses in StarkNet and Ethereum
+ *  between addresses in Starknet and Ethereum
  *  For every type whose byte size can be known on compile time
  *  @param type Solidity type
  *  @param version required for calculating structs byte size

--- a/tests/behaviour/behaviour.test.ts
+++ b/tests/behaviour/behaviour.test.ts
@@ -64,7 +64,7 @@ describe('Transpile solidity', function () {
   }
 });
 
-// Compiling the transpiled contracts using the StarkNet CLI.
+// Compiling the transpiled contracts using the Starknet CLI.
 describe('Transpiled contracts are valid cairo', function () {
   this.timeout(TIME_LIMIT);
 
@@ -113,7 +113,7 @@ const deployedAddresses: Map<string, { address: string; hash: string }> = new Ma
 
 // Deploying the tests to the Testnet thought interface commands
 // The test net is a flask server that runs and therefor cannot be interacted with
-// in the same manner as the StarkNet CLI.
+// in the same manner as the Starknet CLI.
 describe('Compiled contracts are deployable', function () {
   this.timeout(TIME_LIMIT);
 


### PR DESCRIPTION
Changes the capitalization of Starknet from `'StarkNet'` to `'Starknet'`. Currently only applies changes to docs only, and not code such as function naming or variable naming.

If there's a need to change the code to be consistent with this capitalization as well then do leave a comment.

Fixes #907
