### PR TITLE
Temporarily fix cairo-lang dependency version issues after major upgrades

### DIFF
--- a/.github/workflows/test-behaviour.yml
+++ b/.github/workflows/test-behaviour.yml
@@ -103,6 +103,8 @@ jobs:
         run: |
           pip install -r requirements.txt 
           pip install cairo-lang=="$CAIRO_LANG_VERSION"
+          pip install web3==5.*
+          pip install typeguard==2.*
 
       - name: Setup source hash (push)
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -37,6 +37,8 @@ jobs:
           make compile
           pip3 install cairo-lang=="$CAIRO_LANG_VERSION"
           pip3 install starknet-devnet==0.4.4
+          pip3 install web3==5.*
+          pip3 install typeguard==2.*
 
       - name: Build warplib
         run: yarn warplib

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,7 @@ flask-cors >= 3.0.10
 cairo-lang==0.10.3
 # Requrired by the cli test
 starknet-devnet==0.4.4
+# Fix until cairo-lang supports web3 v6 or adds a matching pattern for v5
+web3==5.*
+# Fix until cairo-lang 0.11 is released
+typeguard==2.*

--- a/warp_venv.sh
+++ b/warp_venv.sh
@@ -7,5 +7,7 @@ $PYTHON_BIN -m venv "$SCRIPT_DIR"/warp_venv
 . $SCRIPT_DIR/warp_venv/bin/activate
 
 pip install cairo-lang==0.10.3
+pip install web3==5.*
+pip install typeguard==2.*
 
 deactivate


### PR DESCRIPTION
When I was merging changes on my other PR, I noticed some issues when `starknet` was being executed on the workflow tests, and they didn't seem to have been caused by my changes.
Turns out that the errors were related to breaking changes from two `cairo-lang` dependencies that were upgraded to the next major version literally like 3 days ago, more specifically `web3` and `typeguard`. Since `cairo-lang` didn't have a specific major version matching, it accepted the new package versions while not yet supporting them, and then these errors happened. There's already an open issue for this: https://github.com/starkware-libs/cairo-lang/issues/151.

In the latest `cairo-lang` pre-release, `typeguard` is already set to `<3.0.0`, but `web3` isn't yet. When both of these are fixed and there's a new release, it would be good to upgrade it here. For the moment, I added explicit installs for `web3` (`==5.*`) and `typeguard` (`==2.*`), which seem to have done the trick.