### PR TITLE
translate int conversions to Cairo 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,9 +210,6 @@ warplib/src/maths/lt_signed.cairo
 # bitwise_or - handwritten
 warplib/src/maths/bitwise_not.cairo
 
-# ---conversions---
-warplib/src/conversions/int_conversions.cairo
-
 # ---external-input-input-checks---
 warplib/src/external_input_check/external_input_check_ints.cairo
 # external_input_check_address.cairo - handwritten
@@ -226,4 +223,3 @@ warplib/src/warp_memory/bytes.cairo
 
 tests/cli/starknet_open_zeppelin_accounts.json
 tests/cli/starknet_open_zeppelin_accounts.json.backup
-

--- a/src/cairoUtilFuncGen/calldata/calldataToStorage.ts
+++ b/src/cairoUtilFuncGen/calldata/calldataToStorage.ts
@@ -19,7 +19,6 @@ import { printTypeNode } from '../../utils/astPrinter';
 import { CairoDynArray, CairoType, TypeConversionContext } from '../../utils/cairoTypeSystem';
 import { NotSupportedYetError } from '../../utils/errors';
 import { createCairoGeneratedFunction, createCallToFunction } from '../../utils/functionGeneration';
-import { WARP_UINT256 } from '../../utils/importPaths';
 import { getElementType, safeGetNodeType } from '../../utils/nodeTypeProcessing';
 import { mapRange, narrowBigIntSafe, typeNameFromTypeNode } from '../../utils/utils';
 import { add, delegateBasedOnType, GeneratedFunctionInfo, StringIndexedFuncGen } from '../base';
@@ -179,7 +178,7 @@ export class CalldataToStorageGen extends StringIndexedFuncGen {
          }
       }
 
