### PR TITLE
Dependency injection of infer type in Cairo Writer

### DIFF
--- a/src/cairoWriter/writers/functionCallWriter.ts
+++ b/src/cairoWriter/writers/functionCallWriter.ts
@@ -4,7 +4,6 @@ import {
   ContractDefinition,
   FunctionCall,
   FunctionCallKind,
-  InferType,
   Literal,
   MemberAccess,
   SrcDesc,
@@ -30,10 +29,7 @@ export class FunctionCallWriter extends CairoASTNodeWriter {
       case FunctionCallKind.FunctionCall: {
         if (node.vExpression instanceof MemberAccess) {
           // check if we're calling a member of a contract
-          const nodeType = safeGetNodeType(
-            node.vExpression.vExpression,
-            new InferType(writer.targetCompilerVersion),
-          );
+          const nodeType = safeGetNodeType(node.vExpression.vExpression, this.ast.inference);
           if (
             nodeType instanceof UserDefinedType &&
             nodeType.definition instanceof ContractDefinition
@@ -103,10 +99,7 @@ export class FunctionCallWriter extends CairoASTNodeWriter {
           assert(val < BigInt('0x800000000000000000000000000000000000000000000000000000000000000'));
           return [`${args[0]}`];
         }
-        const nodeType = safeGetNodeType(
-          node.vExpression,
-          new InferType(writer.targetCompilerVersion),
-        );
+        const nodeType = safeGetNodeType(node.vExpression, this.ast.inference);
         if (
           nodeType instanceof UserDefinedType &&
           nodeType.definition instanceof ContractDefinition

--- a/src/cairoWriter/writers/parameterListWriter.ts
+++ b/src/cairoWriter/writers/parameterListWriter.ts
@@ -3,7 +3,6 @@ import {
   ContractDefinition,
   DataLocation,
   FunctionDefinition,
-  InferType,
   ParameterList,
   SrcDesc,
 } from 'solc-typed-ast';
@@ -26,7 +25,7 @@ export class ParameterListWriter extends CairoASTNodeWriter {
           : defContext;
 
       const tp = CairoType.fromSol(
-        safeGetNodeType(value, new InferType(writer.targetCompilerVersion)),
+        safeGetNodeType(value, this.ast.inference),
         this.ast,
         varTypeConversionContext,
       );

--- a/src/cairoWriter/writers/parameterListWriter.ts
+++ b/src/cairoWriter/writers/parameterListWriter.ts
@@ -12,7 +12,7 @@ import { isExternallyVisible } from '../../utils/utils';
 import { CairoASTNodeWriter } from '../base';
 
 export class ParameterListWriter extends CairoASTNodeWriter {
-  writeInner(node: ParameterList, writer: ASTWriter): SrcDesc {
+  writeInner(node: ParameterList, _writer: ASTWriter): SrcDesc {
     const defContext =
       node.parent instanceof FunctionDefinition && isExternallyVisible(node.parent)
         ? TypeConversionContext.CallDataRef

--- a/src/cairoWriter/writers/structDefinitionWriter.ts
+++ b/src/cairoWriter/writers/structDefinitionWriter.ts
@@ -1,4 +1,4 @@
-import { ASTWriter, InferType, SrcDesc, StructDefinition } from 'solc-typed-ast';
+import { ASTWriter, SrcDesc, StructDefinition } from 'solc-typed-ast';
 import { CairoType, TypeConversionContext } from '../../utils/cairoTypeSystem';
 import { safeGetNodeType } from '../../utils/nodeTypeProcessing';
 import { mangleStructName } from '../../utils/utils';
@@ -14,7 +14,7 @@ export class StructDefinitionWriter extends CairoASTNodeWriter {
           .map(
             (value) =>
               `${value.name} : ${CairoType.fromSol(
-                safeGetNodeType(value, new InferType(writer.targetCompilerVersion)),
+                safeGetNodeType(value, this.ast.inference),
                 this.ast,
                 TypeConversionContext.StorageAllocation,
               )},`,

--- a/src/cairoWriter/writers/structDefinitionWriter.ts
+++ b/src/cairoWriter/writers/structDefinitionWriter.ts
@@ -6,7 +6,7 @@ import { CairoASTNodeWriter } from '../base';
 import { INDENT } from '../utils';
 
 export class StructDefinitionWriter extends CairoASTNodeWriter {
-  writeInner(node: StructDefinition, writer: ASTWriter): SrcDesc {
+  writeInner(node: StructDefinition, _writer: ASTWriter): SrcDesc {
     return [
       [
         `struct ${mangleStructName(node)}{`,


### PR DESCRIPTION
Some of the Cairo Writers create a new instance of InferType every time their functions are called, this pr change that to work with a reference passed when Writers were created.