### PR TITLE
remove member access PFS pass

### DIFF
--- a/src/passes/publicFunctionSplitter/externalFunctionCreator.ts
+++ b/src/passes/publicFunctionSplitter/externalFunctionCreator.ts
@@ -8,7 +8,7 @@ import {
   Expression,
   FunctionKind,
   ContractKind,
-  MemberAccess,
+  // MemberAccess,
   Identifier,
 } from 'solc-typed-ast';
 import { AST } from '../../ast/ast';
@@ -18,7 +18,7 @@ import { TranspilationAbandonedError } from '../../utils/errors';
 import { INTERNAL_FUNCTION_SUFFIX } from '../../utils/nameModifiers';
 import { createBlock, createIdentifier, createReturn } from '../../utils/nodeTemplates';
 import {
-  getContractTypeString,
+  // getContractTypeString,
   getFunctionTypeString,
   getReturnTypeString,
 } from '../../utils/getTypeString';
@@ -118,17 +118,10 @@ function createCallToInternalFunction(
     );
   }
 
-  const memberAccess = new MemberAccess(
+  const functionIdentifier = new Identifier(
     ast.reserveId(),
     '',
     getFunctionTypeString(functionDef, ast.inference, nodeInSourceUnit),
-    new Identifier(
-      ast.reserveId(),
-      '',
-      getContractTypeString(contract),
-      contract.name,
-      contract.id,
-    ),
     functionDef.name,
     functionDef.id,
   );
@@ -138,7 +131,7 @@ function createCallToInternalFunction(
     '',
     getReturnTypeString(functionDef, ast, nodeInSourceUnit),
     FunctionCallKind.FunctionCall,
-    memberAccess,
+    functionIdentifier,
     argList,
   );
 }

--- a/src/passes/publicFunctionSplitter/externalFunctionCreator.ts
+++ b/src/passes/publicFunctionSplitter/externalFunctionCreator.ts
@@ -8,7 +8,6 @@ import {
   Expression,
   FunctionKind,
   ContractKind,
-  // MemberAccess,
   Identifier,
 } from 'solc-typed-ast';
 import { AST } from '../../ast/ast';
@@ -17,11 +16,7 @@ import { cloneASTNode } from '../../utils/cloning';
 import { TranspilationAbandonedError } from '../../utils/errors';
 import { INTERNAL_FUNCTION_SUFFIX } from '../../utils/nameModifiers';
 import { createBlock, createIdentifier, createReturn } from '../../utils/nodeTemplates';
-import {
-  // getContractTypeString,
-  getFunctionTypeString,
-  getReturnTypeString,
-} from '../../utils/getTypeString';
+import { getFunctionTypeString, getReturnTypeString } from '../../utils/getTypeString';
 export class ExternalFunctionCreator extends ASTMapper {
   constructor(
     public internalToExternalFunctionMap: Map<FunctionDefinition, FunctionDefinition>,

--- a/tests/compilation/passingContracts.ts
+++ b/tests/compilation/passingContracts.ts
@@ -121,7 +121,7 @@ export const passingContracts = [
   // 'tests/compilation/contracts/mutableReferences/scalarStorage.sol',
   // 'tests/compilation/contracts/namedArgs/constructor.sol',
   // 'tests/compilation/contracts/namedArgs/eventsAndErrors.sol',
-  // 'tests/compilation/contracts/namedArgs/function.sol',
+  'tests/compilation/contracts/namedArgs/function.sol',
   // 'tests/compilation/contracts/nestedStaticArrayStruct.sol',
   // 'tests/compilation/contracts/nestedStructStaticArray.sol',
   'tests/compilation/contracts/nestedStructs.sol',


### PR DESCRIPTION
Since cairo1 doesn't support Contract member accesses , it needs to be removed from internal call that PFS are making from external functions.

Old cairo code: 
```js
1: mapping(uint => uint) internal __warp_0_data
<cairo information - multiline end>

contract C {
    mapping(uint => uint) internal __warp_0_data;

    function f_26121ff0() external {
        set_1ab06ee5_internal(3, 2);
    }

    function set_1ab06ee5_internal(uint __warp_1_key, uint __warp_2_value) internal {
        __warp_0_data[__warp_1_key] = __warp_2_value;
    }

    constructor() {}

    function set_1ab06ee5(uint __warp_1_key, uint __warp_2_value) external {
        return C.set_1ab06ee5_internal(__warp_1_key, __warp_2_value);
    }
}
```

to new one: 
```js
<cairo information - multiline start> storage allocations
1: mapping(uint => uint) internal __warp_0_data
<cairo information - multiline end>

contract C {
    mapping(uint => uint) internal __warp_0_data;

    function f_26121ff0() external {
        set_1ab06ee5_internal(3, 2);
    }

    function set_1ab06ee5_internal(uint __warp_1_key, uint __warp_2_value) internal {
        __warp_0_data[__warp_1_key] = __warp_2_value;
    }

    constructor() {}

    function set_1ab06ee5(uint __warp_1_key, uint __warp_2_value) external {
        return set_1ab06ee5_internal(__warp_1_key, __warp_2_value);
    }
}
```