-      func ${funcName}(loc : felt, dyn_array_struct : ${structDef.name}) -> (loc : felt){ 
+      func ${funcName}(loc : felt, dyn_array_struct : ${structDef.name}) -> (loc : felt){
          alloc_locals;
          let (len_uint256) = warp_uint256(dyn_array_struct.len);
          ${lenName}.write(loc, len_uint256);
@@ -191,7 +190,7 @@ export class CalldataToStorageGen extends StringIndexedFuncGen {
     return {
       name: funcName,
       code: code,
-      functionsCalled: [this.requireImport(...WARP_UINT256), dynArray, dynArrayLength, writeDef],
+      functionsCalled: [dynArray, dynArrayLength, writeDef],
     };
   }
 

--- a/src/cairoUtilFuncGen/storage/storageToCalldata.ts
+++ b/src/cairoUtilFuncGen/storage/storageToCalldata.ts
@@ -18,7 +18,7 @@ import { printTypeNode } from '../../utils/astPrinter';
 import { CairoDynArray, CairoType, TypeConversionContext } from '../../utils/cairoTypeSystem';
 import { NotSupportedYetError } from '../../utils/errors';
 import { createCairoGeneratedFunction, createCallToFunction } from '../../utils/functionGeneration';
-import { ALLOC, U128_FROM_FELT, WARP_UINT256 } from '../../utils/importPaths';
+import { ALLOC, U128_FROM_FELT } from '../../utils/importPaths';
 import { getElementType, safeGetNodeType } from '../../utils/nodeTypeProcessing';
 import { mapRange, narrowBigIntSafe, typeNameFromTypeNode } from '../../utils/utils';
 import { add, delegateBasedOnType, GeneratedFunctionInfo, StringIndexedFuncGen } from '../base';
@@ -188,11 +188,7 @@ export class StorageToCalldataGen extends StringIndexedFuncGen {
       }
     `;
 
-    const importedFuncs = [
-      this.requireImport(...WARP_UINT256),
-      this.requireImport(...U128_FROM_FELT),
-      this.requireImport(...ALLOC),
-    ];
+    const importedFuncs = [this.requireImport(...U128_FROM_FELT), this.requireImport(...ALLOC)];
 
     const funcInfo: GeneratedFunctionInfo = {
       name: funcName,

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -82,3 +82,13 @@ export interface ExecSyncError {
 export function instanceOfExecSyncError(object: any): object is ExecSyncError {
   return 'stderr' in object;
 }
+
+export function requireNonNullish<T>(x: T | null | undefined): T {
+  if (x === null) {
+    throw new Error('Unexpected null');
+  }
+  if (x === undefined) {
+    throw new Error('Unexpected undefined');
+  }
+  return x as T;
+}

--- a/src/utils/importFuncGenerator.ts
+++ b/src/utils/importFuncGenerator.ts
@@ -85,6 +85,7 @@ const FUNCTION_IMPORTS = [
   Paths.U240_TO_FELT,
   Paths.U248_TO_FELT,
   Paths.U256_FROM_FELTS,
+  Paths.UPCAST,
   Paths.ARRAY,
   Paths.ARRAY_TRAIT,
   Paths.BOOL_INTO_FELT252,

--- a/src/utils/importPaths.ts
+++ b/src/utils/importPaths.ts
@@ -298,3 +298,7 @@ export const WM_CREATE: [string[], string] = [ACCESSOR_TRAIT, 'warp_memory.creat
 export const WM_TO_FELT_ARRAY: [string[], string] = [['not set yet'], 'wm_to_felt_array'];
 
 export const SUPER: string[] = ['super'];
+
+export const SIGNED_UPCAST: [string[], string] = [INTEGER_CONVERSIONS, 'signed_upcast'];
+export const UPCAST: [string[], string] = [['integer'], 'upcast'];
+export const CUTOFF_DOWNCAST: [string[], string] = [INTEGER_CONVERSIONS, 'cutoff_downcast'];

--- a/src/warplib/generateWarplib.ts
+++ b/src/warplib/generateWarplib.ts
@@ -1,5 +1,4 @@
 import { generateFile, PATH_TO_WARPLIB, WarplibFunctionInfo } from './utils';
-import { int_conversions } from './implementations/conversions/int';
 import { add, add_unsafe, add_signed, add_signed_unsafe } from './implementations/maths/add';
 import { div_signed, div_signed_unsafe } from './implementations/maths/div';
 import { exp, exp_signed, exp_signed_unsafe, exp_unsafe } from './implementations/maths/exp';
@@ -66,7 +65,6 @@ const mathWarplibFunctions: WarplibFunctionInfo[] = [
   // bitwise_or - handwritten
   bitwise_not(),
 ];
-const conversionWarplibFunctions: WarplibFunctionInfo[] = [int_conversions()];
 const inputCheckWarplibFunctions: WarplibFunctionInfo[] = [
   external_input_check_ints(),
   // external_input_check_address - handwritten
@@ -74,16 +72,16 @@ const inputCheckWarplibFunctions: WarplibFunctionInfo[] = [
 const warplibTypes: WarplibFunctionInfo[] = [fixed_bytes_types()];
 const warp_memory: WarplibFunctionInfo[] = [warp_memory_fixed_bytes()];
 
-generateWarplibFor('maths', mathWarplibFunctions, true);
-generateWarplibFor('conversions', conversionWarplibFunctions, true);
-generateWarplibFor('external_input_check', inputCheckWarplibFunctions, true);
-generateWarplibFor('types', warplibTypes, true);
+generateWarplibFor('maths', mathWarplibFunctions);
+generateWarplibFor('conversions', []);
+generateWarplibFor('external_input_check', inputCheckWarplibFunctions);
+generateWarplibFor('types', warplibTypes);
 generateWarplibFor('warp_memory', warp_memory, false);
 
 function generateWarplibFor(
   folderName: string,
   functions: WarplibFunctionInfo[],
-  writeExportFile: boolean,
+  writeExportFile = true,
 ) {
   functions.forEach((warpFunc: WarplibFunctionInfo) => generateFile(warpFunc, folderName));
   if (writeExportFile) {

--- a/tests/compilation/compilation.test.ts
+++ b/tests/compilation/compilation.test.ts
@@ -165,6 +165,7 @@ const expectedResults = new Map<string, ResultType>(
     ['tryCatch.sol', 'WillNotSupport'],
     ['tupleAssignment7.sol', 'Success'],
     ['tupleAssignment8.sol', 'SolCompileFailed'],
+    ['typeConversion/explicitIntConversion.sol', 'Success'],
     ['typeConversion/explicitTypeConversion.sol', 'Success'],
     ['typeConversion/implicitReturnConversion.sol', 'Success'],
     ['typeConversion/implicitTypeConv.sol', 'Success'],

--- a/tests/compilation/contracts/address/7/256Address.sol
+++ b/tests/compilation/contracts/address/7/256Address.sol
@@ -2,12 +2,16 @@ pragma solidity ^0.7.6;
 
 contract WARP {
 
-    function test160(uint160 me) public view {
-        address x = address(uint256(me));
+    function test160(uint160 n1, bytes20 n2) public view {
+        address a1 = address(uint256(n1));
+        address a2 = address(bytes32(n2));
     }
 
-    function test256(uint256 me) public view {
-        address x = address(me);
-        uint256 y = uint256(x);
+    function test256(uint256 n1, bytes32 n2) public view {
+        address a1 = address(n1);
+        address a2 = address(n2);
+
+        uint256 m1 = uint256(a1);
+        bytes32 m2 = bytes32(a2);
     }
 }

--- a/tests/compilation/contracts/address/8/256Address.sol
+++ b/tests/compilation/contracts/address/8/256Address.sol
@@ -2,12 +2,16 @@ pragma solidity ^0.8.6;
 
 contract WARP {
 
-    function test160(uint160 me) public view {
-        address x = address(uint256(me));
+    function test160(uint160 n1, bytes20 n2) public view {
+        address a1 = address(uint256(n1));
+        address a2 = address(bytes32(n2));
     }
 
-    function test256(uint256 me) public view {
-        address x = address(me);
-        uint256 y = uint256(x);
+    function test256(uint256 n1, bytes32 n2) public view {
+        address a1 = address(n1);
+        address a2 = address(n2);
+
+        uint256 m1 = uint256(a1);
+        bytes32 m2 = bytes32(a2);
     }
 }

--- a/tests/compilation/contracts/typeConversion/explicitIntConversion.sol
+++ b/tests/compilation/contracts/typeConversion/explicitIntConversion.sol
@@ -1,0 +1,16 @@
+pragma solidity ^0.7.6;
+
+contract WARP {
+
+    function conversions() public pure {
+        uint8   x1 = 1;
+        uint16  x2 = uint16(x1);
+        int32   x3 = int32(x2);
+        int64   x4 = int64(x3);
+        uint128 x5 = uint128(x4);
+        uint64  x6 = uint64(x5);
+        int32   x7 = int32(x6);
+        int16   x8 = int16(x7);
+        uint8   x9 = uint8(x8);
+    }
+}

--- a/tests/compilation/passingContracts.ts
+++ b/tests/compilation/passingContracts.ts
@@ -161,6 +161,7 @@ export const passingContracts = [
   // 'tests/compilation/contracts/tryCatch.sol',
   // 'tests/compilation/contracts/tupleAssignment7.sol',
   // 'tests/compilation/contracts/tupleAssignment8.sol',
+  'tests/compilation/contracts/typeConversion/explicitIntConversion.sol',
   'tests/compilation/contracts/typeConversion/explicitTypeConversion.sol',
   // 'tests/compilation/contracts/typeConversion/implicitReturnConversion.sol',
   // 'tests/compilation/contracts/typeConversion/implicitTypeConv.sol',

--- a/warplib/src/conversions/integer_conversions.cairo
+++ b/warplib/src/conversions/integer_conversions.cairo
@@ -1,26 +1,15 @@
-use integer::u128_try_from_felt252;
-use integer::u256_from_felt252;
-use integer::u128_to_felt252;
 use array::ArrayImpl;
+use integer::{downcast, upcast, u128_try_from_felt252, BoundedInt};
 use option::OptionTrait;
-use option::OptionTraitImpl;
 use starknet::ContractAddress;
-use traits::Into;
-use traits::TryInto;
+use traits::{Into, TryInto};
+
+use warplib::integer::{bitnot, Integer};
 
 fn u256_from_felts(low_felt: felt252, high_felt: felt252) -> u256 {
     let low_u128: u128 = get_u128_try_from_felt_result(low_felt);
     let high_u128: u128 = get_u128_try_from_felt_result(high_felt);
     return u256 { low: low_u128, high: high_u128 };
-}
-
-fn try_u256_to_felt252(x: u256) -> felt252 {
-    let MAX_FELT = u256_from_felt252(-1);
-    if x > MAX_FELT {
-        panic_with_felt252('Overflow in u256_to_felt252')
-    }
-    // hex is 2**128
-    u128_to_felt252(x.low) + 0x100000000000000000000000000000000 * u128_to_felt252(x.high)
 }
 
 fn get_u128_try_from_felt_result(value: felt252) -> u128 {
@@ -81,4 +70,35 @@ fn unsafe_contract_address_from_u256(x: u256) -> ContractAddress {
             },
         Option::None(_) => panic_with_felt252('the u256 does not fit in felt'),
     }
+}
+
+// FIXME: Should have been possible without our special Integer trait,
+// but NumericLiteral doesn't quite work yet. Without being able to
+// create constants of our generic type, we can't do anything.
+fn signed_upcast<
+    FromType,
+    impl IntegerFrom: Integer<FromType>,
+    impl BoundedIntFrom: BoundedInt<FromType>,
+    impl SubFrom: Sub<FromType>,
+    impl PartialOrdFrom: PartialOrd<FromType>,
+    impl CopyFrom: Copy<FromType>,
+    impl DropFrom: Drop<FromType>,
+    ToType,
+    impl BoundedIntTo: BoundedInt<ToType>,
+    impl SubTo: Sub<ToType>,
+>(x: FromType) -> ToType {
+    if x < Integer::signed_upper_bound() {
+        upcast(x)
+    } else {
+        bitnot(upcast(bitnot(x)))
+    }
+}
+
+fn cutoff_downcast<
+    FromType,
+    impl BitAndFrom: BitAnd<FromType>,
+    ToType,
+    impl BoundedIntTo: BoundedInt<ToType>,
+>(x: FromType) -> ToType {
+    downcast(x & upcast(BoundedInt::<ToType>::max())).unwrap()
 }

--- a/warplib/src/integer.cairo
+++ b/warplib/src/integer.cairo
@@ -1,0 +1,83 @@
+// FIXME: merge imports using "use bla::{foo, bar}" syntax, when
+// updated to Cairo 1.1
+use integer::BoundedInt;
+use integer::downcast;
+use integer::u256;
+use integer::upcast;
+use option::OptionTrait;
+
+trait Integer<T> {
+    // basically, 2^(width - 1), but precomputed, because there is no
+    // way to compute that efficiently at the moment
+    fn signed_upper_bound() -> T;
+}
+
+impl Integer8 of Integer<u8> {
+    fn signed_upper_bound() -> u8 {
+        0x80
+    }
+}
+
+impl Integer16 of Integer<u16> {
+    fn signed_upper_bound() -> u16 {
+        0x8000
+    }
+}
+
+impl Integer32 of Integer<u32> {
+    fn signed_upper_bound() -> u32 {
+        0x80000000
+    }
+}
+
+impl Integer64 of Integer<u64> {
+    fn signed_upper_bound() -> u64 {
+        0x8000000000000000
+    }
+}
+
+impl Integer128 of Integer<u128> {
+    fn signed_upper_bound() -> u128 {
+        0x80000000000000000000000000000000
+    }
+}
+
+impl Integer256 of Integer<u256> {
+    fn signed_upper_bound() -> u256 {
+        u256 { low: 0, high: Integer::signed_upper_bound() }
+    }
+}
+
+// FIXME: remove, when we update to Cairo 1.1, use builtin BitNot instead
+fn bitnot<T, impl BoundedIntT: BoundedInt<T>, impl SubT: Sub<T>>(x: T) -> T {
+    BoundedInt::max() - x
+}
+
+// FIXME: remove, when core implementations are available
+impl U8BitAnd of BitAnd<u8> {
+    #[inline(always)]
+    fn bitand(lhs: u8, rhs: u8) -> u8 {
+        downcast(upcast::<u8, u128>(lhs) & upcast(rhs)).unwrap()
+    }
+}
+
+impl U16BitAnd of BitAnd<u16> {
+    #[inline(always)]
+    fn bitand(lhs: u16, rhs: u16) -> u16 {
+        downcast(upcast::<u16, u128>(lhs) & upcast(rhs)).unwrap()
+    }
+}
+
+impl U32BitAnd of BitAnd<u32> {
+    #[inline(always)]
+    fn bitand(lhs: u32, rhs: u32) -> u32 {
+        downcast(upcast::<u32, u128>(lhs) & upcast(rhs)).unwrap()
+    }
+}
+
+impl U64BitAnd of BitAnd<u64> {
+    #[inline(always)]
+    fn bitand(lhs: u64, rhs: u64) -> u64 {
+        downcast(upcast::<u64, u128>(lhs) & upcast(rhs)).unwrap()
+    }
+}

--- a/warplib/src/lib.cairo
+++ b/warplib/src/lib.cairo
@@ -1,6 +1,7 @@
 // Add here modules ready to use in Cairo1;
 mod conversions;
 mod external_input_check;
+mod integer;
 mod maths;
 mod warp_memory;
 mod types;


### PR DESCRIPTION


Instead of generating Cairo functions, we use generic capabilities of
   Cairo 1 to write a single static function in warplib.

Additionally we remove some usages of old functions, but not all of
   them, since they are tied to much into some subsystems, like
   calldata and storage. This will be finished in future work.
