### PR TITLE
translate int conversions to Cairo 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -207,9 +207,6 @@ warplib/src/maths/lt_signed.cairo
 # bitwise_or - handwritten
 warplib/src/maths/bitwise_not.cairo
 
-# ---conversions---
-warplib/src/conversions/int_conversions.cairo
-
 # ---external-input-input-checks---
 warplib/src/external_input_check/external_input_check_ints.cairo
 # external_input_check_address.cairo - handwritten
@@ -217,4 +214,3 @@ warplib/src/external_input_check/external_input_check_ints.cairo
 
 tests/cli/starknet_open_zeppelin_accounts.json
 tests/cli/starknet_open_zeppelin_accounts.json.backup
-

--- a/src/cairoUtilFuncGen/calldata/calldataToStorage.ts
+++ b/src/cairoUtilFuncGen/calldata/calldataToStorage.ts
@@ -19,7 +19,6 @@ import { printTypeNode } from '../../utils/astPrinter';
 import { CairoDynArray, CairoType, TypeConversionContext } from '../../utils/cairoTypeSystem';
 import { NotSupportedYetError } from '../../utils/errors';
 import { createCairoGeneratedFunction, createCallToFunction } from '../../utils/functionGeneration';
-import { WARP_UINT256 } from '../../utils/importPaths';
 import { getElementType, safeGetNodeType } from '../../utils/nodeTypeProcessing';
 import { mapRange, narrowBigIntSafe, typeNameFromTypeNode } from '../../utils/utils';
 import { add, delegateBasedOnType, GeneratedFunctionInfo, StringIndexedFuncGen } from '../base';
@@ -179,7 +178,7 @@ export class CalldataToStorageGen extends StringIndexedFuncGen {
          }
       }
 
-      func ${funcName}(loc : felt, dyn_array_struct : ${structDef.name}) -> (loc : felt){ 
+      func ${funcName}(loc : felt, dyn_array_struct : ${structDef.name}) -> (loc : felt){
          alloc_locals;
          let (len_uint256) = warp_uint256(dyn_array_struct.len);
          ${lenName}.write(loc, len_uint256);
@@ -191,7 +190,7 @@ export class CalldataToStorageGen extends StringIndexedFuncGen {
     return {
       name: funcName,
       code: code,
-      functionsCalled: [this.requireImport(...WARP_UINT256), dynArray, dynArrayLength, writeDef],
+      functionsCalled: [dynArray, dynArrayLength, writeDef],
     };
   }
 

--- a/src/cairoUtilFuncGen/storage/storageToCalldata.ts
+++ b/src/cairoUtilFuncGen/storage/storageToCalldata.ts
@@ -18,7 +18,7 @@ import { printTypeNode } from '../../utils/astPrinter';
 import { CairoDynArray, CairoType, TypeConversionContext } from '../../utils/cairoTypeSystem';
 import { NotSupportedYetError } from '../../utils/errors';
 import { createCairoGeneratedFunction, createCallToFunction } from '../../utils/functionGeneration';
-import { ALLOC, U128_FROM_FELT, WARP_UINT256 } from '../../utils/importPaths';
+import { ALLOC, U128_FROM_FELT } from '../../utils/importPaths';
 import { getElementType, safeGetNodeType } from '../../utils/nodeTypeProcessing';
 import { mapRange, narrowBigIntSafe, typeNameFromTypeNode } from '../../utils/utils';
 import { add, delegateBasedOnType, GeneratedFunctionInfo, StringIndexedFuncGen } from '../base';
@@ -188,11 +188,7 @@ export class StorageToCalldataGen extends StringIndexedFuncGen {
       }
     `;
 
-    const importedFuncs = [
-      this.requireImport(...WARP_UINT256),
-      this.requireImport(...U128_FROM_FELT),
-      this.requireImport(...ALLOC),
-    ];
+    const importedFuncs = [this.requireImport(...U128_FROM_FELT), this.requireImport(...ALLOC)];
 
     const funcInfo: GeneratedFunctionInfo = {
       name: funcName,

--- a/src/passes/cairoUtilImporter.ts
+++ b/src/passes/cairoUtilImporter.ts
@@ -1,6 +1,7 @@
 import {
   AddressType,
   ElementaryTypeName,
+  FunctionCall,
   IntType,
   Literal,
   MemberAccess,
@@ -12,7 +13,14 @@ import {
 import { AST } from '../ast/ast';
 import { ASTMapper } from '../ast/mapper';
 import { createImport } from '../utils/importFuncGenerator';
-import { INTO, U256_FROM_FELTS, U128_FROM_FELT, CONTRACT_ADDRESS } from '../utils/importPaths';
+import {
+  INTO,
+  U256_FROM_FELTS,
+  U128_FROM_FELT,
+  CONTRACT_ADDRESS,
+  CUTOFF_DOWNCAST,
+  WARPLIB_INTEGER,
+} from '../utils/importPaths';
 import { safeGetNodeType } from '../utils/nodeTypeProcessing';
 import { getContainingSourceUnit, primitiveTypeToCairo } from '../utils/utils';
 
@@ -39,6 +47,17 @@ export class CairoUtilImporter extends ASTMapper {
     } else if (cairoType === 'ContractAddress') {
       createImport(...CONTRACT_ADDRESS, this.dummySourceUnit ?? node, ast);
     }
+  }
+
+  visitFunctionCall(node: FunctionCall, ast: AST): void {
+    // FIXME: remove when BitAnd is available for integer types in
+    // corelib
+    if (node.vFunctionName === CUTOFF_DOWNCAST[1]) {
+      const path = WARPLIB_INTEGER.slice(0, -1);
+      const name = WARPLIB_INTEGER.at(-1)!;
+      createImport(path, name, this.dummySourceUnit ?? node, ast);
+    }
+    super.visitFunctionCall(node, ast);
   }
 
   visitLiteral(node: Literal, ast: AST): void {

--- a/src/passes/cairoUtilImporter.ts
+++ b/src/passes/cairoUtilImporter.ts
@@ -12,6 +12,7 @@ import {
 } from 'solc-typed-ast';
 import { AST } from '../ast/ast';
 import { ASTMapper } from '../ast/mapper';
+import { requireNonNullish } from '../export';
 import { createImport } from '../utils/importFuncGenerator';
 import {
   INTO,
@@ -54,7 +55,7 @@ export class CairoUtilImporter extends ASTMapper {
     // corelib
     if (node.vFunctionName === CUTOFF_DOWNCAST[1]) {
       const path = WARPLIB_INTEGER.slice(0, -1);
-      const name = WARPLIB_INTEGER.at(-1)!;
+      const name = requireNonNullish(WARPLIB_INTEGER.at(-1));
       createImport(path, name, this.dummySourceUnit ?? node, ast);
     }
     super.visitFunctionCall(node, ast);

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -82,3 +82,13 @@ export interface ExecSyncError {
 export function instanceOfExecSyncError(object: any): object is ExecSyncError {
   return 'stderr' in object;
 }
+
+export function requireNonNullish<T>(x: T | null | undefined): T {
+  if (x === null) {
+    throw new Error('Unexpected null');
+  }
+  if (x === undefined) {
+    throw new Error('Unexpected undefined');
+  }
+  return x as T;
+}

--- a/src/utils/importFuncGenerator.ts
+++ b/src/utils/importFuncGenerator.ts
@@ -150,6 +150,7 @@ export function createImport(
     Paths.WARP_MEMORY_TRAIT,
     Paths.BOOL_INTO_FELT252,
     Paths.FELT252_INTO_BOOL,
+    Paths.UPCAST,
     Paths.WARPLIB_INTEGER,
   ];
   if (pathsForFunctionImport.some((i) => encodePath([path, name]) === encodePath(i))) {

--- a/src/utils/importPaths.ts
+++ b/src/utils/importPaths.ts
@@ -86,7 +86,6 @@ export const NARROW_SAFE: [string[], string] = [[...WARPLIB_MATHS, 'utils'], 'na
 export const PACK_BYTES_FELT: [string[], string] = [[...WARPLIB_KECCAK], 'pack_bytes_felt'];
 export const STRING_HASH: [string[], string] = [['warplib', 'string_hash'], 'string_hash'];
 export const WARP_KECCAK: [string[], string] = [[...WARPLIB_KECCAK], 'warp_keccak'];
-export const WARP_UINT256: [string[], string] = [[...INT_CONVERSIONS], 'warp_uint256'];
 export const WM_DYN_ARRAY_LENGTH: [string[], string] = [[...WARPLIB_MEMORY], 'wm_dyn_array_length'];
 export const WM_INDEX_DYN: [string[], string] = [[...WARPLIB_MEMORY], 'wm_index_dyn'];
 export const WM_INDEX_STATIC: [string[], string] = [[...WARPLIB_MEMORY], 'wm_index_static'];
@@ -260,3 +259,7 @@ export const ACCESSOR: [string[], string] = [MEMORY_MODULE, 'WarpMemoryAccesssor
 export const ACCESSOR_TRAIT: [string[], string] = [MEMORY_MODULE, 'WarpMemoryAccesssorTrait'];
 
 export const SUPER: string[] = ['super'];
+
+export const SIGNED_UPCAST: [string[], string] = [INTEGER_CONVERSIONS, 'signed_upcast'];
+export const UPCAST: [string[], string] = [['integer'], 'upcast'];
+export const CUTOFF_DOWNCAST: [string[], string] = [INTEGER_CONVERSIONS, 'cutoff_downcast'];

--- a/src/warplib/generateWarplib.ts
+++ b/src/warplib/generateWarplib.ts
@@ -1,5 +1,4 @@
 import { generateFile, PATH_TO_WARPLIB, WarplibFunctionInfo } from './utils';
-import { int_conversions } from './implementations/conversions/int';
 import { add, add_unsafe, add_signed, add_signed_unsafe } from './implementations/maths/add';
 import { div_signed, div_signed_unsafe } from './implementations/maths/div';
 import { exp, exp_signed, exp_signed_unsafe, exp_unsafe } from './implementations/maths/exp';
@@ -62,14 +61,13 @@ const mathWarplibFunctions: WarplibFunctionInfo[] = [
   // bitwise_or - handwritten
   bitwise_not(),
 ];
-const conversionWarplibFunctions: WarplibFunctionInfo[] = [int_conversions()];
 const inputCheckWarplibFunctions: WarplibFunctionInfo[] = [
   external_input_check_ints(),
   // external_input_check_address - handwritten
 ];
 
 generateWarplibFor('maths', mathWarplibFunctions);
-generateWarplibFor('conversions', conversionWarplibFunctions);
+generateWarplibFor('conversions', []);
 generateWarplibFor('external_input_check', inputCheckWarplibFunctions);
 
 function generateWarplibFor(folderName: string, functions: WarplibFunctionInfo[]) {

--- a/src/warplib/implementations/conversions/int.ts
+++ b/src/warplib/implementations/conversions/int.ts
@@ -1,103 +1,12 @@
 import assert from 'assert';
 import { FunctionCall, generalizeType, IntType } from 'solc-typed-ast';
 import { AST } from '../../../ast/ast';
+import { createCallToFunction, createNumberTypeName } from '../../../export';
 import { printNode, printTypeNode } from '../../../utils/astPrinter';
+import { CUTOFF_DOWNCAST, SIGNED_UPCAST, UPCAST } from '../../../utils/importPaths';
 import { safeGetNodeType } from '../../../utils/nodeTypeProcessing';
-import {
-  bound,
-  forAllWidths,
-  IntFunction,
-  mask,
-  msb,
-  uint256,
-  WarplibFunctionInfo,
-} from '../../utils';
 
-export function int_conversions(): WarplibFunctionInfo {
-  return {
-    fileName: 'int_conversions',
-    imports: [
-      'from starkware.cairo.common.bitwise import bitwise_and',
-      'from starkware.cairo.common.cairo_builtins import BitwiseBuiltin',
-      'from starkware.cairo.common.math import split_felt',
-      'from starkware.cairo.common.uint256 import Uint256, uint256_add',
-    ],
-    functions: [
-      ...forAllWidths((from) => {
-        const x = forAllWidths((to) => {
-          if (from < to) {
-            if (to === 256) {
-              return [
-                `func warp_int${from}_to_int256{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}(op : felt) -> (res : Uint256){`,
-                `    let (msb) = bitwise_and(op, ${msb(from)});`,
-                `    let (high, low) = split_felt(op);`,
-                `    let naiveExtension = Uint256(low, high);`,
-                `    if (msb == 0){`,
-                `        return (naiveExtension,);`,
-                `    }else{`,
-                `        let (res, _) = uint256_add(naiveExtension, ${uint256(
-                  sign_extend_value(from, to),
-                )});`,
-                `        return (res,);`,
-                `    }`,
-                '}',
-              ];
-            } else {
-              return [
-                `func warp_int${from}_to_int${to}{bitwise_ptr: BitwiseBuiltin*}(op : felt) -> (res : felt){`,
-                `    let (msb) = bitwise_and(op, ${msb(from)});`,
-                `    if (msb == 0){`,
-                `        return (op,);`,
-                `    }else{`,
-                `        return (op + 0x${sign_extend_value(from, to).toString(16)},);`,
-                `    }`,
-                '}',
-              ];
-            }
-          } else if (from === to) {
-            return [];
-          } else {
-            if (from === 256) {
-              if (to > 128) {
-                return [
-                  `func warp_int${from}_to_int${to}{bitwise_ptr: BitwiseBuiltin*}(op : Uint256) -> (res : felt){`,
-                  `    let (high) = bitwise_and(op.high,${mask(to - 128)});`,
-                  `    return (op.low + ${bound(128)} * high,);`,
-                  `}`,
-                ];
-              } else {
-                return [
-                  `func warp_int${from}_to_int${to}{bitwise_ptr: BitwiseBuiltin*}(op : Uint256) -> (res : felt){`,
-                  `    let (res) = bitwise_and(op.low, ${mask(to)});`,
-                  `    return (res,);`,
-                  `}`,
-                ];
-              }
-            } else {
-              return [
-                `func warp_int${from}_to_int${to}{bitwise_ptr : BitwiseBuiltin*}(op : felt) -> (res : felt){`,
-                `    let (res) = bitwise_and(op, ${mask(to)});`,
-                `    return (res,);`,
-                `}`,
-              ];
-            }
-          }
-        });
-        return x.map((f) => f.join('\n')).join('\n');
-      }),
-      [
-        'func warp_uint256{range_check_ptr}(op : felt) -> (res : Uint256){',
-        '    let split = split_felt(op);',
-        '    return (Uint256(low=split.low, high=split.high),);',
-        '}',
-      ].join('\n'),
-    ],
-  };
-}
-
-function sign_extend_value(from: number, to: number): bigint {
-  return 2n ** BigInt(to) - 2n ** BigInt(from);
-}
+const cairoWidths = [8, 16, 32, 64, 128, 256];
 
 export function functionaliseIntConversion(conversion: FunctionCall, ast: AST): void {
   const arg = conversion.vArguments[0];
@@ -116,19 +25,24 @@ export function functionaliseIntConversion(conversion: FunctionCall, ast: AST): 
     )}`,
   );
 
-  if (fromType.nBits < 256 && toType.nBits === 256 && !fromType.signed && !toType.signed) {
-    IntFunction(conversion, conversion.vArguments[0], 'uint', 'int_conversions', ast);
-    return;
-  } else if (
-    fromType.nBits === toType.nBits ||
-    (fromType.nBits < toType.nBits && !fromType.signed && !toType.signed)
-  ) {
-    arg.typeString = conversion.typeString;
-    ast.replaceNode(conversion, arg);
-    return;
-  } else {
-    const name = `${fromType.pp().startsWith('u') ? fromType.pp().slice(1) : fromType.pp()}_to_int`;
-    IntFunction(conversion, conversion.vArguments[0], name, 'int_conversions', ast);
+  const fromCairoWidth = cairoWidths.find((x) => x >= fromType.nBits)!;
+  const toCairoWidth = cairoWidths.find((x) => x >= toType.nBits)!;
+
+  if (fromCairoWidth === toCairoWidth) {
     return;
   }
+  let functionPath: [string[], string];
+  if (fromCairoWidth < toCairoWidth) {
+    functionPath = fromType.signed ? SIGNED_UPCAST : UPCAST;
+  } else {
+    functionPath = CUTOFF_DOWNCAST;
+  }
+  const functionDef = ast.registerImport(
+    conversion,
+    ...functionPath,
+    [['from', createNumberTypeName(fromType.nBits, fromType.signed, ast)]],
+    [['to', createNumberTypeName(toType.nBits, toType.signed, ast)]],
+  );
+  const functionCall = createCallToFunction(functionDef, conversion.vArguments, ast);
+  ast.replaceNode(conversion, functionCall);
 }

--- a/src/warplib/implementations/conversions/int.ts
+++ b/src/warplib/implementations/conversions/int.ts
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import { FunctionCall, generalizeType, IntType } from 'solc-typed-ast';
 import { AST } from '../../../ast/ast';
-import { createCallToFunction, createNumberTypeName } from '../../../export';
+import { createCallToFunction, createNumberTypeName, requireNonNullish } from '../../../export';
 import { printNode, printTypeNode } from '../../../utils/astPrinter';
 import { CUTOFF_DOWNCAST, SIGNED_UPCAST, UPCAST } from '../../../utils/importPaths';
 import { safeGetNodeType } from '../../../utils/nodeTypeProcessing';
@@ -25,8 +25,8 @@ export function functionaliseIntConversion(conversion: FunctionCall, ast: AST): 
     )}`,
   );
 
-  const fromCairoWidth = cairoWidths.find((x) => x >= fromType.nBits)!;
-  const toCairoWidth = cairoWidths.find((x) => x >= toType.nBits)!;
+  const fromCairoWidth = requireNonNullish(cairoWidths.find((x) => x >= fromType.nBits));
+  const toCairoWidth = requireNonNullish(cairoWidths.find((x) => x >= toType.nBits));
 
   if (fromCairoWidth === toCairoWidth) {
     return;

--- a/tests/compilation/compilation.test.ts
+++ b/tests/compilation/compilation.test.ts
@@ -165,6 +165,7 @@ const expectedResults = new Map<string, ResultType>(
     ['tryCatch.sol', 'WillNotSupport'],
     ['tupleAssignment7.sol', 'Success'],
     ['tupleAssignment8.sol', 'SolCompileFailed'],
+    ['typeConversion/explicitIntConversion.sol', 'Success'],
     ['typeConversion/explicitTypeConversion.sol', 'Success'],
     ['typeConversion/implicitReturnConversion.sol', 'Success'],
     ['typeConversion/implicitTypeConv.sol', 'Success'],

--- a/tests/compilation/contracts/address/7/256Address.sol
+++ b/tests/compilation/contracts/address/7/256Address.sol
@@ -2,12 +2,16 @@ pragma solidity ^0.7.6;
 
 contract WARP {
 
-    function test160(uint160 me) public view {
-        address x = address(uint256(me));
+    function test160(uint160 n1, bytes20 n2) public view {
+        address a1 = address(uint256(n1));
+        address a2 = address(bytes32(n2));
     }
 
-    function test256(uint256 me) public view {
-        address x = address(me);
-        uint256 y = uint256(x);
+    function test256(uint256 n1, bytes32 n2) public view {
+        address a1 = address(n1);
+        address a2 = address(n2);
+
+        uint256 m1 = uint256(a1);
+        bytes32 m2 = bytes32(a2);
     }
 }

--- a/tests/compilation/contracts/address/8/256Address.sol
+++ b/tests/compilation/contracts/address/8/256Address.sol
@@ -2,12 +2,16 @@ pragma solidity ^0.8.6;
 
 contract WARP {
 
-    function test160(uint160 me) public view {
-        address x = address(uint256(me));
+    function test160(uint160 n1, bytes20 n2) public view {
+        address a1 = address(uint256(n1));
+        address a2 = address(bytes32(n2));
     }
 
-    function test256(uint256 me) public view {
-        address x = address(me);
-        uint256 y = uint256(x);
+    function test256(uint256 n1, bytes32 n2) public view {
+        address a1 = address(n1);
+        address a2 = address(n2);
+
+        uint256 m1 = uint256(a1);
+        bytes32 m2 = bytes32(a2);
     }
 }

--- a/tests/compilation/contracts/typeConversion/explicitIntConversion.sol
+++ b/tests/compilation/contracts/typeConversion/explicitIntConversion.sol
@@ -1,0 +1,16 @@
+pragma solidity ^0.7.6;
+
+contract WARP {
+
+    function conversions() public pure {
+        uint8   x1 = 1;
+        uint16  x2 = uint16(x1);
+        int32   x3 = int32(x2);
+        int64   x4 = int64(x3);
+        uint128 x5 = uint128(x4);
+        uint64  x6 = uint64(x5);
+        int32   x7 = int32(x6);
+        int16   x8 = int16(x7);
+        uint8   x9 = uint8(x8);
+    }
+}

--- a/tests/compilation/passingContracts.ts
+++ b/tests/compilation/passingContracts.ts
@@ -161,6 +161,7 @@ export const passingContracts = [
   // 'tests/compilation/contracts/tryCatch.sol',
   // 'tests/compilation/contracts/tupleAssignment7.sol',
   // 'tests/compilation/contracts/tupleAssignment8.sol',
+  'tests/compilation/contracts/typeConversion/explicitIntConversion.sol',
   'tests/compilation/contracts/typeConversion/explicitTypeConversion.sol',
   // 'tests/compilation/contracts/typeConversion/implicitReturnConversion.sol',
   // 'tests/compilation/contracts/typeConversion/implicitTypeConv.sol',

--- a/warplib/src/integer.cairo
+++ b/warplib/src/integer.cairo
@@ -1,0 +1,83 @@
+// FIXME: merge imports using "use bla::{foo, bar}" syntax, when
+// updated to Cairo 1.1
+use integer::BoundedInt;
+use integer::downcast;
+use integer::u256;
+use integer::upcast;
+use option::OptionTrait;
+
+trait Integer<T> {
+    // basically, 2^(width - 1), but precomputed, because there is no
+    // way to compute that efficiently at the moment
+    fn signed_upper_bound() -> T;
+}
+
+impl Integer8 of Integer<u8> {
+    fn signed_upper_bound() -> u8 {
+        0x80
+    }
+}
+
+impl Integer16 of Integer<u16> {
+    fn signed_upper_bound() -> u16 {
+        0x8000
+    }
+}
+
+impl Integer32 of Integer<u32> {
+    fn signed_upper_bound() -> u32 {
+        0x80000000
+    }
+}
+
+impl Integer64 of Integer<u64> {
+    fn signed_upper_bound() -> u64 {
+        0x8000000000000000
+    }
+}
+
+impl Integer128 of Integer<u128> {
+    fn signed_upper_bound() -> u128 {
+        0x80000000000000000000000000000000
+    }
+}
+
+impl Integer256 of Integer<u256> {
+    fn signed_upper_bound() -> u256 {
+        u256 { low: 0, high: Integer::signed_upper_bound() }
+    }
+}
+
+// FIXME: remove, when we update to Cairo 1.1, use builtin BitNot instead
+fn bitnot<T, impl BoundedIntT: BoundedInt<T>, impl SubT: Sub<T>>(x: T) -> T {
+    BoundedInt::max() - x
+}
+
+// FIXME: remove, when core implementations are available
+impl U8BitAnd of BitAnd<u8> {
+    #[inline(always)]
+    fn bitand(lhs: u8, rhs: u8) -> u8 {
+        downcast(upcast::<u8, u128>(lhs) & upcast(rhs)).unwrap()
+    }
+}
+
+impl U16BitAnd of BitAnd<u16> {
+    #[inline(always)]
+    fn bitand(lhs: u16, rhs: u16) -> u16 {
+        downcast(upcast::<u16, u128>(lhs) & upcast(rhs)).unwrap()
+    }
+}
+
+impl U32BitAnd of BitAnd<u32> {
+    #[inline(always)]
+    fn bitand(lhs: u32, rhs: u32) -> u32 {
+        downcast(upcast::<u32, u128>(lhs) & upcast(rhs)).unwrap()
+    }
+}
+
+impl U64BitAnd of BitAnd<u64> {
+    #[inline(always)]
+    fn bitand(lhs: u64, rhs: u64) -> u64 {
+        downcast(upcast::<u64, u128>(lhs) & upcast(rhs)).unwrap()
+    }
+}

--- a/warplib/src/lib.cairo
+++ b/warplib/src/lib.cairo
@@ -1,6 +1,7 @@
 // Add here modules ready to use in Cairo1;
 mod conversions;
 mod external_input_check;
+mod integer;
 mod maths;
 mod warp_memory;
 


### PR DESCRIPTION
Instead of generating Cairo functions, we use generic capabilities of
   Cairo 1 to write a single static function in warplib.

Additionally we remove some usages of old functions, but not all of
   them, since they are tied to much into some subsystems, like
   calldata and storage. This will be finished in future work.